### PR TITLE
fix: paginate GitHub PR commits and labels to avoid dropping data

### DIFF
--- a/src/common/api/ghClient.ts
+++ b/src/common/api/ghClient.ts
@@ -8,6 +8,12 @@ export class GitHubClient {
   private static readonly BASE_URL = 'https://api.github.com';
   private static readonly USER_AGENT = `${EXTENSION_NAME}-vscode-extension`;
 
+  /**
+   * GitHub's pull request "list commits" endpoint returns at most 250 commits,
+   * regardless of pagination. PRs with more commits cannot be fully cloned.
+   */
+  public static readonly MAX_PR_COMMITS = 250;
+
   constructor(
     private readonly _owner: string,
     private readonly _repo: string
@@ -118,6 +124,30 @@ export class GitHubClient {
   }
 
   /**
+   * Perform a paginated GET request, following pages until a partial page is
+   * returned. Defaults to the maximum page size GitHub allows (100).
+   */
+  private async makePaginatedRequest<T>(endpoint: string): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const sep = endpoint.includes('?') ? '&' : '?';
+      const batch = await this.makeRequest<T[]>(
+        `${endpoint}${sep}per_page=${perPage}&page=${page}`
+      );
+      results.push(...batch);
+      if (batch.length < perPage) {
+        break;
+      }
+      page++;
+    }
+
+    return results;
+  }
+
+  /**
    * Fetch pull request data by PR number
    */
   public async fetchPullRequest(prNumber: number): Promise<GitHubPR> {
@@ -130,7 +160,7 @@ export class GitHubClient {
    */
   public async fetchPullRequestCommits(prNumber: number): Promise<GitHubCommit[]> {
     const endpoint = `/repos/${this.owner}/${this.repo}/pulls/${prNumber}/commits`;
-    return this.makeRequest<GitHubCommit[]>(endpoint);
+    return this.makePaginatedRequest<GitHubCommit>(endpoint);
   }
 
   /**
@@ -236,6 +266,6 @@ export class GitHubClient {
    */
   public async fetchLabels(): Promise<GitHubLabel[]> {
     const endpoint = `/repos/${this.owner}/${this.repo}/labels`;
-    return this.makeRequest<GitHubLabel[]>(endpoint);
+    return this.makePaginatedRequest<GitHubLabel>(endpoint);
   }
 }

--- a/src/test/unit/ghClient.test.ts
+++ b/src/test/unit/ghClient.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitHubCommit, GitHubLabel } from '../../types/dataTypes';
+
+/**
+ * The pagination logic lives in the private `makePaginatedRequest`, which is
+ * exercised through the public `fetchPullRequestCommits` / `fetchLabels`
+ * methods. We stub the private `makeRequest` transport seam to simulate GitHub
+ * returning multiple pages.
+ */
+type MakeRequestStub = (endpoint: string) => Promise<unknown>;
+
+function stubMakeRequest(client: GitHubClient, stub: MakeRequestStub): string[] {
+  const calls: string[] = [];
+  (client as any).makeRequest = (endpoint: string) => {
+    calls.push(endpoint);
+    return stub(endpoint);
+  };
+  return calls;
+}
+
+function makeCommits(count: number, startIndex: number): GitHubCommit[] {
+  return Array.from({ length: count }, (_v, i) => ({
+    sha: `sha-${startIndex + i}`,
+    commit: { message: `commit ${startIndex + i}` },
+    parents: [],
+  }));
+}
+
+describe('GitHubClient pagination', () => {
+  describe('fetchPullRequestCommits', () => {
+    it('follows pages and returns all commits (100 + 100 + 12 = 212)', async () => {
+      const client = new GitHubClient('owner', 'repo');
+      const pages = [makeCommits(100, 0), makeCommits(100, 100), makeCommits(12, 200)];
+
+      const calls = stubMakeRequest(client, () => Promise.resolve(pages.shift() ?? []));
+
+      const commits = await client.fetchPullRequestCommits(1);
+
+      assert.strictEqual(commits.length, 212, 'should return all 212 commits across pages');
+      assert.strictEqual(commits[0].sha, 'sha-0');
+      assert.strictEqual(commits[211].sha, 'sha-211');
+
+      // 3 requests: stops because the last page (12) is shorter than per_page (100).
+      assert.strictEqual(calls.length, 3);
+      assert.ok(calls[0].includes('per_page=100'));
+      assert.ok(calls[0].includes('page=1'));
+      assert.ok(calls[1].includes('page=2'));
+      assert.ok(calls[2].includes('page=3'));
+    });
+
+    it('stops after a single request when fewer than a full page is returned', async () => {
+      const client = new GitHubClient('owner', 'repo');
+      const calls = stubMakeRequest(client, () => Promise.resolve(makeCommits(5, 0)));
+
+      const commits = await client.fetchPullRequestCommits(1);
+
+      assert.strictEqual(commits.length, 5);
+      assert.strictEqual(calls.length, 1);
+    });
+
+    it('appends the per_page/page params with & when the endpoint already has a query', async () => {
+      const client = new GitHubClient('owner', 'repo');
+      const calls = stubMakeRequest(client, () => Promise.resolve([]));
+
+      // Force a query-string endpoint by exercising the private helper directly.
+      await (client as any).makePaginatedRequest('/foo?state=all');
+
+      assert.strictEqual(calls.length, 1);
+      assert.ok(calls[0].includes('?state=all&per_page=100&page=1'));
+    });
+  });
+
+  describe('fetchLabels', () => {
+    it('returns labels from every page', async () => {
+      const client = new GitHubClient('owner', 'repo');
+      const page1: GitHubLabel[] = Array.from({ length: 100 }, (_v, i) => ({
+        id: i,
+        name: `label-${i}`,
+        description: null,
+        color: 'ffffff',
+        default: false,
+      }));
+      const page2: GitHubLabel[] = [
+        { id: 100, name: 'label-100', description: null, color: '000000', default: false },
+      ];
+      const pages = [page1, page2];
+
+      stubMakeRequest(client, () => Promise.resolve(pages.shift() ?? []));
+
+      const labels = await client.fetchLabels();
+      assert.strictEqual(labels.length, 101);
+    });
+  });
+});

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -25,6 +25,8 @@ export interface GitHubPR {
   html_url: string;
   labels: GitHubLabel[];
   assignees: GitHubUser[];
+  /** Total number of commits on the PR (as reported by GitHub). */
+  commits?: number;
 }
 
 export interface GitHubCommitFile {

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -149,6 +149,14 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
         // Continue with PR fetching even if fetch fails
       }
 
+      // GitHub's list-commits endpoint caps at 250 commits. If the PR reports
+      // more than that, the commit list (and therefore the clone) is incomplete.
+      if (prData.commits !== undefined && prData.commits > GitHubClient.MAX_PR_COMMITS) {
+        const warning = `PR #${prNumber} has ${prData.commits} commits, but GitHub only exposes the first ${GitHubClient.MAX_PR_COMMITS}. This PR is too large to clone fully.`;
+        this.loggingService.warn(warning);
+        await window.showWarningMessage(warning, 'OK');
+      }
+
       const commits = await this.ghClient.fetchPullRequestCommits(prNumber);
 
       // Fetch detailed information for each commit including files


### PR DESCRIPTION
## Bug

GitHub's list endpoints (`GET /repos/{owner}/{repo}/pulls/{n}/commits` and `.../labels`) return only 30 items per page by default. `GitHubClient` made a single `makeRequest` call with no pagination, so:

- PRs with more than 30 commits showed only the first 30 and cherry-picked an **incomplete** set of commits (CRITICAL — silent data loss).
- Repos with more than 30 labels silently lost the rest.

## Fix

- Added a generic `makePaginatedRequest<T>` that follows pages (`per_page=100`) until a partial page is returned, correctly joining the query string with `?`/`&`.
- `fetchPullRequestCommits` and `fetchLabels` now use it, returning the full data set.
- The pulls/commits endpoint hard-caps at **250** commits regardless of pagination. Added `GitHubClient.MAX_PR_COMMITS` and, when a PR's reported `commits` count exceeds it, `PrCloneWebViewProvider` now logs a warning and shows a `window.showWarningMessage` telling the user the PR is too large to clone fully.
- Added an optional `commits` count field to the `GitHubPR` type (returned by the GitHub PR object).

## Tests

Added `src/test/unit/ghClient.test.ts` (4 unit tests, stubbing the private `makeRequest` transport seam):

- multi-page aggregation: pages of 100 + 100 + 12 yield all **212** commits in order, with 3 requests.
- single short page short-circuits after one request.
- query-string endpoints get pagination params appended with `&`.
- labels are aggregated across pages.

## Verification

- `yarn compile` passes (type-check + lint + bundle).
- `yarn test:unit`: **215 passing**, including the 4 new tests.