### PR TITLE
feat: enhance branch management with preferred refs and new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In fast-paced development environments, switching between Git branches is freque
 | Open a terminal in a selected worktree's directory | `Git Smart Checkout: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
 | Create a new PR from selected commits in another GitHub PR | `Git Smart Checkout: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
-| Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template ...` | [Create branch from template](docs/create-branch-from-template.md) |
+| Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
 | Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
 
 ## Extension Settings

--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -20,6 +20,7 @@ import {
   getRefLabel,
   getRefLabelWithStar,
   ICON_BRANCH,
+  ICON_STAR_FILLED,
   ICON_FOLDER,
   ICON_PLUS,
   ICON_REMOTE_BRANCH
@@ -127,12 +128,19 @@ export class CheckoutToCommand extends BaseCommand {
     ];
 
     const toItem = (ref: IGitRef): (vscode.QuickPickItem & { ref: IGitRef; type: 'ref' }) => {
-      const isPreferred = this.configManager.isPreferred(repoId, ref);
       const isCheckedOutInWorktree = !ref.remote && !ref.isTag && checkedOutBranchNames.has(ref.name);
-      const label = getRefLabelWithStar(ref, isPreferred);
+      const isPreferred = this.configManager.isPreferred(repoId, ref);
+      // Star first (stays visible at all times), then the worktree folder icon, then the ref label.
+      const label = [
+        isPreferred ? ICON_STAR_FILLED : undefined,
+        isCheckedOutInWorktree ? ICON_FOLDER : undefined,
+        getRefLabel(ref),
+      ]
+        .filter(Boolean)
+        .join(' ');
 
       return {
-        label: isCheckedOutInWorktree ? `${ICON_FOLDER} ${label}` : label,
+        label,
         description: getRefDescription(ref),
         detail: getRefDetails(ref),
         buttons: [
@@ -150,12 +158,23 @@ export class CheckoutToCommand extends BaseCommand {
 
     const buildItems = () => {
       const [locals, remotes] = getMergedBranchLists(branchList, currentBranch);
-      const preferredLocal = locals.filter((b) => this.configManager.isPreferred(repoId, b));
-      const preferredRemote = remotes.filter((b) => this.configManager.isPreferred(repoId, b));
+      const tags = branchList.filter((t) => t.isTag);
+      // Preferred refs float to the top of each section, ordered by when they were starred.
+      const preferredLocal = this.configManager.sortByPreferredOrder(
+        repoId,
+        locals.filter((b) => this.configManager.isPreferred(repoId, b))
+      );
+      const preferredRemote = this.configManager.sortByPreferredOrder(
+        repoId,
+        remotes.filter((b) => this.configManager.isPreferred(repoId, b))
+      );
+      const preferredTags = this.configManager.sortByPreferredOrder(
+        repoId,
+        tags.filter((t) => this.configManager.isPreferred(repoId, t))
+      );
       const nonPreferredLocal = locals.filter((b) => !this.configManager.isPreferred(repoId, b));
       const nonPreferredRemote = remotes.filter((b) => !this.configManager.isPreferred(repoId, b));
-      const preferredTags = branchList.filter((t) => t.isTag && this.configManager.isPreferred(repoId, t));
-      const otherTags = branchList.filter((t) => t.isTag && !this.configManager.isPreferred(repoId, t));
+      const otherTags = tags.filter((t) => !this.configManager.isPreferred(repoId, t));
 
       const items: (vscode.QuickPickItem & { ref?: IGitRef; type?: 'action' | 'ref' })[] = [];
       items.push(...quickPickActions.map((a) => ({ label: a.label, type: 'action' as const })));
@@ -320,12 +339,10 @@ export class CheckoutToCommand extends BaseCommand {
   }
 
   async createNewBranchFrom(git: GitExecutor, branchList: IGitRef[]) {
-    const baseBranchList = branchList.map((branch) => `${ICON_BRANCH} ${branch.fullName}`);
-    const baseBranchName = await vscode.window.showQuickPick(baseBranchList, {
-      placeHolder: 'Select a branch to base the new branch on',
-    });
+    const repoId = await getRepoId(git);
+    const baseRef = await this.pickBaseRef(branchList, repoId);
 
-    if (!baseBranchName) {
+    if (!baseRef) {
       throw new Error('Base branch name is not provided.');
     }
 
@@ -338,15 +355,13 @@ export class CheckoutToCommand extends BaseCommand {
       throw new Error('New branch name is not provided.');
     }
 
-    const strippedBase = baseBranchName.replace(/^\$\([^)]*\)\s*/, '');
-
     try {
       const dirty = await git.isWorkdirHasChanges();
       const stashName = `smart-checkout-new-branch-${Date.now()}`;
       if (dirty) {
         await git.createStash(stashName);
       }
-      const newBranch = await git.createBranch(newBranchName, strippedBase);
+      const newBranch = await git.createBranch(newBranchName, baseRef.fullName);
       capture(AnalyticsEvent.BranchCreated);
       if (dirty) {
         try {
@@ -361,5 +376,83 @@ export class CheckoutToCommand extends BaseCommand {
       const msg = e instanceof Error ? e.message : String(e);
       throw new Error(`Failed to create the new branch: ${msg}`);
     }
+  }
+
+  /**
+   * Pick a ref to base a new branch on. Mirrors the main checkout picker:
+   * refs are grouped (local / remote / tags), preferred refs float to the top
+   * of each group, and the inline star button toggles a ref's preferred state.
+   */
+  private async pickBaseRef(
+    branchList: IGitRef[],
+    repoId: string
+  ): Promise<IGitRef | undefined> {
+    const qp = vscode.window.createQuickPick<
+      vscode.QuickPickItem & { ref?: IGitRef }
+    >();
+    qp.title = 'Create new branch from...';
+    qp.placeholder = 'Select a branch to base the new branch on';
+
+    const toItem = (ref: IGitRef): vscode.QuickPickItem & { ref: IGitRef } => ({
+      label: getRefLabelWithStar(ref, this.configManager.isPreferred(repoId, ref)),
+      description: getRefDescription(ref),
+      detail: getRefDetails(ref),
+      buttons: [
+        {
+          iconPath: new vscode.ThemeIcon(
+            this.configManager.isPreferred(repoId, ref) ? 'star-full' : 'star'
+          ),
+          tooltip: this.configManager.isPreferred(repoId, ref) ? 'Unstar' : 'Star',
+        },
+      ],
+      ref,
+    });
+
+    const buildItems = () => {
+      const locals = branchList.filter((b) => !b.isTag && !b.remote);
+      const remotes = branchList.filter((b) => !b.isTag && b.remote);
+      const tags = branchList.filter((b) => b.isTag);
+      const split = (refs: IGitRef[]) => {
+        const preferred = this.configManager.sortByPreferredOrder(
+          repoId,
+          refs.filter((r) => this.configManager.isPreferred(repoId, r))
+        );
+        const rest = refs.filter((r) => !this.configManager.isPreferred(repoId, r));
+        return [...preferred, ...rest];
+      };
+
+      const items: (vscode.QuickPickItem & { ref?: IGitRef })[] = [];
+      items.push({ label: 'Branches', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...split(locals).map(toItem));
+      items.push({ label: 'Remote branches', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...split(remotes).map(toItem));
+      items.push({ label: 'Tags', kind: vscode.QuickPickItemKind.Separator });
+      items.push(...split(tags).map(toItem));
+      return items;
+    };
+
+    qp.onDidTriggerItemButton(async (e) => {
+      const ref = (e.item as { ref?: IGitRef }).ref;
+      if (!ref) {
+        return;
+      }
+      await this.configManager.togglePreferred(repoId, ref, branchList);
+      qp.items = buildItems();
+    });
+
+    const selectionPromise = new Promise<IGitRef | undefined>((resolve) => {
+      qp.onDidAccept(() => {
+        resolve(qp.selectedItems[0]?.ref);
+        qp.hide();
+      });
+      qp.onDidHide(() => resolve(undefined));
+    });
+
+    qp.items = buildItems();
+    qp.show();
+
+    const picked = await selectionPromise;
+    qp.dispose();
+    return picked;
   }
 }

--- a/src/commands/utils/refFormatting.ts
+++ b/src/commands/utils/refFormatting.ts
@@ -8,8 +8,7 @@ export const ICON_PLUS = '$(plus)';
 export const ICON_FOLDER = '$(folder)';
 export const ICON_ARROW_UP = '↑';
 export const ICON_ARROW_DOWN = '↓';
-export const ICON_STAR_FILLED = '★';
-export const ICON_STAR = '☆';
+export const ICON_STAR_FILLED = '$(star-full)';
 
 const getRefIcon = (ref: IGitRef) => {
   switch (true) {
@@ -28,13 +27,14 @@ export const getRefLabel = (ref: IGitRef) => {
   return result.join(' ');
 };
 
+/**
+ * Label for a ref with a leading star when it's preferred. The star stays
+ * visible at all times (unlike the inline quick-pick button, which only shows
+ * on hover), so preferred refs remain marked when the row is not active.
+ */
 export const getRefLabelWithStar = (ref: IGitRef, isPreferred: boolean) => {
-  const dataArr = [getRefIcon(ref), ref.fullName];
-  if (isPreferred) {
-    dataArr.unshift(ICON_STAR_FILLED);
-  }
-
-  return dataArr.join(' ');
+  const label = getRefLabel(ref);
+  return isPreferred ? `${ICON_STAR_FILLED} ${label}` : label;
 };
 
 export const getRefDescription = (ref: IGitRef) => {

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -1,8 +1,14 @@
 import { ConfigurationTarget, workspace } from 'vscode';
 import { AUTO_STASH_MODE_MANUAL, ExtensionConfig, PreferredRefsMap, PreferredRefsRepo } from './extensionConfig';
 import { EXTENSION_NAME } from '../const';
-import { getFullRefname } from '../common/git/refName';
 import { IGitRef } from '../common/git/types';
+import {
+  cleanupMissingRefs,
+  getRepoPrefs,
+  isRefPreferred,
+  sortByPreferredOrder,
+  togglePreferredRef,
+} from './preferredRefs';
 
 export class ConfigurationManager {
   private config: ExtensionConfig;
@@ -91,79 +97,25 @@ export class ConfigurationManager {
 
   // Preferred refs helpers
   public getPreferredRefs(repoId: string): PreferredRefsRepo {
-    const map = this.config.preferredRefs || {};
-    const existing = map[repoId];
-    if (existing) {
-      return existing;
-    }
-    return { locals: [], remotes: [], tags: [] };
+    return getRepoPrefs(this.config.preferredRefs, repoId);
   }
 
   public isPreferred(repoId: string, ref: IGitRef): boolean {
-    const pref = this.getPreferredRefs(repoId);
-    const fullRef = getFullRefname(ref);
-    if (ref.isTag) {
-      return pref.tags.includes(fullRef);
-    }
-    if (ref.remote) {
-      return pref.remotes.includes(fullRef);
-    }
-    return pref.locals.includes(fullRef);
+    return isRefPreferred(this.getPreferredRefs(repoId), ref);
+  }
+
+  /** Sort refs by the order they were starred in (non-preferred refs sort last). */
+  public sortByPreferredOrder<T extends IGitRef>(repoId: string, refs: T[]): T[] {
+    return sortByPreferredOrder(refs, this.getPreferredRefs(repoId));
   }
 
   public async togglePreferred(repoId: string, ref: IGitRef, existingRefs: IGitRef[]): Promise<void> {
     const config = workspace.getConfiguration(EXTENSION_NAME);
-    // fetch plain configuration object rather than proxied one
+    // fetch the plain stored value rather than the proxied/merged one
     const map = (config.inspect<PreferredRefsMap>('preferredRefs')?.globalValue || {}) as PreferredRefsMap;
-    const repoPrefs: PreferredRefsRepo = map[repoId] || { locals: [], remotes: [], tags: [] };
+    const nextPrefs = togglePreferredRef(getRepoPrefs(map, repoId), ref, existingRefs);
 
-    const add = (arr: string[], val: string) => {
-      if (!arr.includes(val)) {
-        arr.push(val);
-      }
-    };
-    
-    const remove = (arr: string[], val: string) => {
-      const idx = arr.indexOf(val);
-      if (idx >= 0) {arr.splice(idx, 1);}
-    };
-
-    if (ref.isTag) {
-      const full = getFullRefname(ref);
-      if (repoPrefs.tags.includes(full)) {
-        remove(repoPrefs.tags, full);
-      } else {
-        add(repoPrefs.tags, full);
-      }
-    } else if (ref.remote) {
-      // toggle remote
-      const remoteFull = getFullRefname(ref);
-      const localFull = `refs/heads/${ref.name}`;
-      const existsLocal = existingRefs.some(r => !r.remote && !r.isTag && r.name === ref.name);
-      if (repoPrefs.remotes.includes(remoteFull)) {
-        remove(repoPrefs.remotes, remoteFull);
-        if (existsLocal) {remove(repoPrefs.locals, localFull);}
-      } else {
-        add(repoPrefs.remotes, remoteFull);
-        if (existsLocal) {add(repoPrefs.locals, localFull);}
-      }
-    } else {
-      // toggle local
-      const localFull = getFullRefname(ref);
-      const remoteFulls = existingRefs
-        .filter(r => r.remote && !r.isTag && r.name === ref.name)
-        .map(r => `refs/remotes/${r.remote}/${r.name}`);
-      const isPreferredLocal = repoPrefs.locals.includes(localFull);
-      if (isPreferredLocal) {
-        remove(repoPrefs.locals, localFull);
-        remoteFulls.forEach(rf => remove(repoPrefs.remotes, rf));
-      } else {
-        add(repoPrefs.locals, localFull);
-        remoteFulls.forEach(rf => add(repoPrefs.remotes, rf));
-      }
-    }
-
-    const updated: PreferredRefsMap = { ...(this.config.preferredRefs || {}), [repoId]: repoPrefs };
+    const updated: PreferredRefsMap = { ...map, [repoId]: nextPrefs };
     await config.update('preferredRefs', updated, ConfigurationTarget.Global);
     this.reload();
   }
@@ -171,20 +123,11 @@ export class ConfigurationManager {
   public async cleanupMissing(repoId: string, existingFullRefnames: Set<string>): Promise<void> {
     const map = (this.config.preferredRefs || {}) as PreferredRefsMap;
     const prefs = map[repoId];
-    if (!prefs) {return;}
+    if (!prefs) {
+      return;
+    }
 
-    const filterExisting = (arr: string[]) => arr.filter(full => existingFullRefnames.has(full));
-    const newPrefs: PreferredRefsRepo = {
-      locals: filterExisting(prefs.locals),
-      remotes: filterExisting(prefs.remotes),
-      tags: filterExisting(prefs.tags),
-    };
-
-    const changed =
-      newPrefs.locals.length !== prefs.locals.length ||
-      newPrefs.remotes.length !== prefs.remotes.length ||
-      newPrefs.tags.length !== prefs.tags.length;
-
+    const { prefs: newPrefs, changed } = cleanupMissingRefs(prefs, existingFullRefnames);
     if (changed) {
       const config = workspace.getConfiguration(EXTENSION_NAME);
       const updated: PreferredRefsMap = { ...map, [repoId]: newPrefs };
@@ -192,5 +135,4 @@ export class ConfigurationManager {
       this.reload();
     }
   }
-
 }

--- a/src/configuration/preferredRefs.ts
+++ b/src/configuration/preferredRefs.ts
@@ -1,0 +1,144 @@
+import { getFullRefname } from '../common/git/refName';
+import { IGitRef } from '../common/git/types';
+import { PreferredRefsMap, PreferredRefsRepo } from './extensionConfig';
+
+export const emptyPreferredRefs = (): PreferredRefsRepo => ({
+  locals: [],
+  remotes: [],
+  tags: [],
+});
+
+/** Preferences for a single repo, or an empty set when none are stored yet. */
+export const getRepoPrefs = (
+  map: PreferredRefsMap | undefined,
+  repoId: string
+): PreferredRefsRepo => map?.[repoId] ?? emptyPreferredRefs();
+
+export const isRefPreferred = (prefs: PreferredRefsRepo, ref: IGitRef): boolean => {
+  const full = getFullRefname(ref);
+  if (ref.isTag) {
+    return prefs.tags.includes(full);
+  }
+  if (ref.remote) {
+    return prefs.remotes.includes(full);
+  }
+  return prefs.locals.includes(full);
+};
+
+/**
+ * Toggle the preferred state of a ref, returning a new preferences object
+ * (the input is left untouched).
+ *
+ * Local and remote branches that share a name are kept in sync: starring one
+ * stars its counterpart, and unstarring one unstars the other. Tags toggle on
+ * their own.
+ */
+export const togglePreferredRef = (
+  prefs: PreferredRefsRepo,
+  ref: IGitRef,
+  existingRefs: IGitRef[]
+): PreferredRefsRepo => {
+  const next: PreferredRefsRepo = {
+    locals: [...prefs.locals],
+    remotes: [...prefs.remotes],
+    tags: [...prefs.tags],
+  };
+
+  const add = (arr: string[], val: string) => {
+    if (!arr.includes(val)) {
+      arr.push(val);
+    }
+  };
+
+  const remove = (arr: string[], val: string) => {
+    const idx = arr.indexOf(val);
+    if (idx >= 0) {
+      arr.splice(idx, 1);
+    }
+  };
+
+  if (ref.isTag) {
+    const full = getFullRefname(ref);
+    if (next.tags.includes(full)) {
+      remove(next.tags, full);
+    } else {
+      add(next.tags, full);
+    }
+  } else if (ref.remote) {
+    const remoteFull = getFullRefname(ref);
+    const localFull = `refs/heads/${ref.name}`;
+    const existsLocal = existingRefs.some((r) => !r.remote && !r.isTag && r.name === ref.name);
+    if (next.remotes.includes(remoteFull)) {
+      remove(next.remotes, remoteFull);
+      if (existsLocal) {
+        remove(next.locals, localFull);
+      }
+    } else {
+      add(next.remotes, remoteFull);
+      if (existsLocal) {
+        add(next.locals, localFull);
+      }
+    }
+  } else {
+    const localFull = getFullRefname(ref);
+    const remoteFulls = existingRefs
+      .filter((r) => r.remote && !r.isTag && r.name === ref.name)
+      .map((r) => `refs/remotes/${r.remote}/${r.name}`);
+    if (next.locals.includes(localFull)) {
+      remove(next.locals, localFull);
+      remoteFulls.forEach((rf) => remove(next.remotes, rf));
+    } else {
+      add(next.locals, localFull);
+      remoteFulls.forEach((rf) => add(next.remotes, rf));
+    }
+  }
+
+  return next;
+};
+
+/**
+ * Drop preferred entries whose full refname is no longer present.
+ * Returns the filtered prefs and whether anything changed.
+ */
+export const cleanupMissingRefs = (
+  prefs: PreferredRefsRepo,
+  existingFullRefnames: Set<string>
+): { prefs: PreferredRefsRepo; changed: boolean } => {
+  const filter = (arr: string[]) => arr.filter((full) => existingFullRefnames.has(full));
+  const next: PreferredRefsRepo = {
+    locals: filter(prefs.locals),
+    remotes: filter(prefs.remotes),
+    tags: filter(prefs.tags),
+  };
+
+  const changed =
+    next.locals.length !== prefs.locals.length ||
+    next.remotes.length !== prefs.remotes.length ||
+    next.tags.length !== prefs.tags.length;
+
+  return { prefs: next, changed };
+};
+
+/**
+ * Position of a ref within its preferred list (the order it was starred in).
+ * Non-preferred refs sort last.
+ */
+export const preferredOrderIndex = (prefs: PreferredRefsRepo, ref: IGitRef): number => {
+  const full = getFullRefname(ref);
+  const arr = ref.isTag ? prefs.tags : ref.remote ? prefs.remotes : prefs.locals;
+  const idx = arr.indexOf(full);
+  return idx < 0 ? Number.MAX_SAFE_INTEGER : idx;
+};
+
+/**
+ * Stable sort by star order: refs keep the order in which they were starred,
+ * with ties (and non-preferred refs) preserving their original order.
+ */
+export const sortByPreferredOrder = <T extends IGitRef>(
+  refs: T[],
+  prefs: PreferredRefsRepo
+): T[] =>
+  refs
+    .map((ref, index) => ({ ref, index, order: preferredOrderIndex(prefs, ref) }))
+    .sort((a, b) => a.order - b.order || a.index - b.index)
+    .map((entry) => entry.ref);

--- a/src/test/e2e/commandInterface.test.ts
+++ b/src/test/e2e/commandInterface.test.ts
@@ -521,25 +521,25 @@ describe('VS Code command interface', () => {
       let inspectedBasePicker = false;
       let inspectedInput = false;
       const restoreQuickPick = stubCreateQuickPick((items, quickPick) => {
-        assert.strictEqual(quickPick.placeholder, 'Select a branch to checkout');
-        inspectedCommandPicker = true;
-        const createFromAction = items.find((item) =>
-          item.type === 'action' && item.label.includes('Create new branch from...')
-        );
+        // The command picker and the base-branch picker both use createQuickPick;
+        // distinguish them by placeholder.
+        if (quickPick.placeholder === 'Select a branch to checkout') {
+          inspectedCommandPicker = true;
+          const createFromAction = items.find((item) =>
+            item.type === 'action' && item.label.includes('Create new branch from...')
+          );
 
-        assert.ok(createFromAction, 'create-new-branch-from action should be listed');
-        return createFromAction;
-      });
-      const restoreShowQuickPick = stubShowQuickPick((items, options) => {
+          assert.ok(createFromAction, 'create-new-branch-from action should be listed');
+          return createFromAction;
+        }
+
         inspectedBasePicker = true;
-        assert.strictEqual(options?.placeHolder, 'Select a branch to base the new branch on');
+        assert.strictEqual(quickPick.placeholder, 'Select a branch to base the new branch on');
         assert.ok(
-          items.some((item) => typeof item === 'string' && item.includes(repo.mainBranch)),
+          items.some((item) => item.ref?.name === repo.mainBranch),
           'base picker should include the main branch'
         );
-        const featureItem = items.find((item) =>
-          typeof item === 'string' && item.includes(repo.featureBranch)
-        );
+        const featureItem = items.find((item) => item.ref?.name === repo.featureBranch);
 
         assert.ok(featureItem, 'base picker should include the feature branch');
         return featureItem;
@@ -574,7 +574,6 @@ describe('VS Code command interface', () => {
       } finally {
         errors.restore();
         restoreInput();
-        restoreShowQuickPick();
         restoreQuickPick();
         repo.cleanup();
       }

--- a/src/test/unit/enrichOnActive.test.ts
+++ b/src/test/unit/enrichOnActive.test.ts
@@ -1,0 +1,179 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { EnrichableItem, attachLazyEnrichment } from '../../commands/utils/enrichOnActive';
+
+function makeRef(name: string, over: Partial<IGitRef> = {}): IGitRef {
+  return { name, fullName: name, hash: `hash-${name}`, authorName: '', ...over };
+}
+
+function toItem(ref: IGitRef): EnrichableItem {
+  return { label: ref.name, ref };
+}
+
+// Minimal QuickPick stand-in: records item/activeItem assignments and exposes a
+// driver to fire onDidChangeActive the way VS Code would when the user navigates.
+function makeFakeQuickPick() {
+  let listener: ((active: EnrichableItem[]) => void) | undefined;
+  const quickPick = {
+    items: [] as EnrichableItem[],
+    activeItems: [] as EnrichableItem[],
+    onDidChangeActive(l: (active: EnrichableItem[]) => void) {
+      listener = l;
+      return { dispose: () => { listener = undefined; } };
+    },
+  };
+  const fireActive = async (active: EnrichableItem[]) => {
+    quickPick.activeItems = active;
+    await listener?.(active);
+  };
+  return { quickPick, fireActive };
+}
+
+function attach(
+  quickPick: ReturnType<typeof makeFakeQuickPick>['quickPick'],
+  git: GitExecutor,
+  rebuild: () => EnrichableItem[]
+): vscode.Disposable {
+  return attachLazyEnrichment({
+    quickPick: quickPick as unknown as vscode.QuickPick<EnrichableItem>,
+    git,
+    rebuild,
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('attachLazyEnrichment', () => {
+  it('fetches details once per ref and serves re-highlights from cache', async () => {
+    const ref = makeRef('main');
+    const calls: string[] = [];
+    const git = {
+      getRefDetailsFast: async (r: IGitRef) => {
+        calls.push(r.name);
+        return { comment: 'hello' };
+      },
+    } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    const item = toItem(ref);
+    attach(quickPick, git, () => [item]);
+
+    await fireActive([item]);
+    await fireActive([item]);
+
+    assert.deepStrictEqual(calls, ['main']);
+  });
+
+  it('merges resolved details into the ref, repaints, and keeps the highlight', async () => {
+    const ref = makeRef('main');
+    const git = {
+      getRefDetailsFast: async () => ({
+        comment: 'Fix bug',
+        authorName: 'Jane',
+        committerDate: '1700000000',
+      }),
+    } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    let rebuilds = 0;
+    attach(quickPick, git, () => {
+      rebuilds++;
+      return [toItem(ref)];
+    });
+
+    await fireActive([toItem(ref)]);
+
+    assert.strictEqual(ref.comment, 'Fix bug');
+    assert.strictEqual(ref.authorName, 'Jane');
+    assert.strictEqual(ref.committerDate, '1700000000');
+    assert.strictEqual(rebuilds, 1);
+    assert.strictEqual(quickPick.activeItems[0]?.ref?.name, 'main');
+  });
+
+  it('does not repaint when the user moved on before the fetch resolved', async () => {
+    const refA = makeRef('a');
+    const refB = makeRef('b');
+    const pendingDetails = deferred<Partial<IGitRef>>();
+    const git = {
+      getRefDetailsFast: async (r: IGitRef) =>
+        r.name === 'a' ? pendingDetails.promise : { comment: 'B subject' },
+    } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    let rebuilds = 0;
+    attach(quickPick, git, () => {
+      rebuilds++;
+      return [toItem(refA), toItem(refB)];
+    });
+
+    const pendingA = fireActive([toItem(refA)]); // suspends awaiting refA's details
+    await fireActive([toItem(refB)]); // refB resolves immediately and repaints
+
+    pendingDetails.resolve({ comment: 'A subject' });
+    await pendingA;
+
+    assert.strictEqual(refB.comment, 'B subject');
+    assert.strictEqual(refA.comment, 'A subject'); // still merged into the ref
+    assert.strictEqual(rebuilds, 1); // but only refB triggered a repaint
+  });
+
+  it('leaves the row untouched when no details are resolved', async () => {
+    const ref = makeRef('main');
+    const git = { getRefDetailsFast: async () => undefined } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    let rebuilds = 0;
+    attach(quickPick, git, () => {
+      rebuilds++;
+      return [toItem(ref)];
+    });
+
+    await fireActive([toItem(ref)]);
+
+    assert.strictEqual(rebuilds, 0);
+    assert.strictEqual(ref.comment, undefined);
+  });
+
+  it('ignores items without a ref (separators and actions)', async () => {
+    const calls: string[] = [];
+    const git = {
+      getRefDetailsFast: async (r: IGitRef) => {
+        calls.push(r.name);
+        return { comment: 'x' };
+      },
+    } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    let rebuilds = 0;
+    attach(quickPick, git, () => {
+      rebuilds++;
+      return [];
+    });
+
+    await fireActive([{ label: 'Branches', kind: vscode.QuickPickItemKind.Separator }]);
+
+    assert.deepStrictEqual(calls, []);
+    assert.strictEqual(rebuilds, 0);
+  });
+
+  it('stops enriching after the returned disposable is disposed', async () => {
+    const calls: string[] = [];
+    const git = {
+      getRefDetailsFast: async (r: IGitRef) => {
+        calls.push(r.name);
+        return { comment: 'x' };
+      },
+    } as unknown as GitExecutor;
+    const { quickPick, fireActive } = makeFakeQuickPick();
+    const sub = attach(quickPick, git, () => [toItem(makeRef('main'))]);
+    sub.dispose();
+
+    await fireActive([toItem(makeRef('main'))]);
+
+    assert.deepStrictEqual(calls, []);
+  });
+});

--- a/src/test/unit/preferredRefs.test.ts
+++ b/src/test/unit/preferredRefs.test.ts
@@ -1,0 +1,189 @@
+import * as assert from 'assert';
+
+import { IGitRef } from '../../common/git/types';
+import { PreferredRefsRepo } from '../../configuration/extensionConfig';
+import {
+  cleanupMissingRefs,
+  emptyPreferredRefs,
+  getRepoPrefs,
+  isRefPreferred,
+  preferredOrderIndex,
+  sortByPreferredOrder,
+  togglePreferredRef,
+} from '../../configuration/preferredRefs';
+
+function local(name: string): IGitRef {
+  return { name, fullName: name, authorName: '' };
+}
+
+function remote(name: string, remoteName = 'origin'): IGitRef {
+  return { name, fullName: `${remoteName}/${name}`, remote: remoteName, authorName: '' };
+}
+
+function tag(name: string): IGitRef {
+  return { name, fullName: name, isTag: true, authorName: '' };
+}
+
+describe('preferredRefs', () => {
+  describe('getRepoPrefs', () => {
+    it('returns an empty set for unknown repos', () => {
+      assert.deepStrictEqual(getRepoPrefs(undefined, 'a'), emptyPreferredRefs());
+      assert.deepStrictEqual(getRepoPrefs({}, 'a'), emptyPreferredRefs());
+    });
+
+    it('returns the stored prefs when present', () => {
+      const prefs: PreferredRefsRepo = { locals: ['refs/heads/main'], remotes: [], tags: [] };
+      assert.strictEqual(getRepoPrefs({ a: prefs }, 'a'), prefs);
+    });
+  });
+
+  describe('isRefPreferred', () => {
+    const prefs: PreferredRefsRepo = {
+      locals: ['refs/heads/main'],
+      remotes: ['refs/remotes/origin/feature'],
+      tags: ['refs/tags/v1'],
+    };
+
+    it('matches locals, remotes and tags by full refname', () => {
+      assert.strictEqual(isRefPreferred(prefs, local('main')), true);
+      assert.strictEqual(isRefPreferred(prefs, remote('feature')), true);
+      assert.strictEqual(isRefPreferred(prefs, tag('v1')), true);
+    });
+
+    it('does not cross-match a tag and a same-named branch', () => {
+      const p: PreferredRefsRepo = { locals: ['refs/heads/v1'], remotes: [], tags: [] };
+      assert.strictEqual(isRefPreferred(p, tag('v1')), false);
+      assert.strictEqual(isRefPreferred(p, local('v1')), true);
+    });
+
+    it('returns false for non-preferred refs', () => {
+      assert.strictEqual(isRefPreferred(prefs, local('other')), false);
+    });
+  });
+
+  describe('togglePreferredRef', () => {
+    it('does not mutate the input prefs', () => {
+      const prefs = emptyPreferredRefs();
+      const next = togglePreferredRef(prefs, local('main'), [local('main')]);
+      assert.deepStrictEqual(prefs, emptyPreferredRefs());
+      assert.deepStrictEqual(next.locals, ['refs/heads/main']);
+    });
+
+    it('toggles a local branch on and off', () => {
+      const on = togglePreferredRef(emptyPreferredRefs(), local('main'), [local('main')]);
+      assert.deepStrictEqual(on.locals, ['refs/heads/main']);
+      const off = togglePreferredRef(on, local('main'), [local('main')]);
+      assert.deepStrictEqual(off.locals, []);
+    });
+
+    it('toggles a tag independently', () => {
+      const on = togglePreferredRef(emptyPreferredRefs(), tag('v1'), [tag('v1')]);
+      assert.deepStrictEqual(on.tags, ['refs/tags/v1']);
+      assert.deepStrictEqual(on.locals, []);
+      assert.deepStrictEqual(on.remotes, []);
+    });
+
+    it('stars the matching remote when a local with a counterpart is starred', () => {
+      const refs = [local('main'), remote('main')];
+      const next = togglePreferredRef(emptyPreferredRefs(), local('main'), refs);
+      assert.deepStrictEqual(next.locals, ['refs/heads/main']);
+      assert.deepStrictEqual(next.remotes, ['refs/remotes/origin/main']);
+    });
+
+    it('stars the matching local when a remote with a counterpart is starred', () => {
+      const refs = [local('main'), remote('main')];
+      const next = togglePreferredRef(emptyPreferredRefs(), remote('main'), refs);
+      assert.deepStrictEqual(next.remotes, ['refs/remotes/origin/main']);
+      assert.deepStrictEqual(next.locals, ['refs/heads/main']);
+    });
+
+    it('does not create a local entry for a remote without a local counterpart', () => {
+      const refs = [remote('only-remote')];
+      const next = togglePreferredRef(emptyPreferredRefs(), remote('only-remote'), refs);
+      assert.deepStrictEqual(next.remotes, ['refs/remotes/origin/only-remote']);
+      assert.deepStrictEqual(next.locals, []);
+    });
+
+    it('unstarring a local also unstars its synced remotes', () => {
+      const refs = [local('main'), remote('main')];
+      const on = togglePreferredRef(emptyPreferredRefs(), local('main'), refs);
+      const off = togglePreferredRef(on, local('main'), refs);
+      assert.deepStrictEqual(off.locals, []);
+      assert.deepStrictEqual(off.remotes, []);
+    });
+
+    it('does not duplicate a synced local that is already preferred', () => {
+      const refs = [local('main'), remote('main')];
+      // local already starred; starring the remote counterpart must not re-add the local
+      const start: PreferredRefsRepo = { locals: ['refs/heads/main'], remotes: [], tags: [] };
+      const next = togglePreferredRef(start, remote('main'), refs);
+      assert.deepStrictEqual(next.locals, ['refs/heads/main']);
+      assert.deepStrictEqual(next.remotes, ['refs/remotes/origin/main']);
+    });
+  });
+
+  describe('cleanupMissingRefs', () => {
+    it('reports no change when everything still exists', () => {
+      const prefs: PreferredRefsRepo = {
+        locals: ['refs/heads/main'],
+        remotes: ['refs/remotes/origin/main'],
+        tags: ['refs/tags/v1'],
+      };
+      const existing = new Set([
+        'refs/heads/main',
+        'refs/remotes/origin/main',
+        'refs/tags/v1',
+      ]);
+      const { prefs: next, changed } = cleanupMissingRefs(prefs, existing);
+      assert.strictEqual(changed, false);
+      assert.deepStrictEqual(next, prefs);
+    });
+
+    it('drops entries whose refs no longer exist and flags the change', () => {
+      const prefs: PreferredRefsRepo = {
+        locals: ['refs/heads/main', 'refs/heads/gone'],
+        remotes: ['refs/remotes/origin/gone'],
+        tags: ['refs/tags/v1'],
+      };
+      const existing = new Set(['refs/heads/main', 'refs/tags/v1']);
+      const { prefs: next, changed } = cleanupMissingRefs(prefs, existing);
+      assert.strictEqual(changed, true);
+      assert.deepStrictEqual(next, {
+        locals: ['refs/heads/main'],
+        remotes: [],
+        tags: ['refs/tags/v1'],
+      });
+    });
+  });
+
+  describe('ordering', () => {
+    const prefs: PreferredRefsRepo = {
+      locals: ['refs/heads/b', 'refs/heads/a'],
+      remotes: [],
+      tags: [],
+    };
+
+    it('returns the star position, MAX for non-preferred', () => {
+      assert.strictEqual(preferredOrderIndex(prefs, local('b')), 0);
+      assert.strictEqual(preferredOrderIndex(prefs, local('a')), 1);
+      assert.strictEqual(preferredOrderIndex(prefs, local('c')), Number.MAX_SAFE_INTEGER);
+    });
+
+    it('sorts by star order, keeping original order for ties', () => {
+      const sorted = sortByPreferredOrder([local('a'), local('b'), local('c')], prefs);
+      assert.deepStrictEqual(
+        sorted.map((r) => r.name),
+        ['b', 'a', 'c']
+      );
+    });
+
+    it('is a stable no-op when nothing is preferred', () => {
+      const refs = [local('x'), local('y'), local('z')];
+      const sorted = sortByPreferredOrder(refs, emptyPreferredRefs());
+      assert.deepStrictEqual(
+        sorted.map((r) => r.name),
+        ['x', 'y', 'z']
+      );
+    });
+  });
+});

--- a/src/utils/getRepoId.ts
+++ b/src/utils/getRepoId.ts
@@ -1,18 +1,27 @@
-import { GitExecutor } from '../common/git/gitExecutor';
-import { getWorkspaceFoldersFormatted } from '../common/vscode';
+import { createHash } from 'crypto';
+import { basename } from 'path';
 
+import { GitExecutor } from '../common/git/gitExecutor';
+
+/**
+ * Stable, collision-free identifier used to key per-repo preferences.
+ *
+ * GitHub repos use `<owner>/<repo>` so the key follows the repo across clones.
+ * Everything else falls back to the repository path: a short hash keeps unrelated
+ * local repos from colliding (the previous `<workspace folder>` / `'default'`
+ * fallbacks both shared a bucket across distinct repos).
+ */
 export const getRepoId = async (git: GitExecutor): Promise<string> => {
   const info = await git.getRepoInfo();
   if (info) {
     return `${info.owner}/${info.repo}`;
   }
 
-  const wsf = getWorkspaceFoldersFormatted();
-  if (wsf && wsf.length > 0) {
-    return wsf[0].name;
+  const repoPath = git.repositoryPath;
+  if (repoPath) {
+    const hash = createHash('sha1').update(repoPath).digest('hex').slice(0, 8);
+    return `local:${basename(repoPath)}:${hash}`;
   }
 
   return 'default';
 };
-
-

--- a/website/src/components/Features/Features.tsx
+++ b/website/src/components/Features/Features.tsx
@@ -38,6 +38,14 @@ const features: Feature[] = [
     color: 'orange',
   },
   {
+    icon: '🔀',
+    title: 'Rebase with Stash',
+    description:
+      'Rebase the current branch onto any other branch, tag, or ref while your local changes are stashed and restored automatically — no need to commit or clean up first.',
+    command: 'Git Smart Checkout: Rebase ... (With Stash)',
+    color: 'purple',
+  },
+  {
     icon: '⬅️',
     title: 'Checkout Previous Branch',
     description: (
@@ -56,6 +64,14 @@ const features: Feature[] = [
       'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR.',
     command: 'Git Smart Checkout: Clone pull request...',
     tag: 'Beta',
+    color: 'orange',
+  },
+  {
+    icon: '#️⃣',
+    title: 'Checkout by PR Number',
+    description:
+      "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
+    command: 'Git Smart Checkout: Checkout by PR number... (With Stash)',
     color: 'orange',
   },
   {
@@ -82,6 +98,15 @@ const features: Feature[] = [
       'Generate version tags from a configurable template. Read values from package.json, extract ticket IDs from branch names, and auto-increment to avoid collisions.',
     command: 'Git Smart Checkout: Create Tag from Template',
     color: 'blue',
+  },
+  {
+    icon: '🌿',
+    title: 'Branch from Template',
+    description:
+      'Create and check out a branch from a reusable template. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
+    command: 'Git Smart Checkout: Create Branch from Template...',
+    tag: 'New',
+    color: 'green',
   },
   {
     icon: '🌲',

--- a/website/src/components/PlannedFeatures/PlannedFeatures.tsx
+++ b/website/src/components/PlannedFeatures/PlannedFeatures.tsx
@@ -45,13 +45,6 @@ const planned: PlannedFeature[] = [
       'See ⇡N ⇣M (ahead/behind) counts in the status bar for the current branch, with a click-to-fetch shortcut.',
   },
   {
-    icon: '🌿',
-    tier: 2,
-    title: 'Branch Templates',
-    description:
-      'Auto-fill new branch names from configurable templates like feature/{issue}-{slug}, parsing issue IDs from clipboard or active ticket.',
-  },
-  {
     icon: '🗂️',
     tier: 2,
     title: 'Multi-root Workspace',


### PR DESCRIPTION
- Implemented preferred refs management for local, remote, and tag branches.
- Added functionality to toggle preferred state of refs and sort by preference.
- Introduced new command for creating branches from templates with Jira integration.
- Updated UI elements to reflect preferred state with inline star indicators.
- Enhanced tests for preferred refs functionality and lazy enrichment in quick picks.