### PR TITLE
Add preferred refs configuration and enhance branch checkout functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,12 @@
           "default": true,
           "description": "Use in-place cherry-pick instead of temporary worktree for PR cloning (this method doesn't allow to solve conflicts, so use when completely sure that there will be no conflicts during cherry pick"
         }
+        ,
+        "git-smart-checkout.preferredRefs": {
+          "type": "object",
+          "default": {},
+          "markdownDescription": "Per-user map of preferred refs by repository. Keys are `<owner>/<repo>` (GitHub) or workspace folder name; values include arrays: locals, remotes, tags (stored as full refnames like `refs/heads/<name>`, `refs/remotes/<remote>/<name>`, `refs/tags/<name>`)."
+        }
       }
     }
   },

--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -1,20 +1,22 @@
 import * as vscode from 'vscode';
 
 import { GitExecutor } from '../../common/git/gitExecutor';
-import { BaseCommand } from '../command';
 import { IGitRef } from '../../common/git/types';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { LoggingService } from '../../logging/loggingService';
+import { AutoStashService } from '../../services/autoStashService';
+import { getRepoId } from '../../utils/getRepoId';
+import { BaseCommand } from '../command';
+import { getMergedBranchLists } from '../utils/getMergedBranchLists';
 import {
   getRefDescription,
   getRefDetails,
   getRefLabel,
+  getRefLabelWithStar,
   ICON_BRANCH,
   ICON_PLUS,
-  ICON_REMOTE_BRANCH,
+  ICON_REMOTE_BRANCH
 } from '../utils/refFormatting';
-import { getMergedBranchLists } from '../utils/getMergedBranchLists';
-import { ConfigurationManager } from '../../configuration/configurationManager';
-import { LoggingService } from '../../logging/loggingService';
-import { AutoStashService } from '../../services/autoStashService';
 
 export const LABEL_CREATE_NEW_BRANCH = `${ICON_PLUS} Create new branch...`;
 export const LABEL_CREATE_NEW_BRANCH_FROM = `${ICON_PLUS} Create new branch from...`;
@@ -99,67 +101,136 @@ export class CheckoutToCommand extends BaseCommand {
       throw new Error('The current workspace is not a git repository.');
     }
 
+    const repoId = await getRepoId(git);
     // Get the list of branches from the separate function
     const branchList = await this.getBranchList(git);
+    const existingFullSet = new Set(
+      branchList.map((ref) =>
+        ref.isTag
+          ? `refs/tags/${ref.name}`
+          : ref.remote
+          ? `refs/remotes/${ref.remote}/${ref.name}`
+          : `refs/heads/${ref.name}`
+      )
+    );
+    await this.configManager.cleanupMissing(repoId, existingFullSet);
 
     const [locals, remotes] = getMergedBranchLists(branchList, currentBranch);
-
-    const quickPickTags = branchList
-      .filter((branch) => branch.isTag)
-      .map((tag) => ({
-        label: getRefLabel(tag),
-        description: getRefDescription(tag),
-        detail: getRefDetails(tag),
-      }));
 
     const quickPickActions = [
       { label: LABEL_CREATE_NEW_BRANCH },
       { label: LABEL_CREATE_NEW_BRANCH_FROM },
     ];
 
-    const quickPickItems: vscode.QuickPickItem[] = [
-      ...quickPickActions,
-      {
-        label: 'Branches',
-        kind: vscode.QuickPickItemKind.Separator,
-      },
-      ...locals.map((branch) => ({
-        label: getRefLabel(branch),
-        description: getRefDescription(branch),
-        detail: getRefDetails(branch),
-      })),
-      {
-        label: 'Remote branches',
-        kind: vscode.QuickPickItemKind.Separator,
-      },
+    const preferredLocal = locals.filter((b) => this.configManager.isPreferred(repoId, b));
+    const preferredRemote = remotes.filter((b) => this.configManager.isPreferred(repoId, b));
+    const nonPreferredLocal = locals.filter((b) => !this.configManager.isPreferred(repoId, b));
+    const nonPreferredRemote = remotes.filter((b) => !this.configManager.isPreferred(repoId, b));
+    const preferredTags = branchList.filter((t) => t.isTag && this.configManager.isPreferred(repoId, t));
+    const otherTags = branchList.filter((t) => t.isTag && !this.configManager.isPreferred(repoId, t));
 
-      ...remotes.map((branch) => ({
-        label: getRefLabel(branch),
-        description: getRefDescription(branch),
-        detail: getRefDetails(branch),
-      })),
+    const qp = vscode.window.createQuickPick<
+      vscode.QuickPickItem & { ref?: IGitRef; type?: 'action' | 'ref' }
+    >();
+    qp.title = 'Checkout to...';
+    qp.placeholder = 'Select a branch to checkout';
 
-      {
-        label: 'Tags',
-        kind: vscode.QuickPickItemKind.Separator,
-      },
-      ...quickPickTags,
-    ];
-
-    // Show the quick pick list
-    const pickedItem = await vscode.window.showQuickPick(quickPickItems, {
-      // Options
-      placeHolder: 'Select a branch to checkout',
+    const toItem = (ref: IGitRef): (vscode.QuickPickItem & { ref: IGitRef; type: 'ref' }) => ({
+      label: getRefLabelWithStar(ref, this.configManager.isPreferred(repoId, ref)),
+      description: getRefDescription(ref),
+      detail: getRefDetails(ref),
+      buttons: [
+        {
+          iconPath: new vscode.ThemeIcon(
+            this.configManager.isPreferred(repoId, ref) ? 'star-full' : 'star'
+          ),
+          tooltip: this.configManager.isPreferred(repoId, ref) ? 'Unstar' : 'Star',
+        },
+      ],
+      ref,
+      type: 'ref',
     });
 
-    // If the user didn't select anything, return
-    if (!pickedItem) {
+    const buildItems = () => {
+      const items: (vscode.QuickPickItem & { ref?: IGitRef; type?: 'action' | 'ref' })[] = [];
+      items.push(...quickPickActions.map((a) => ({ label: a.label, type: 'action' as const })));
+
+      // if (preferredLocal.length > 0) {
+      //   items.push({ label: 'Preferred branches', kind: vscode.QuickPickItemKind.Separator });
+      //   items.push(...preferredLocal.map(toItem));
+      // }
+
+      // if (preferredRemote.length > 0) {
+      //   items.push({ label: 'Preferred remote branches', kind: vscode.QuickPickItemKind.Separator });
+      //   items.push(...preferredRemote.map(toItem));
+      // }
+
+      items.push({ label: 'Branches', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...preferredLocal.map(toItem), ...nonPreferredLocal.map(toItem));
+
+      items.push({ label: 'Remote branches', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...preferredRemote.map(toItem), ...nonPreferredRemote.map(toItem));
+
+      // if (preferredTags.length > 0) {
+      //   items.push({ label: 'Preferred tags', kind: vscode.QuickPickItemKind.Separator });
+      //   items.push(...preferredTags.map(toItem));
+      // }
+      items.push({ label: 'Tags', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...preferredTags.map(toItem), ...otherTags.map(toItem));
+      return items;
+    };
+
+    qp.items = buildItems();
+
+    qp.onDidTriggerItemButton(async (e) => {
+      const ref = (e.item as any).ref as IGitRef | undefined;
+      if (!ref) {
+        return;
+      }
+      await this.configManager.togglePreferred(repoId, ref, branchList);
+      qp.items = buildItems();
+    });
+
+    const picked = await new Promise<
+      | { kind: 'action'; label: string }
+      | { kind: 'ref'; ref: IGitRef; label: string }
+      | undefined
+    >((resolve) => {
+      qp.onDidAccept(() => {
+        const sel = qp.selectedItems[0] as any;
+        if (!sel) {
+          resolve(undefined);
+          qp.hide();
+          return;
+        }
+        if (sel.type === 'action') {
+          resolve({ kind: 'action', label: sel.label });
+        } else if (sel.type === 'ref' && sel.ref) {
+          resolve({ kind: 'ref', ref: sel.ref, label: sel.label });
+        } else {
+          resolve(undefined);
+        }
+        qp.hide();
+      });
+      qp.onDidHide(() => resolve(undefined));
+      qp.show();
+    });
+
+    if (!picked) {
       throw new Error();
+    }
+
+    if (picked.kind === 'action') {
+      return {
+        currentBranch,
+        selection: picked.label,
+        branchList,
+      };
     }
 
     return {
       currentBranch,
-      selection: pickedItem.label,
+      selection: getRefLabel(picked.ref),
       branchList,
     };
   }

--- a/src/commands/utils/refFormatting.ts
+++ b/src/commands/utils/refFormatting.ts
@@ -7,6 +7,8 @@ export const ICON_TAG = '$(tag)';
 export const ICON_PLUS = '$(plus)';
 export const ICON_ARROW_UP = '↑';
 export const ICON_ARROW_DOWN = '↓';
+export const ICON_STAR_FILLED = '★';
+export const ICON_STAR = '☆';
 
 const getRefIcon = (ref: IGitRef) => {
   switch (true) {
@@ -23,6 +25,11 @@ export const getRefLabel = (ref: IGitRef) => {
   const result = [getRefIcon(ref), ref.fullName];
 
   return result.join(' ');
+};
+
+export const getRefLabelWithStar = (ref: IGitRef, isPreferred: boolean) => {
+  const star = isPreferred ? ICON_STAR_FILLED : ICON_STAR;
+  return [star, getRefIcon(ref), ref.fullName].join(' ');
 };
 
 export const getRefDescription = (ref: IGitRef) => {

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -1,6 +1,7 @@
 import { ConfigurationTarget, workspace } from 'vscode';
-import { AUTO_STASH_MODE_MANUAL, ExtensionConfig } from './extensionConfig';
+import { AUTO_STASH_MODE_MANUAL, ExtensionConfig, PreferredRefsMap, PreferredRefsRepo } from './extensionConfig';
 import { EXTENSION_NAME } from '../const';
+import { IGitRef } from '../common/git/types';
 
 export class ConfigurationManager {
   private config: ExtensionConfig;
@@ -15,6 +16,7 @@ export class ConfigurationManager {
       defaultTargetBranch: vscodeConfig.get('defaultTargetBranch', 'main'),
       prBranchPrefix: vscodeConfig.get('prBranchPrefix', ''),
       useInPlaceCherryPick: vscodeConfig.get('useInPlaceCherryPick', true),
+      preferredRefs: vscodeConfig.get('preferredRefs', {} as PreferredRefsMap),
       logging: {
         enabled: vscodeConfig.get('logging.enabled', true),
       },
@@ -31,6 +33,7 @@ export class ConfigurationManager {
       defaultTargetBranch: vscodeConfig.get('defaultTargetBranch', 'main'),
       prBranchPrefix: vscodeConfig.get('prBranchPrefix', ''),
       useInPlaceCherryPick: vscodeConfig.get('useInPlaceCherryPick', true),
+      preferredRefs: vscodeConfig.get('preferredRefs', {} as PreferredRefsMap),
       logging: {
         enabled: vscodeConfig.get('logging.enabled', true),
       },
@@ -59,5 +62,115 @@ export class ConfigurationManager {
   public async updateShowStatusBar(enabled: boolean): Promise<void> {
     const config = workspace.getConfiguration(EXTENSION_NAME);
     await config.update('showStatusBar', enabled, ConfigurationTarget.Global);
+  }
+
+  // Preferred refs helpers
+  public getPreferredRefs(repoId: string): PreferredRefsRepo {
+    const map = this.config.preferredRefs || {};
+    const existing = map[repoId];
+    if (existing) {
+      return existing;
+    }
+    return { locals: [], remotes: [], tags: [] };
+  }
+
+  public isPreferred(repoId: string, ref: IGitRef): boolean {
+    const pref = this.getPreferredRefs(repoId);
+    const fullRef = this.getFullRefname(ref);
+    if (ref.isTag) {
+      return pref.tags.includes(fullRef);
+    }
+    if (ref.remote) {
+      return pref.remotes.includes(fullRef);
+    }
+    return pref.locals.includes(fullRef);
+  }
+
+  public async togglePreferred(repoId: string, ref: IGitRef, existingRefs: IGitRef[]): Promise<void> {
+    const config = workspace.getConfiguration(EXTENSION_NAME);
+    // fetch plain configuration object rather than proxied one
+    const map = (config.inspect<PreferredRefsMap>('preferredRefs')?.globalValue || {}) as PreferredRefsMap;
+    const repoPrefs: PreferredRefsRepo = map[repoId] || { locals: [], remotes: [], tags: [] };
+
+    const add = (arr: string[], val: string) => {
+      if (!arr.includes(val)) {
+        arr.push(val);
+      }
+    };
+    
+    const remove = (arr: string[], val: string) => {
+      const idx = arr.indexOf(val);
+      if (idx >= 0) {arr.splice(idx, 1);}
+    };
+
+    if (ref.isTag) {
+      const full = this.getFullRefname(ref);
+      if (repoPrefs.tags.includes(full)) {
+        remove(repoPrefs.tags, full);
+      } else {
+        add(repoPrefs.tags, full);
+      }
+    } else if (ref.remote) {
+      // toggle remote
+      const remoteFull = this.getFullRefname(ref);
+      const localFull = `refs/heads/${ref.name}`;
+      const existsLocal = existingRefs.some(r => !r.remote && !r.isTag && r.name === ref.name);
+      if (repoPrefs.remotes.includes(remoteFull)) {
+        remove(repoPrefs.remotes, remoteFull);
+        if (existsLocal) {remove(repoPrefs.locals, localFull);}
+      } else {
+        add(repoPrefs.remotes, remoteFull);
+        if (existsLocal) {add(repoPrefs.locals, localFull);}
+      }
+    } else {
+      // toggle local
+      const localFull = this.getFullRefname(ref);
+      const remoteFulls = existingRefs
+        .filter(r => r.remote && !r.isTag && r.name === ref.name)
+        .map(r => `refs/remotes/${r.remote}/${r.name}`);
+      const isPreferredLocal = repoPrefs.locals.includes(localFull);
+      if (isPreferredLocal) {
+        remove(repoPrefs.locals, localFull);
+        remoteFulls.forEach(rf => remove(repoPrefs.remotes, rf));
+      } else {
+        add(repoPrefs.locals, localFull);
+        remoteFulls.forEach(rf => add(repoPrefs.remotes, rf));
+      }
+    }
+
+    const updated: PreferredRefsMap = { ...(this.config.preferredRefs || {}), [repoId]: repoPrefs };
+    await config.update('preferredRefs', updated, ConfigurationTarget.Global);
+    this.reload();
+  }
+
+  public async cleanupMissing(repoId: string, existingFullRefnames: Set<string>): Promise<void> {
+    const map = (this.config.preferredRefs || {}) as PreferredRefsMap;
+    const prefs = map[repoId];
+    if (!prefs) {return;}
+
+    const filterExisting = (arr: string[]) => arr.filter(full => existingFullRefnames.has(full));
+    const newPrefs: PreferredRefsRepo = {
+      locals: filterExisting(prefs.locals),
+      remotes: filterExisting(prefs.remotes),
+      tags: filterExisting(prefs.tags),
+    };
+
+    const changed =
+      newPrefs.locals.length !== prefs.locals.length ||
+      newPrefs.remotes.length !== prefs.remotes.length ||
+      newPrefs.tags.length !== prefs.tags.length;
+
+    if (changed) {
+      const config = workspace.getConfiguration(EXTENSION_NAME);
+      const updated: PreferredRefsMap = { ...map, [repoId]: newPrefs };
+      await config.update('preferredRefs', updated, ConfigurationTarget.Global);
+      this.reload();
+    }
+  }
+
+  private getFullRefname(ref: IGitRef): string {
+    if (ref.isTag) {return `refs/tags/${ref.name}`;}
+    if (ref.remote) {return `refs/remotes/${ref.remote}/${ref.name}`;}
+    return `refs/heads/${ref.name}`;
   }
 }

--- a/src/configuration/extensionConfig.ts
+++ b/src/configuration/extensionConfig.ts
@@ -14,6 +14,14 @@ export type TAutoStashModeConfig = (typeof autoStashModeConfig)[keyof typeof aut
 
 export const AUTO_STASH_MODES = Object.values(autoStashModeConfig);
 
+export interface PreferredRefsRepo {
+  locals: string[];
+  remotes: string[];
+  tags: string[];
+}
+
+export type PreferredRefsMap = Record<string, PreferredRefsRepo>;
+
 export interface ExtensionConfig {
   mode: TAutoStashModeConfig;
   refetchBeforeCheckout: boolean;
@@ -24,6 +32,7 @@ export interface ExtensionConfig {
   logging: {
     enabled: boolean;
   };
+  preferredRefs?: PreferredRefsMap;
 }
 
 export interface IAutoStashMode {

--- a/src/utils/getRepoId.ts
+++ b/src/utils/getRepoId.ts
@@ -1,0 +1,18 @@
+import { GitExecutor } from '../common/git/gitExecutor';
+import { getWorkspaceFoldersFormatted } from '../common/vscode';
+
+export const getRepoId = async (git: GitExecutor): Promise<string> => {
+  const info = await git.getRepoInfo();
+  if (info) {
+    return `${info.owner}/${info.repo}`;
+  }
+
+  const wsf = getWorkspaceFoldersFormatted();
+  if (wsf && wsf.length > 0) {
+    return wsf[0].name;
+  }
+
+  return 'default';
+};
+
+


### PR DESCRIPTION

- Introduced `preferredRefs` configuration to allow users to manage preferred branches, remotes, and tags.
- Updated `CheckoutToCommand` to utilize preferred refs, improving the branch selection experience.
- Added helper methods in `ConfigurationManager` for managing preferred refs.
- Enhanced ref formatting to display preferred status with star icons.
- Introduced `getRepoId` utility to retrieve repository identifiers for configuration management.