### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['**'] # Triggers on push to any branch


### PR DESCRIPTION
Potential fix for [https://github.com/zaknafeyn/git-smart-checkout/security/code-scanning/4](https://github.com/zaknafeyn/git-smart-checkout/security/code-scanning/4)

To fix this issue, add an explicit `permissions` block with the least privilege needed for the workflow. For common build/test workflows like this one, read-only access to repository contents is sufficient. The `permissions` block should be added at the top level (i.e., workflow root, before `jobs:`) to cover all jobs. Specifically, insert `permissions:\n  contents: read` after the `name:` and before or after the `on:` block. This will restrict the automatically generated `GITHUB_TOKEN` to just reading repository content, following GitHub best practices and reducing the risk surface without altering the workflow's behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
