### PR TITLE
Fix "Create new branch from..." broken by icon prefix and missing auto-stash

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -39,18 +39,24 @@ export class CheckoutToCommand extends BaseCommand {
 
       const newBranch = await this.getTargetBranch(git, selection, branchList);
 
-      const autoStashMode = await this.autoStashService.getAutoStashMode();
+      const isNewBranch =
+        selection === LABEL_CREATE_NEW_BRANCH ||
+        selection === LABEL_CREATE_NEW_BRANCH_FROM;
 
-      if (!autoStashMode) {
-        return;
+      if (!isNewBranch) {
+        const autoStashMode = await this.autoStashService.getAutoStashMode();
+
+        if (!autoStashMode) {
+          return;
+        }
+
+        await this.autoStashService.checkoutAndStashChanges(
+          git,
+          currentBranch,
+          newBranch,
+          autoStashMode
+        );
       }
-
-      await this.autoStashService.checkoutAndStashChanges(
-        git,
-        currentBranch,
-        newBranch,
-        autoStashMode
-      );
     } catch (error) {
       if (error instanceof Error) {
         const message = error.message;
@@ -275,15 +281,15 @@ export class CheckoutToCommand extends BaseCommand {
       const newBranch = await git.createBranch(newBranchName);
       return newBranch;
     } catch (e) {
-      await vscode.window.showErrorMessage('Failed to create the new branch.', 'OK');
-      throw new Error('Failed to create the new branch.');
+      const msg = e instanceof Error ? e.message : String(e);
+      await vscode.window.showErrorMessage(`Failed to create the new branch: ${msg}`, 'OK');
+      throw new Error(`Failed to create the new branch: ${msg}`);
     }
   }
 
   async createNewBranchFrom(git: GitExecutor, branchList: IGitRef[]) {
     const baseBranchList = branchList.map((branch) => `${ICON_BRANCH} ${branch.fullName}`);
     const baseBranchName = await vscode.window.showQuickPick(baseBranchList, {
-      // Options
       placeHolder: 'Select a branch to base the new branch on',
     });
 
@@ -300,11 +306,26 @@ export class CheckoutToCommand extends BaseCommand {
       throw new Error('New branch name is not provided.');
     }
 
+    const strippedBase = baseBranchName.replace(/^\$\([^)]*\)\s*/, '');
+
     try {
-      const newBranch = await git.createBranch(newBranchName, baseBranchName);
+      const dirty = await git.isWorkdirHasChanges();
+      const stashName = `smart-checkout-new-branch-${Date.now()}`;
+      if (dirty) {
+        await git.createStash(stashName);
+      }
+      const newBranch = await git.createBranch(newBranchName, strippedBase);
+      if (dirty) {
+        try {
+          await git.popStash(stashName);
+        } catch {
+          // conflicts are left for the user to resolve
+        }
+      }
       return newBranch;
     } catch (e) {
-      throw new Error('Failed to create the new branch.');
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`Failed to create the new branch: ${msg}`);
     }
   }
 }

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -102,7 +102,8 @@ export class AutoStashService {
             await git.pullCurrentBranch();
           }
         } catch (e) {
-          throw new Error('Failed to checkout the selected branch.');
+          const msg = e instanceof Error ? e.message : String(e);
+          throw new Error(`Failed to checkout the selected branch: ${msg}`);
         }
         break;
     }
@@ -129,7 +130,8 @@ export class AutoStashService {
         await git.pullCurrentBranch();
       }
     } catch (e) {
-      throw new Error('Failed to checkout the selected branch.');
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`Failed to checkout the selected branch: ${msg}`);
     }
 
     try {
@@ -163,14 +165,14 @@ export class AutoStashService {
       handleErrorMessage(e);
     }
 
-    // Checkout the selected branch
     try {
       await git.checkout(nextBranch);
       if (await git.hasUpstreamBranch(nextBranch)) {
         await git.pullCurrentBranch();
       }
     } catch (e) {
-      throw new Error('Failed to checkout the selected branch.');
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`Failed to checkout the selected branch: ${msg}`);
     }
 
     const operation = apply ? 'apply' : 'pop';


### PR DESCRIPTION
- Strip codicon prefix (e.g. `$(source-control)`) from base branch name before passing it to `git checkout -b`, which caused a shell error (`/bin/sh: source-control: command not found`)
- Auto-stash dirty working tree before creating a branch from a different base and pop the stash afterwards, so local changes are preserved instead of aborting with "local changes would be overwritten"
- Skip the redundant auto-stash prompt in `execute()` when the user already went through "Create new branch" / "Create new branch from...", since those flows handle stashing internally
- Surface the original git error message in all catch blocks instead of showing a generic "Failed to ..." string

Output example (when an error occurs):
<img width="564" height="994" alt="Screenshot From 2026-03-29 18-17-51" src="https://github.com/user-attachments/assets/fe7a4377-7f47-4ead-b38a-1ce83127e145" />
