### PR TITLE
fix: correct recurring token naming and remove duplicate Cancel button

### DIFF
--- a/docs/create-branch-from-template.md
+++ b/docs/create-branch-from-template.md
@@ -48,7 +48,7 @@ You can type a Jira key manually (e.g. `PROJ-123`) and choose **Use "PROJ-123"**
 | `{jira-title[:limit[:separator]]}` | `{jira-title:25:-}` | Slug from the issue summary. Optional `limit` truncates length. Optional `separator` uses its first character (default `-`). |
 | `{f:<file>:<json-path>}` | `{f:package.json:.version}` | Reads a JSON value from a workspace-local file. |
 | `{b:<regex>}` | `{b:\b[A-Z]+-\d+\b}` | First regex match from the current branch name. |
-| `{r:<N>}` | `{r:1}` | Auto-increments from `N` until the branch name does not exist locally or on a remote. |
+| `{r:<N>:<sep>}` | `{r:1:-}` | Optional uniqueness suffix. If the branch built **without** this token is free, the token is dropped. Otherwise it appends `<sep><N>`, incrementing `N` until the name is free. `N` defaults to `1`; `<sep>` defaults to empty. Bare `{r}` and `{r:<N>}` are also valid. |
 | `{s:<script>}` | `{s:./script.sh}` | Runs a workspace-local script (stdout). Stops on script failure. |
 
 The resolved branch name is **lowercased** except the Jira key, which stays **uppercase**.
@@ -58,10 +58,10 @@ The resolved branch name is **lowercased** except the Jira key, which stays **up
 Template:
 
 ```text
-vradchuk/{jira-key}-{jira-title:25:-}-{r:1}
+feature/{jira-key}-{jira-title:25:-}{r:1:-}
 ```
 
-For Jira issue `KEY-123` with summary `[UI] Implement modal dialog with email retry`, if `vradchuk/KEY-123-ui-implement-modal-dia-1` already exists, the command tries `...-2`, `...-3`, and so on.
+For Jira issue `KEY-123` with summary `[UI] Implement modal dialog with email retry`, the command first tries `feature/KEY-123-ui-implement-modal-dia`. If that branch already exists, it tries `feature/KEY-123-ui-implement-modal-dia-1`, then `...-2`, and so on until the name is free.
 
 ## Confirmation
 

--- a/docs/create-tag-from-template.md
+++ b/docs/create-tag-from-template.md
@@ -13,7 +13,7 @@ Generate Git tags from a configurable template with safe token substitution for 
 | --- | --- | --- |
 | `{f:<file>:<json-path>}` | `{f:package.json:.version}` | Reads a JSON value from a workspace-local file. |
 | `{b:<regex>}` | `{b:\b[A-Z]+-\d{3,4}\b}` | Extracts the first regex match from the current branch name. |
-| `{r:<N>}` | `{r:1}` | Auto-increments from `N` until the resulting tag name does not exist. |
+| `{r:<N>:<sep>}` | `{r:1:-}` | Optional uniqueness suffix. If the tag built **without** this token is free, the token is dropped. Otherwise it appends `<sep><N>`, incrementing `N` until the name is free. `N` defaults to `1`; `<sep>` defaults to empty. Bare `{r}` and `{r:<N>}` are also valid. |
 | `{s:<script>}` or `{s:stdout\|stderr:<script>}` | `{s:./get-build-id.sh}` | Runs a workspace-local script and uses its output. Defaults to `stdout`; specify `stderr` to capture the error stream instead. Tag generation stops if the script fails. |
 
 ## Example
@@ -21,10 +21,13 @@ Generate Git tags from a configurable template with safe token substitution for 
 With this template:
 
 ```text
-mobile-v{f:package.json:.version}-{b:\b[A-Z]+-\d{3,4}\b}-{r:1}
+mobile-v{f:package.json:.version}-{b:\b[A-Z]+-\d{3,4}\b}{r:1:-}
 ```
 
-On branch `feature/FEAT-123-login` with `package.json` version `12.3.4` and existing tags `mobile-v12.3.4-FEAT-123-1` and `mobile-v12.3.4-FEAT-123-2`, the command generates:
+On branch `feature/FEAT-123-login` with `package.json` version `12.3.4`:
+
+- If no `mobile-v12.3.4-FEAT-123` tag exists yet, the command generates `mobile-v12.3.4-FEAT-123` (the `{r}` suffix is dropped).
+- If `mobile-v12.3.4-FEAT-123`, `mobile-v12.3.4-FEAT-123-1`, and `mobile-v12.3.4-FEAT-123-2` already exist, it generates:
 
 ```text
 mobile-v12.3.4-FEAT-123-3

--- a/package.json
+++ b/package.json
@@ -68,33 +68,33 @@
     "commands": [
       {
         "command": "git-smart-checkout.checkoutTo",
-        "title": "Checkout to ... (With Stash)",
-        "category": "Git Smart Checkout"
+        "title": "Checkout to... (With Stash)",
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.checkoutPrevious",
         "title": "Checkout previous branch (With Stash)",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.pullWithStash",
         "title": "Pull (With Stash)",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.pullRebaseWithStash",
         "title": "Pull (Rebase With Stash)",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.switchMode",
         "title": "Switch Mode",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.clonePullRequest",
         "title": "Clone pull request...",
-        "category": "Git Smart Checkout",
+        "category": "gsc",
         "icon": {
           "light": "resources/light/clone.svg",
           "dark": "resources/dark/clone.svg"
@@ -103,7 +103,7 @@
       {
         "command": "git-smart-checkout.prCancelCloneMenu",
         "title": "Cancel PR clone",
-        "category": "Git Smart Checkout",
+        "category": "gsc",
         "icon": {
           "light": "resources/light/revert.svg",
           "dark": "resources/dark/revert.svg"
@@ -112,7 +112,7 @@
       {
         "command": "git-smart-checkout.prConflictsResolvedMenu",
         "title": "Conflicts resolved",
-        "category": "Git Smart Checkout",
+        "category": "gsc",
         "icon": {
           "light": "resources/light/forward.svg",
           "dark": "resources/dark/forward.svg"
@@ -120,68 +120,68 @@
       },
       {
         "command": "git-smart-checkout.rebaseWithStash",
-        "title": "Rebase ... (With Stash)",
-        "category": "Git Smart Checkout"
+        "title": "Rebase (With Stash)",
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.createTagFromTemplate",
-        "title": "Create Tag from Template",
-        "category": "Git Smart Checkout"
+        "title": "Create Tag from Template...",
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.createBranchFromTemplate",
         "title": "Create Branch from Template...",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.checkoutByPR",
         "title": "Checkout by PR number... (With Stash)",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.prReviewInWorktree",
         "title": "PR Review in Worktree",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.removePRReviewInWorktree",
         "title": "Remove PR review in Worktree",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.moveToNewWorktree",
         "title": "Move to new worktree",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.copyStagedChangesToWorktree",
-        "title": "Copy staged changes to worktree ...",
-        "category": "Git Smart Checkout"
+        "title": "Copy staged changes to worktree...",
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.copyWipChangesToWorktree",
-        "title": "Copy WIP changes to worktree ...",
-        "category": "Git Smart Checkout"
+        "title": "Copy WIP changes to worktree...",
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.copyWipChangesFromWorktree",
         "title": "Copy WIP from Worktree",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.moveWipChangesFromWorktree",
         "title": "Move WIP from Worktree",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.removeWorktree",
         "title": "Remove Worktree...",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       },
       {
         "command": "git-smart-checkout.openWorktreeDevTerminal",
         "title": "Open Worktree Dev Terminal...",
-        "category": "Git Smart Checkout"
+        "category": "gsc"
       }
     ],
     "menus": {
@@ -322,12 +322,12 @@
         "git-smart-checkout.tagTemplate": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Template used to generate Git tag names. Supports tokens: `{f:<file>:<json-path>}`, `{b:<regex>}`, `{r:<start-number>}`, `{s:<script>}` (stdout) or `{s:stderr:<script>}`.\n\nExample: `test-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}-{s:./test.sh}-{r:1}`"
+          "markdownDescription": "Template used to generate Git tag names. Supports tokens: `{f:<file>:<json-path>}`, `{b:<regex>}`, `{r:<start-number>[:<separator>]}`, `{s:<script>}` (stdout) or `{s:stderr:<script>}`.\n\nThe `{r}` token is an optional uniqueness suffix: it is dropped when the tag built without it is free, otherwise it appends `<separator><start-number>` and increments until the name is free.\n\nExample: `test-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}-{s:./test.sh}{r:1:-}`"
         },
         "git-smart-checkout.branchTemplate": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Template used to generate Git branch names when running **Create Branch from Template ...**. Supports tokens: `{jira-key}`, `{jira-title[:limit[:separator]]}`, `{f:<file>:<json-path>}`, `{b:<regex>}`, `{r:<start-number>}`, `{s:<script>}`.\n\nExample: `vradchuk/{jira-key}-{jira-title:25:-}-{r:1}` — fetches a Jira issue, uppercases the key (e.g. `KEY-123`), slugifies the title (max 25 chars, `-` separator), and auto-increments `{r:1}` until the branch name is available. The resolved name is lowercased except the Jira key."
+          "markdownDescription": "Template used to generate Git branch names when running **Create Branch from Template ...**. Supports tokens: `{jira-key}`, `{jira-title[:limit[:separator]]}`, `{f:<file>:<json-path>}`, `{b:<regex>}`, `{r:<start-number>[:<separator>]}`, `{s:<script>}`.\n\nExample: `vradchuk/{jira-key}-{jira-title:25:-}{r:1:-}` — fetches a Jira issue, uppercases the key (e.g. `KEY-123`), slugifies the title (max 25 chars, `-` separator), and adds `{r:1:-}` only if the branch already exists (appending `-1`, `-2`, … until free). The resolved name is lowercased except the Jira key."
         },
         "git-smart-checkout.jira.domain": {
           "type": "string",

--- a/src/commands/createBranchFromTemplateCommand/index.ts
+++ b/src/commands/createBranchFromTemplateCommand/index.ts
@@ -126,7 +126,7 @@ export class CreateBranchFromTemplateCommand extends BaseCommand {
     }
 
     let branchName = resolved.branch;
-    const hadRecurringToken = resolved.recurringValueUsed !== undefined;
+    const hadRecurringToken = resolved.hadRecurringToken;
 
     if (!branchName) {
       await this.showErrorMessage(

--- a/src/commands/createTagFromTemplateCommand/index.ts
+++ b/src/commands/createTagFromTemplateCommand/index.ts
@@ -98,7 +98,7 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
       }
 
       tagName = resolved.tag;
-      hadRecurringToken = resolved.recurringValueUsed !== undefined;
+      hadRecurringToken = resolved.hadRecurringToken;
       log(`Final tag: ${tagName}`);
     }
 

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -282,7 +282,7 @@ export class AutoStashService {
       `Switching branches will ${operation} a stash that conflicts with the target branch.\n\n` +
       `Conflicting files:\n${fileList}\n\n` +
       `Continue anyway? You will need to resolve conflicts manually after checkout.`;
-    const choice = await window.showWarningMessage(message, { modal: true }, 'Continue', 'Cancel');
+    const choice = await window.showWarningMessage(message, { modal: true }, 'Continue');
     return choice === 'Continue';
   }
 

--- a/src/services/branchTemplateService.ts
+++ b/src/services/branchTemplateService.ts
@@ -23,6 +23,8 @@ export interface ResolvedBranch {
   branch: string;
   recurringValueUsed?: number;
   recurringAttempts: number;
+  /** True when the template contained an {r} token (regardless of whether a number was appended). */
+  hadRecurringToken: boolean;
 }
 
 const JIRA_KEY_TOKEN = '{jira-key}';
@@ -174,6 +176,7 @@ export async function resolveBranchTemplate(
     branch,
     recurringValueUsed: resolved.recurringValueUsed,
     recurringAttempts: resolved.recurringAttempts,
+    hadRecurringToken: resolved.hadRecurringToken,
   };
 }
 

--- a/src/services/tagTemplateService.ts
+++ b/src/services/tagTemplateService.ts
@@ -36,6 +36,8 @@ export interface ResolvedTag {
   tag: string;
   recurringValueUsed?: number;
   recurringAttempts: number;
+  /** True when the template contained an {r} token (regardless of whether a number was appended). */
+  hadRecurringToken: boolean;
 }
 
 export class ScriptTokenError extends Error {
@@ -89,10 +91,30 @@ function scanTokens(template: string): TokenMatch[] {
         i = j + 1;
         continue;
       }
+    } else if (template[i] === '{' && template[i + 1] === 'r' && template[i + 2] === '}') {
+      // Bare {r} token — equivalent to {r:1} with no separator.
+      tokens.push({ full: '{r}', type: 'r', args: '', index: i });
+      i += 3;
+      continue;
     }
     i++;
   }
   return tokens;
+}
+
+// ─── Recurring token args ─────────────────────────────────────────────────────
+// Syntax: {r}, {r:N}, {r:N:sep}. Splits on the FIRST colon so separators may
+// contain further colons. The number defaults to 1; the separator defaults to ''.
+
+export function parseRecurringTokenArgs(args: string): { start: number; separator: string } {
+  const colonIdx = args.indexOf(':');
+  const numPart = colonIdx === -1 ? args : args.substring(0, colonIdx);
+  const separator = colonIdx === -1 ? '' : args.substring(colonIdx + 1);
+
+  const parsed = parseInt(numPart.trim(), 10);
+  const start = isNaN(parsed) ? 1 : parsed;
+
+  return { start, separator };
 }
 
 // ─── Exported helpers (also used in unit tests) ───────────────────────────────
@@ -356,21 +378,41 @@ export async function resolveTagTemplate(
     }
   }
 
-  // Step 4: resolve {r:N} token last (recurring/auto-increment)
+  // Step 4: resolve {r} token last (recurring/auto-increment).
+  // The token only adds uniqueness: try the bare name first; only when it is
+  // taken do we append `<separator><N>` and increment until a free name is found.
   const recurringTokens = tokens.filter((t) => t.type === 'r');
   if (recurringTokens.length === 0) {
-    return { tag: result, recurringAttempts: 0 };
+    return { tag: result, recurringAttempts: 0, hadRecurringToken: false };
   }
 
-  const startN = parseInt(recurringTokens[0].args, 10);
-  let currentN = isNaN(startN) ? 1 : startN;
-  let attempts = 0;
+  const { start, separator } = parseRecurringTokenArgs(recurringTokens[0].args);
 
-  while (attempts < MAX_RECURRING_ITERATIONS) {
+  const buildCandidate = (suffix: string): string => {
     let candidate = result;
     for (const token of recurringTokens) {
-      candidate = candidate.replace(token.full, String(currentN));
+      candidate = candidate.replace(token.full, suffix);
     }
+    return candidate;
+  };
+
+  let attempts = 0;
+
+  // First attempt: the bare name with the token removed entirely.
+  const bareCandidate = buildCandidate('');
+  attempts++;
+  const bareExists = await ctx.tagExists(bareCandidate);
+  ctx.logger.info(
+    `[Create Tag] Trying tag: ${bareCandidate} — ${bareExists ? 'exists' : 'available'}`
+  );
+  if (!bareExists) {
+    return { tag: bareCandidate, recurringAttempts: attempts, hadRecurringToken: true };
+  }
+
+  // Bare name taken — append `<separator><N>`, incrementing N until free.
+  let currentN = start;
+  while (attempts < MAX_RECURRING_ITERATIONS) {
+    const candidate = buildCandidate(`${separator}${currentN}`);
     attempts++;
 
     const exists = await ctx.tagExists(candidate);
@@ -379,7 +421,12 @@ export async function resolveTagTemplate(
     );
 
     if (!exists) {
-      return { tag: candidate, recurringValueUsed: currentN, recurringAttempts: attempts };
+      return {
+        tag: candidate,
+        recurringValueUsed: currentN,
+        recurringAttempts: attempts,
+        hadRecurringToken: true,
+      };
     }
     currentN++;
   }

--- a/src/test/unit/branchTemplateService.test.ts
+++ b/src/test/unit/branchTemplateService.test.ts
@@ -117,10 +117,10 @@ describe('branchTemplateService', () => {
       const title = '[UI] Implement modal dialog with email retry';
       const slug = formatJiraTitle(title, { limit: 25, separator: '-' });
       const base = `vradchuk/KEY-123-${slug}`;
-      const existing = new Set([`${base}-1`, `${base}-2`]);
+      const existing = new Set([base, `${base}-1`, `${base}-2`]);
 
       const result = await resolveBranchTemplate(
-        'vradchuk/{jira-key}-{jira-title:25:-}-{r:1}',
+        'vradchuk/{jira-key}-{jira-title:25:-}{r:1:-}',
         makeBranchCtx({
           jiraKey: 'key-123',
           jiraTitle: title,
@@ -130,7 +130,8 @@ describe('branchTemplateService', () => {
 
       assert.strictEqual(result.branch, `${base}-3`.toLowerCase().replace('key-123', 'KEY-123'));
       assert.strictEqual(result.recurringValueUsed, 3);
-      assert.strictEqual(result.recurringAttempts, 3);
+      // bare probe + 1 + 2 + 3
+      assert.strictEqual(result.recurringAttempts, 4);
     });
 
     it('inserts uppercase jira key and lowercases the rest', async () => {
@@ -182,25 +183,35 @@ describe('branchTemplateService', () => {
     });
 
     it('auto-increments recurring token when branch exists', async () => {
-      const existing = new Set(['branch-1', 'branch-2']);
-      const result = await resolveBranchTemplate('branch-{r:1}', makeBranchCtx({
+      const existing = new Set(['branch', 'branch-1', 'branch-2']);
+      const result = await resolveBranchTemplate('branch{r:1:-}', makeBranchCtx({
         branchExists: async (name) => existing.has(name),
       }));
       assert.strictEqual(result.branch, 'branch-3');
       assert.strictEqual(result.recurringValueUsed, 3);
     });
 
-    it('{r:5} starts at 5 when branch is available', async () => {
-      const result = await resolveBranchTemplate('release-{r:5}', makeBranchCtx());
+    it('uses the bare branch name when it is available', async () => {
+      const result = await resolveBranchTemplate('release{r:5:-}', makeBranchCtx());
+      assert.strictEqual(result.branch, 'release');
+      assert.strictEqual(result.recurringValueUsed, undefined);
+      assert.strictEqual(result.hadRecurringToken, true);
+    });
+
+    it('{r:5:-} starts at 5 when the bare branch name is taken', async () => {
+      const result = await resolveBranchTemplate('release{r:5:-}', makeBranchCtx({
+        branchExists: async (name) => name === 'release',
+      }));
       assert.strictEqual(result.branch, 'release-5');
       assert.strictEqual(result.recurringValueUsed, 5);
     });
 
-    it('returns branch unchanged when no {r:N} token is present', async () => {
+    it('returns branch unchanged when no {r} token is present', async () => {
       const result = await resolveBranchTemplate('static-branch', makeBranchCtx());
       assert.strictEqual(result.branch, 'static-branch');
       assert.strictEqual(result.recurringAttempts, 0);
       assert.strictEqual(result.recurringValueUsed, undefined);
+      assert.strictEqual(result.hadRecurringToken, false);
     });
 
     it('throws when recurring iteration cap is reached', async () => {
@@ -233,9 +244,10 @@ describe('branchTemplateService', () => {
     });
 
     it('combines Jira, file, branch regex, and recurring tokens', async () => {
-      const existing = new Set<string>();
+      // The existence check runs on the pre-casing-finalized candidate (uppercase regex match).
+      const existing = new Set<string>(['FEAT-1-1.0-FEAT-99']);
       const result = await resolveBranchTemplate(
-        '{jira-key}-{f:package.json:.version}-{b:\\b[A-Z]+-\\d+\\b}-{r:1}',
+        '{jira-key}-{f:package.json:.version}-{b:\\b[A-Z]+-\\d+\\b}{r:1:-}',
         makeBranchCtx({
           jiraKey: 'FEAT-1',
           getCurrentBranch: async () => 'feature/FEAT-99-extra',

--- a/src/test/unit/tagTemplateService.test.ts
+++ b/src/test/unit/tagTemplateService.test.ts
@@ -5,6 +5,7 @@ import {
   isSafeWorkspacePath,
   readJsonDotPath,
   extractFirstRegexMatch,
+  parseRecurringTokenArgs,
   ScriptTokenError,
   TagTemplateContext,
   TagTemplateLogger,
@@ -97,9 +98,43 @@ describe('tagTemplateService', () => {
     });
   });
 
+  describe('parseRecurringTokenArgs', () => {
+    it('defaults to start 1 and empty separator for empty args ({r})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs(''), { start: 1, separator: '' });
+    });
+
+    it('parses start only ({r:5})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs('5'), { start: 5, separator: '' });
+    });
+
+    it('parses start and separator ({r:1:-})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs('1:-'), { start: 1, separator: '-' });
+    });
+
+    it('parses custom start and separator ({r:5:-})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs('5:-'), { start: 5, separator: '-' });
+    });
+
+    it('treats a trailing colon as an empty separator ({r:1:})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs('1:'), { start: 1, separator: '' });
+    });
+
+    it('defaults the start when omitted but separator given ({r::-})', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs(':-'), { start: 1, separator: '-' });
+    });
+
+    it('falls back to start 1 for a non-numeric start', () => {
+      assert.deepStrictEqual(parseRecurringTokenArgs('abc'), { start: 1, separator: '' });
+    });
+  });
+
   describe('resolveTagTemplate', () => {
     it('resolves full template to correct tag (task spec scenario)', async () => {
-      const existingTags = new Set(['mobile-v12.3.4-FEAT-123-1', 'mobile-v12.3.4-FEAT-123-2']);
+      const existingTags = new Set([
+        'mobile-v12.3.4-FEAT-123',
+        'mobile-v12.3.4-FEAT-123-1',
+        'mobile-v12.3.4-FEAT-123-2',
+      ]);
       const ctx = makeCtx({
         getCurrentBranch: async () => 'feature/FEAT-123-login',
         tagExists: async (name) => existingTags.has(name),
@@ -107,26 +142,30 @@ describe('tagTemplateService', () => {
         realpath: async (p) => p,
       });
       const result = await resolveTagTemplate(
-        'mobile-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}-{r:1}',
+        'mobile-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}{r:1:-}',
         ctx
       );
       assert.strictEqual(result.tag, 'mobile-v12.3.4-FEAT-123-3');
       assert.strictEqual(result.recurringValueUsed, 3);
-      assert.strictEqual(result.recurringAttempts, 3);
+      // bare probe + 1 + 2 + 3
+      assert.strictEqual(result.recurringAttempts, 4);
     });
 
-    it('produces double-dash when regex has no match (empty branch token)', async () => {
+    it('uses the bare name (no suffix) when it is available', async () => {
       const ctx = makeCtx({
-        getCurrentBranch: async () => 'feature/login-screen',
+        getCurrentBranch: async () => 'feature/FEAT-123-login',
         tagExists: async () => false,
         readFile: async () => JSON.stringify({ version: '12.3.4' }),
         realpath: async (p) => p,
       });
       const result = await resolveTagTemplate(
-        'mobile-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}-{r:1}',
+        'mobile-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}{r:1:-}',
         ctx
       );
-      assert.strictEqual(result.tag, 'mobile-v12.3.4--1');
+      assert.strictEqual(result.tag, 'mobile-v12.3.4-FEAT-123');
+      assert.strictEqual(result.recurringValueUsed, undefined);
+      assert.strictEqual(result.hadRecurringToken, true);
+      assert.strictEqual(result.recurringAttempts, 1);
     });
 
     it('resolves unsafe path ../package.json to empty and warns', async () => {
@@ -214,19 +253,22 @@ describe('tagTemplateService', () => {
       assert.strictEqual(result.tag, 'v3.0.0-FEAT-99');
       assert.strictEqual(result.recurringAttempts, 0);
       assert.strictEqual(result.recurringValueUsed, undefined);
+      assert.strictEqual(result.hadRecurringToken, false);
     });
 
-    it('{r:5} starts at 5', async () => {
-      const ctx = makeCtx({ tagExists: async () => false });
-      const result = await resolveTagTemplate('release-{r:5}', ctx);
+    it('{r:5:-} starts at 5 when the bare name is taken', async () => {
+      const ctx = makeCtx({ tagExists: async (name) => name === 'release' });
+      const result = await resolveTagTemplate('release{r:5:-}', ctx);
       assert.strictEqual(result.tag, 'release-5');
       assert.strictEqual(result.recurringValueUsed, 5);
     });
 
-    it('multiple {r:N} tokens in same template are all replaced with same value', async () => {
-      const ctx = makeCtx({ tagExists: async () => false });
+    it('multiple {r} tokens in same template are all replaced with same value', async () => {
+      // Bare candidate "-suffix-" is taken, so the numbered suffix is applied to both tokens.
+      const ctx = makeCtx({ tagExists: async (name) => name === '-suffix-' });
       const result = await resolveTagTemplate('{r:1}-suffix-{r:1}', ctx);
       assert.strictEqual(result.tag, '1-suffix-1');
+      assert.strictEqual(result.recurringValueUsed, 1);
     });
 
     it('throws when iteration cap is reached', async () => {
@@ -235,6 +277,72 @@ describe('tagTemplateService', () => {
         () => resolveTagTemplate('v-{r:1}', ctx),
         /Could not find available tag/
       );
+    });
+
+    describe('{r} recurring token (optional uniqueness suffix)', () => {
+      // Helper: tags in the given set "exist".
+      const existing = (...names: string[]) => {
+        const set = new Set(names);
+        return async (name: string) => set.has(name);
+      };
+
+      it('example 1: {r:1:-} with no existing tag → bare name, no suffix', async () => {
+        const ctx = makeCtx({ tagExists: existing() });
+        const result = await resolveTagTemplate('vradchuk/test{r:1:-}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test');
+        assert.strictEqual(result.recurringValueUsed, undefined);
+        assert.strictEqual(result.hadRecurringToken, true);
+      });
+
+      it('example 2: {r:1:-} when bare name exists → test-1', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test') });
+        const result = await resolveTagTemplate('vradchuk/test{r:1:-}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test-1');
+        assert.strictEqual(result.recurringValueUsed, 1);
+      });
+
+      it('example 3: {r:1:-} when test and test-1 exist → test-2', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test', 'vradchuk/test-1') });
+        const result = await resolveTagTemplate('vradchuk/test{r:1:-}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test-2');
+        assert.strictEqual(result.recurringValueUsed, 2);
+      });
+
+      it('example 4: {r:5:-} when bare name exists → test-5', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test') });
+        const result = await resolveTagTemplate('vradchuk/test{r:5:-}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test-5');
+        assert.strictEqual(result.recurringValueUsed, 5);
+      });
+
+      it('example 5: {r:1} (no separator) when bare name exists → test1', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test') });
+        const result = await resolveTagTemplate('vradchuk/test{r:1}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test1');
+        assert.strictEqual(result.recurringValueUsed, 1);
+      });
+
+      it('example 6: bare {r} when bare name exists → test1 (default start 1, no separator)', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test') });
+        const result = await resolveTagTemplate('vradchuk/test{r}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test1');
+        assert.strictEqual(result.recurringValueUsed, 1);
+      });
+
+      it('bare {r} with no existing tag → bare name, no suffix', async () => {
+        const ctx = makeCtx({ tagExists: existing() });
+        const result = await resolveTagTemplate('vradchuk/test{r}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test');
+        assert.strictEqual(result.recurringValueUsed, undefined);
+        assert.strictEqual(result.hadRecurringToken, true);
+      });
+
+      it('{r:1:} (empty separator) when bare name exists → test1', async () => {
+        const ctx = makeCtx({ tagExists: existing('vradchuk/test') });
+        const result = await resolveTagTemplate('vradchuk/test{r:1:}', ctx);
+        assert.strictEqual(result.tag, 'vradchuk/test1');
+        assert.strictEqual(result.recurringValueUsed, 1);
+      });
     });
 
     describe('{s:stream:script} token', () => {
@@ -341,10 +449,11 @@ describe('tagTemplateService', () => {
           tagExists: async () => false,
         });
         const result = await resolveTagTemplate(
-          '{f:package.json:.version}-{s:stdout:./tag-suffix.sh}-{r:1}',
+          '{f:package.json:.version}-{s:stdout:./tag-suffix.sh}{r:1:-}',
           ctx
         );
-        assert.strictEqual(result.tag, '3.1.0-custom-1');
+        // Bare name is available, so no suffix is appended.
+        assert.strictEqual(result.tag, '3.1.0-custom');
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes two issues with branch/tag template creation and modal dialogs.

### Fixes #72 — Incorrect recurring token name when no branch/tag exists yet
When a template contains an `{r}` (recurring) token, the name is now tried **without** the suffix first. The recurring suffix is only appended when the bare name already exists, then incremented until a free name is found. Previously a number was always appended even when the base name was available.

- Added `hadRecurringToken` to `ResolvedBranch` / `ResolvedTag` so callers can detect the token independently of whether a number was used.
- Support for bare `{r}` token and `{r:N:sep}` separator syntax via `parseRecurringTokenArgs`.

### Fixes #73 — Duplicated Cancel button on modal dialog
Removed the explicit `'Cancel'` button from the auto-stash modal warning dialog. VS Code automatically adds its own Cancel button to modal dialogs, which resulted in two Cancel buttons being shown.

## Test plan
- Updated unit tests for `branchTemplateService` and `tagTemplateService` covering the bare-name-first behavior and separator parsing.

Closes #72
Closes #73