### PR TITLE
fix: prevent data loss when cancelling PR clone in temp-worktree mode

### DIFF
--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -138,6 +138,17 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
     try {
       this.cleanUpActionBegin.forEach((action) => action());
 
+      await setContextIsCloning(false);
+      await setContextIsCherryPickConflict(false);
+
+      // If the in-place service was never started (e.g. temp-worktree mode was
+      // active and this service holds an empty store), there is nothing to clean
+      // up. Bail out BEFORE touching the user's working directory so we never
+      // hard-reset a repository this service did not modify.
+      if (!this.serviceStore.originalBranch) {
+        return;
+      }
+
       // Check if there's an active cherry-pick operation and abort it
       if (await this.git.isCherryPickInProgress()) {
         try {
@@ -148,19 +159,17 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
         }
       }
 
-      // Hard reset to reset all changes in workdir
-      try {
-        await this.git.reset(true);
-      } catch (error) {
-        this.loggingService.warn(`Failed to reset working directory: ${error}`);
+      // Hard reset to discard all changes in workdir, but only when this service
+      // actually created a feature branch. Without a created branch there are no
+      // in-place changes that belong to us to reset.
+      if (this.serviceStore.createdBranchName) {
+        try {
+          await this.git.reset(true);
+        } catch (error) {
+          this.loggingService.warn(`Failed to reset working directory: ${error}`);
+        }
       }
 
-      await setContextIsCloning(false);
-      await setContextIsCherryPickConflict(false);
-
-      if (!this.serviceStore.originalBranch) {
-        return;
-      }
       await this.git.checkout(this.serviceStore.originalBranch);
 
       if (this.serviceStore.stashMessage) {

--- a/src/services/prCloneService.ts
+++ b/src/services/prCloneService.ts
@@ -121,7 +121,13 @@ export class PrCloneService {
   }
 
   async abortClonePR() {
-    this.InPlaceService.abortClonePR();
+    const config = this.configurationManager.get();
+
+    if (config.useInPlaceCherryPick) {
+      this.InPlaceService.abortClonePR();
+    } else {
+      this.TempWorktreeService.abortClonePR();
+    }
   }
 
   isDevMode() {

--- a/src/test/unit/prCloneAbort.test.ts
+++ b/src/test/unit/prCloneAbort.test.ts
@@ -1,0 +1,138 @@
+import * as assert from 'assert';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Regression tests for the critical data-loss bug where cancelling a PR clone
+ * in temp-worktree mode hard-reset the user's main repository.
+ *
+ * The in-place service must never touch (hard reset / checkout) the working
+ * directory when it was never started (empty serviceStore) — which is exactly
+ * the state it is left in while temp-worktree mode is active.
+ */
+describe('PrCloneInPlaceService.cleanUp (abort) guard', () => {
+  interface GitCalls {
+    reset: Array<boolean>;
+    checkout: Array<string>;
+    isCherryPickInProgress: number;
+    cherryPickAbort: number;
+    deleteLocalBranch: Array<string>;
+  }
+
+  const createGitStub = (cherryPickInProgress = false) => {
+    const calls: GitCalls = {
+      reset: [],
+      checkout: [],
+      isCherryPickInProgress: 0,
+      cherryPickAbort: 0,
+      deleteLocalBranch: [],
+    };
+
+    const gitStub = {
+      reset: async (hard = false) => {
+        calls.reset.push(hard);
+      },
+      checkout: async (branch: string) => {
+        calls.checkout.push(branch);
+      },
+      isCherryPickInProgress: async () => {
+        calls.isCherryPickInProgress += 1;
+        return cherryPickInProgress;
+      },
+      cherryPickAbort: async () => {
+        calls.cherryPickAbort += 1;
+      },
+      popStash: async () => {},
+      deleteLocalBranch: async (branch: string) => {
+        calls.deleteLocalBranch.push(branch);
+      },
+    } as unknown as GitExecutor;
+
+    return { gitStub, calls };
+  };
+
+  const createService = (gitStub: GitExecutor) =>
+    new PrCloneInPlaceService(gitStub, {} as any, mockLogService);
+
+  it('does NOT hard-reset or checkout when the service was never started (temp-worktree mode)', async () => {
+    const { gitStub, calls } = createGitStub();
+    const service = createService(gitStub);
+
+    // Simulate the temp-worktree path: the in-place service holds an empty
+    // store because it was never used to start a clone.
+    await service.abortClonePR();
+    // allow the async cleanUp triggered by abortClonePR to settle
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.deepStrictEqual(
+      calls.reset,
+      [],
+      'reset() must never be called when the service was not started'
+    );
+    assert.deepStrictEqual(
+      calls.checkout,
+      [],
+      'checkout() must never be called when the service was not started'
+    );
+    assert.strictEqual(
+      calls.isCherryPickInProgress,
+      0,
+      'cherry-pick state must not be inspected before the originalBranch guard'
+    );
+  });
+
+  it('hard-resets and restores the original branch when a clone was actually started', async () => {
+    const { gitStub, calls } = createGitStub();
+    const service = createService(gitStub);
+
+    // Reproduce the state of a started in-place clone.
+    (service as any).serviceStore = {
+      originalBranch: 'main',
+      createdBranchName: 'feature/foo',
+      isAborting: false,
+    };
+
+    await (service as any).cleanUp(true);
+
+    assert.deepStrictEqual(
+      calls.reset,
+      [true],
+      'a started clone must perform exactly one hard reset'
+    );
+    assert.deepStrictEqual(
+      calls.checkout,
+      ['main'],
+      'a started clone must restore the original branch'
+    );
+    assert.deepStrictEqual(
+      calls.deleteLocalBranch,
+      ['feature/foo'],
+      'aborting a started clone must delete the created branch'
+    );
+  });
+
+  it('does NOT hard-reset when started but no feature branch was created yet', async () => {
+    const { gitStub, calls } = createGitStub();
+    const service = createService(gitStub);
+
+    // originalBranch is set (clone began) but createdBranchName is still absent.
+    (service as any).serviceStore = {
+      originalBranch: 'main',
+    };
+
+    await (service as any).cleanUp(true);
+
+    assert.deepStrictEqual(
+      calls.reset,
+      [],
+      'no hard reset should occur before a feature branch is created'
+    );
+    assert.deepStrictEqual(
+      calls.checkout,
+      ['main'],
+      'the original branch should still be restored'
+    );
+  });
+});


### PR DESCRIPTION
## Bug

Cancelling a PR clone while **temp-worktree mode** was active hard-reset the user's main repository, destroying uncommitted changes (FABLE_REVIEW issue #1, CRITICAL data loss).

Root causes:
- `PrCloneService.abortClonePR()` unconditionally called `this.InPlaceService.abortClonePR()`, ignoring the `useInPlaceCherryPick` setting.
- `PrCloneInPlaceService.cleanUp()` ran `git reset --hard` (`this.git.reset(true)`) **before** the `if (!this.serviceStore.originalBranch) return;` guard. In temp-worktree mode the in-place service is never used (empty `serviceStore`), so the hard reset hit the user's main repo and wiped uncommitted work.

## Fix

1. `PrCloneService.abortClonePR()` now dispatches on configuration, exactly like `clonePR()` and `cherryPickNext()`:
   - `useInPlaceCherryPick` true -> `InPlaceService.abortClonePR()`
   - otherwise -> `TempWorktreeService.abortClonePR()`
2. `PrCloneInPlaceService.cleanUp()` moves the `originalBranch` guard above the cherry-pick-abort / reset block, so an un-started service never touches the working directory. The `git reset --hard` now only runs when `serviceStore.createdBranchName` is set (i.e. a feature branch was actually created).

## Tests

Adds `src/test/unit/prCloneAbort.test.ts` with a stubbed `GitExecutor`:
- Aborting an unstarted in-place service (temp-worktree mode) performs **no** `reset` and **no** `checkout`.
- A started clone still performs exactly one hard reset, restores the original branch, and deletes the created branch.
- A clone that started but created no feature branch restores the branch without a hard reset.

`yarn compile` (check-types + lint + build) passes. All 214 unit tests pass, including the 3 new ones.