### PR TITLE
feat: copy current branch name to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In fast-paced development environments, switching between Git branches is freque
 | --- | --- | --- |
 | Checkout to a branch, tag, or remote ref with configurable stash behavior | `Git Smart Checkout: Checkout to ... (With Stash)` | [Checkout with stash](docs/checkout-with-stash.md) |
 | Checkout the previous branch with the same stash behavior | `Git Smart Checkout: Checkout previous branch (With Stash)` | [Checkout previous branch with stash](docs/checkout-previous-branch-with-stash.md) |
+| Copy the current branch name to the clipboard | `Git Smart Checkout: Copy current branch name to clipboard` | [Copy current branch name](docs/copy-current-branch-name.md) |
 | Checkout a GitHub pull request branch by PR number or URL | `Git Smart Checkout: Checkout by PR number... (With Stash)` | [Checkout by PR number with stash](docs/checkout-by-pr-number-with-stash.md) |
 | Review a GitHub pull request in a linked worktree and remove tracked review worktrees | `Git Smart Checkout: PR Review in Worktree`, `Git Smart Checkout: Remove PR review in Worktree` | [PR review in worktree](docs/pr-review-in-worktree.md) |
 | Pull the current branch while preserving local changes | `Git Smart Checkout: Pull (With Stash)` | [Pull with stash](docs/pull-with-stash.md) |

--- a/docs/copy-current-branch-name.md
+++ b/docs/copy-current-branch-name.md
@@ -1,0 +1,13 @@
+# Copy Current Branch Name
+
+Command: `Git Smart Checkout: Copy current branch name to clipboard`
+
+Use this command to copy the name of the currently checked-out branch to the clipboard, similar to running `git branch --show-current | pbcopy`.
+
+## What It Does
+
+1. Reads the current branch name.
+2. Copies it to the system clipboard.
+3. Shows a notification confirming what was copied that auto-dismisses after 5 seconds.
+
+If the current workspace is not a git repository (or no branch can be determined, e.g. a detached HEAD), the command shows an error message instead.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.copyBranchName",
+        "title": "Copy current branch name to clipboard",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.pullWithStash",
         "title": "Pull (With Stash)",
         "category": "GSC"
@@ -195,6 +200,9 @@
         },
         {
           "command": "git-smart-checkout.checkoutPrevious"
+        },
+        {
+          "command": "git-smart-checkout.copyBranchName"
         },
         {
           "command": "git-smart-checkout.pullWithStash"

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -23,6 +23,7 @@ export enum AnalyticsEvent {
   CopyWipChangesFromWorktree = 'copy_wip_changes_from_worktree',
   MoveWipChangesFromWorktree = 'move_wip_changes_from_worktree',
   WorktreeDevTerminalOpened = 'worktree_dev_terminal_opened',
+  CopyBranchName = 'copy_branch_name',
 }
 
 let client: PostHog | null = null;

--- a/src/commands/copyBranchNameCommand/index.ts
+++ b/src/commands/copyBranchNameCommand/index.ts
@@ -1,0 +1,40 @@
+import { env } from 'vscode';
+
+import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
+import { LoggingService } from '../../logging/loggingService';
+import { showAutoDismissNotification } from '../../utils/showAutoDismissNotification';
+import { BaseCommand } from '../command';
+
+export class CopyBranchNameCommand extends BaseCommand {
+  constructor(logService: LoggingService) {
+    super(logService);
+  }
+
+  async execute(): Promise<void> {
+    try {
+      const git = await this.getGitExecutor();
+
+      const branch = await git.getCurrentBranch();
+      if (!branch) {
+        throw new Error('The current workspace is not a git repository.');
+      }
+
+      await env.clipboard.writeText(branch);
+
+      this.logService.info(`Copied current branch name to clipboard: ${branch}`);
+      capture(AnalyticsEvent.CopyBranchName);
+
+      showAutoDismissNotification(`Copied branch name to clipboard: ${branch}`);
+    } catch (error) {
+      captureException(error);
+      if (error instanceof Error) {
+        const message = error.message;
+        if (message) {
+          await this.showErrorMessage(message, 'OK');
+        }
+      } else {
+        await this.showErrorMessage('Unknown error', 'OK');
+      }
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { CheckoutToCommand } from './commands/checkoutToCommand';
 import { CheckoutPreviousCommand } from './commands/checkoutPreviousCommand';
+import { CopyBranchNameCommand } from './commands/copyBranchNameCommand';
 import { CommandManager } from './commands/commandManager';
 import { PullRebaseWithStashCommand, PullWithStashCommand } from './commands/pullWithStashCommand';
 import { SwitchModeCommand } from './commands/switchModeCommand';
@@ -114,6 +115,9 @@ export function activate(context: vscode.ExtensionContext) {
   commandManager.registerCommand(`${EXTENSION_NAME}.checkoutTo`, checkoutToCommand);
 
   commandManager.registerCommand(`${EXTENSION_NAME}.checkoutPrevious`, checkoutPreviousCommand);
+
+  const copyBranchNameCommand = new CopyBranchNameCommand(logService);
+  commandManager.registerCommand(`${EXTENSION_NAME}.copyBranchName`, copyBranchNameCommand);
 
   commandManager.registerCommand(`${EXTENSION_NAME}.pullWithStash`, pullWithStashCommand);
   commandManager.registerCommand(`${EXTENSION_NAME}.pullRebaseWithStash`, pullRebaseWithStashCommand);

--- a/src/test/e2e/copyBranchName.test.ts
+++ b/src/test/e2e/copyBranchName.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { CopyBranchNameCommand } from '../../commands/copyBranchNameCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+
+import { createTestRepo } from './helpers/gitTestRepo';
+import { mockLogService } from './helpers/mockLogService';
+
+class TestableCopyBranchNameCommand extends CopyBranchNameCommand {
+  constructor(private readonly git: GitExecutor) {
+    super(mockLogService);
+  }
+
+  protected async getGitExecutor(): Promise<GitExecutor> {
+    return this.git;
+  }
+}
+
+function stubWithProgress(titles: string[]): () => void {
+  const original = vscode.window.withProgress.bind(vscode.window);
+  (vscode.window as any).withProgress = (
+    options: vscode.ProgressOptions,
+    task: (progress: unknown, token: unknown) => Thenable<unknown>
+  ) => {
+    if (options.title) {
+      titles.push(options.title);
+    }
+    // Resolve the task immediately so the auto-dismiss timer does not linger.
+    return Promise.resolve(task({ report: () => undefined }, { isCancellationRequested: false }));
+  };
+  return () => {
+    (vscode.window as any).withProgress = original;
+  };
+}
+
+function stubErrorMessages(messages: string[]): () => void {
+  const original = vscode.window.showErrorMessage.bind(vscode.window);
+  (vscode.window as any).showErrorMessage = async (message: string) => {
+    messages.push(message);
+    return 'OK';
+  };
+  return () => {
+    (vscode.window as any).showErrorMessage = original;
+  };
+}
+
+describe('CopyBranchNameCommand', () => {
+  it('copies the current branch name to the clipboard and shows a notification', async () => {
+    const repo = createTestRepo();
+    repo.exec(`git checkout ${repo.featureBranch}`);
+
+    const titles: string[] = [];
+    const restoreWithProgress = stubWithProgress(titles);
+    await vscode.env.clipboard.writeText('sentinel');
+
+    try {
+      await new TestableCopyBranchNameCommand(repo.git).execute();
+
+      const clipboard = await vscode.env.clipboard.readText();
+      assert.strictEqual(clipboard, repo.featureBranch);
+      assert.strictEqual(titles.length, 1);
+      assert.ok(
+        titles[0].includes(repo.featureBranch),
+        `expected notification title to include "${repo.featureBranch}", got "${titles[0]}"`
+      );
+    } finally {
+      restoreWithProgress();
+      repo.cleanup();
+    }
+  });
+
+  it('shows an error and does not write the clipboard when no branch can be determined', async () => {
+    const fakeGit = {
+      getCurrentBranch: async () => '',
+    } as unknown as GitExecutor;
+
+    const messages: string[] = [];
+    const restoreErrorMessages = stubErrorMessages(messages);
+    await vscode.env.clipboard.writeText('sentinel');
+
+    try {
+      await new TestableCopyBranchNameCommand(fakeGit).execute();
+
+      const clipboard = await vscode.env.clipboard.readText();
+      assert.strictEqual(clipboard, 'sentinel');
+      assert.strictEqual(messages.length, 1);
+      assert.ok(messages[0].includes('not a git repository'));
+    } finally {
+      restoreErrorMessages();
+    }
+  });
+});

--- a/src/utils/showAutoDismissNotification.ts
+++ b/src/utils/showAutoDismissNotification.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+/**
+ * Shows a buttonless notification toast that auto-dismisses after `durationMs`.
+ *
+ * VS Code's `showInformationMessage` has no controllable timeout, so we use the
+ * progress notification location and resolve the underlying promise after a delay.
+ */
+export function showAutoDismissNotification(message: string, durationMs = 5000): void {
+  void vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Notification, title: message, cancellable: false },
+    () => new Promise<void>((resolve) => setTimeout(resolve, durationMs))
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new command **GSC: Copy current branch name to clipboard** that copies the current git branch name to the clipboard and shows a notification confirming what was copied. The notification auto-dismisses after 5 seconds.

This mirrors the CLI `git branch --show-current | pbcopy`.

Closes #76

## Changes

- New command `git-smart-checkout.copyBranchName` (`src/commands/copyBranchNameCommand/`), registered in `extension.ts` and contributed in `package.json` (command + command palette).
- New `showAutoDismissNotification` helper using the `withProgress` notification location for a controllable 5s auto-dismiss (VS Code's `showInformationMessage` has no timeout).
- New `CopyBranchName` analytics event.
- Documentation: new `docs/copy-current-branch-name.md` and a row in the README Features table.
- E2E tests covering the happy path (clipboard + notification) and the non-git error path.

## Testing

- `yarn compile` (type-check + lint) passes.
- `yarn test:e2e` — both new `CopyBranchNameCommand` tests pass. (Pre-existing unrelated suites fail in this local environment due to `git symbolic-ref`/missing `origin` remote in test helpers; not affected by this change.)
- Manual: run the command from the palette, paste to confirm the branch name, observe the toast auto-dismiss after ~5s.