### PR TITLE
fix: check remote-branch existence against the correct ref

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -135,10 +135,12 @@ export class GitExecutor {
 
   async #checkRemoteBranchExists(
     branchName: string,
-    includeRemoteName = false,
+    includeRemoteName = true,
     remoteName = 'origin'
   ): Promise<boolean> {
-    const ref = `refs/remotes${includeRemoteName ? `/${remoteName}` : ''}/${branchName}`;
+    const ref = includeRemoteName
+      ? `refs/remotes/${remoteName}/${branchName}`
+      : `refs/remotes/${branchName}`;
     try {
       await this.#execGitCommand(['show-ref', '--verify', '--quiet', ref]);
       return true;
@@ -184,7 +186,7 @@ export class GitExecutor {
   async checkout(branchName: string, remoteName = 'origin') {
     // Check if it's a remote branch that doesn't have a local counterpart
     const localBranchExists = await this.#checkLocalBranchExists(branchName);
-    const remoteBranchExists = await this.#checkRemoteBranchExists(branchName);
+    const remoteBranchExists = await this.#checkRemoteBranchExists(branchName, true, remoteName);
 
     if (!localBranchExists && remoteBranchExists) {
       // Create a local tracked branch for the remote branch
@@ -612,7 +614,7 @@ export class GitExecutor {
       return true;
     }
 
-    return await this.#checkRemoteBranchExists(branchName);
+    return await this.#checkRemoteBranchExists(branchName, true);
   }
 
   async hasUpstreamBranch(branchName: string): Promise<boolean> {

--- a/src/test/e2e/checkout.test.ts
+++ b/src/test/e2e/checkout.test.ts
@@ -10,7 +10,12 @@ import { IGitRef } from '../../common/git/types';
 import { ConfigurationManager } from '../../configuration/configurationManager';
 import { AutoStashService } from '../../services/autoStashService';
 
-import { createTestRepo, TestRepo } from './helpers/gitTestRepo';
+import {
+  createTestRepo,
+  createTwoRemoteTestRepo,
+  TestRepo,
+  TwoRemoteTestRepo,
+} from './helpers/gitTestRepo';
 import { mockLogService } from './helpers/mockLogService';
 
 const mockConfigManager = {} as unknown as ConfigurationManager;
@@ -153,5 +158,53 @@ describe('AutoStashService — checkoutAndStashChanges', () => {
       assert.strictEqual(await repo.git.getCurrentBranch(), repo.featureBranch);
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'untracked file should persist after checkout');
     });
+  });
+});
+
+describe('GitExecutor — remote-branch existence checks (two remotes)', () => {
+  let repo: TwoRemoteTestRepo;
+  beforeEach(() => { repo = createTwoRemoteTestRepo(); });
+  afterEach(() => { repo.cleanup(); });
+
+  it('branchExist detects a remote-only branch present on origin', async () => {
+    // Precondition: the branch must not exist locally.
+    assert.strictEqual(
+      repo.fileExists('feat.txt'),
+      false,
+      'precondition: feat branch is not checked out locally'
+    );
+
+    assert.strictEqual(
+      await repo.git.branchExist(repo.remoteOnlyBranch),
+      true,
+      'a branch that only exists on origin should be detected by branchExist'
+    );
+  });
+
+  it('branchExist returns false for a name that exists on no remote and no local ref', async () => {
+    assert.strictEqual(await repo.git.branchExist('does-not-exist-anywhere'), false);
+  });
+
+  it('checkout creates a local tracking branch from the named remote when the branch is remote-only', async () => {
+    // `feat` exists on both origin and upstream, so a bare `git checkout feat`
+    // would be ambiguous. checkout() must take the "create -b from <remote>/<branch>"
+    // path, which depends on the remote-existence check resolving correctly.
+    await repo.git.checkout(repo.remoteOnlyBranch, 'origin');
+
+    assert.strictEqual(await repo.git.getCurrentBranch(), repo.remoteOnlyBranch);
+    assert.strictEqual(
+      repo.fileExists('feat.txt'),
+      true,
+      'the remote feat branch content should now be present locally'
+    );
+
+    const upstream = repo.exec(
+      `git rev-parse --abbrev-ref ${repo.remoteOnlyBranch}@{upstream}`
+    ).trim();
+    assert.strictEqual(
+      upstream,
+      `origin/${repo.remoteOnlyBranch}`,
+      'the local branch should track origin, not upstream'
+    );
   });
 });

--- a/src/test/e2e/helpers/gitTestRepo.ts
+++ b/src/test/e2e/helpers/gitTestRepo.ts
@@ -288,6 +288,66 @@ export function createPRTestRepo(): PRTestRepo {
   };
 }
 
+export interface TwoRemoteTestRepo extends TestRepo {
+  originRepoPath: string;
+  upstreamRepoPath: string;
+  remoteOnlyBranch: string;
+}
+
+/**
+ * Repo with two bare remotes (`origin` and `upstream`). A `feat` branch exists on
+ * BOTH remotes (so `git checkout feat` without an explicit remote is ambiguous)
+ * but does NOT exist locally. Used to verify that remote-branch existence checks
+ * resolve against `refs/remotes/<remote>/<branch>` and that checkout creates a
+ * local tracking branch from the named remote.
+ */
+export function createTwoRemoteTestRepo(): TwoRemoteTestRepo {
+  const originRepoPath = createBareRepo('gsc-2remote-origin-');
+  const upstreamRepoPath = createBareRepo('gsc-2remote-upstream-');
+
+  const remoteOnlyBranch = 'feat';
+
+  const base = buildRepo('gsc-2remote-test-', (repoPath, exec) => {
+    fs.writeFileSync(path.join(repoPath, 'file1.txt'), 'initial content\n');
+    exec('git add file1.txt');
+    exec('git commit -m "init: initial commit"');
+  });
+
+  function execInRepo(cmd: string) {
+    execSync(cmd, { cwd: base.repoPath, stdio: 'pipe' });
+  }
+
+  execInRepo(`git remote add origin "${originRepoPath}"`);
+  execInRepo(`git remote add upstream "${upstreamRepoPath}"`);
+  execInRepo('git push -u origin main');
+  execInRepo('git push upstream main');
+
+  // Create the feat branch, push it to both remotes, then drop it locally so it
+  // only exists as a remote-tracking ref on origin AND upstream.
+  execInRepo(`git checkout -b ${remoteOnlyBranch}`);
+  fs.writeFileSync(path.join(base.repoPath, 'feat.txt'), 'feat content\n');
+  execInRepo('git add feat.txt');
+  execInRepo('git commit -m "feat: add feat file"');
+  execInRepo(`git push origin ${remoteOnlyBranch}`);
+  execInRepo(`git push upstream ${remoteOnlyBranch}`);
+  execInRepo('git checkout main');
+  execInRepo(`git branch -D ${remoteOnlyBranch}`);
+
+  const originalCleanup = base.cleanup.bind(base);
+
+  return {
+    ...base,
+    originRepoPath,
+    upstreamRepoPath,
+    remoteOnlyBranch,
+    cleanup() {
+      originalCleanup();
+      fs.rmSync(originRepoPath, { recursive: true, force: true });
+      fs.rmSync(upstreamRepoPath, { recursive: true, force: true });
+    },
+  };
+}
+
 export interface ForkPRTestRepo extends PRTestRepo {
   forkRepoPath: string;
   forkBranch: string;


### PR DESCRIPTION
## Bug

`GitExecutor.#checkRemoteBranchExists` defaulted `includeRemoteName` to `false`, so it verified `refs/remotes/<branch>` (e.g. `refs/remotes/feature-x`) — a ref that never exists. Real remote-tracking refs live under `refs/remotes/<remote>/<branch>`. Both production callers used the default, which meant:

- **`checkout()`**: the "create a local tracking branch from the remote" path (`git checkout -b <name> origin/<name>`) was effectively dead code. The fallback plain `git checkout <name>` fails when the branch exists on more than one remote (Git refuses an ambiguous DWIM checkout).
- **`branchExist()` / `createUniqueFeatureBranch()`**: the uniqueness check missed remote-only branches, so PR clone could pick a feature-branch name that already exists on `origin`, and the later `git push -u origin <name>` would fail.

## Fix

- `#checkRemoteBranchExists` now defaults `includeRemoteName` to `true` and verifies `refs/remotes/<remote>/<branch>`.
- `checkout(branchName, remoteName)` calls it with `(branchName, true, remoteName)`, forwarding the requested remote.
- `branchExist(branchName)` calls it with `(branchName, true)`.

Only two callers exist, both internal to `gitExecutor.ts`; both were updated.

## Tests

Added a `createTwoRemoteTestRepo` fixture (`origin` + `upstream`, with a `feat` branch present on both remotes but not locally) and three e2e cases in `checkout.test.ts`:

- `branchExist` detects a remote-only branch on `origin`.
- `branchExist` returns `false` for a name on no remote/local ref.
- `checkout('feat', 'origin')` creates a local tracking branch from `origin` (not the ambiguous bare checkout) and tracks `origin/feat`.

## Verification

- `yarn compile` (type-check + lint + build) passes.
- The full e2e suite cannot run in this environment because git is configured with `safe.bareRepository=explicit`, which breaks the pre-existing `createBareRepo` helper used by all bare-remote tests (38 pre-existing tests fail for the same reason, unrelated to this change). The fix and the new test scenario were validated independently in an isolated repo using `-c safe.bareRepository=all`: the old ref `refs/remotes/feat` is absent, the correct ref `refs/remotes/origin/feat` exists, the old fallback `git checkout feat` fails as ambiguous, and `git checkout -b feat origin/feat` succeeds and tracks `origin/feat`.