### PR TITLE
fix: use a non-printable separator for ref list parsing

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -212,8 +212,11 @@ export class GitExecutor {
   ): Promise<IGitRef> {
     await this.#execGitCommand(['checkout', '-b', branchName, ...(sourceBranch ? [sourceBranch] : [])]);
 
-    // Get detailed information about the newly created branch
-    const SEPARATOR = '|';
+    // Get detailed information about the newly created branch.
+    // Use the ASCII Unit Separator (\x1f) which cannot occur in ref names,
+    // hashes, dates, or (practically) commit subjects, so a `|` in a subject
+    // can no longer shift the parsed fields.
+    const SEPARATOR = '\x1f';
     const { stdout: branchInfo } = await this.#execGitCommand([
       'for-each-ref',
       `--format=%(refname)${SEPARATOR}%(objectname:short)${SEPARATOR}%(committerdate:unix)${SEPARATOR}%(subject)${SEPARATOR}%(authorname)`,
@@ -260,7 +263,12 @@ export class GitExecutor {
   }
 
   async getAllRefListExtended(): Promise<IGitRef[]> {
-    const SEPARATOR = '|';
+    // Use the ASCII Unit Separator (\x1f) instead of `|`. A commit subject can
+    // legitimately contain `|`, which would shift every field parsed after
+    // `%(subject)` (corrupting `upstream:track`, author name, etc.). The Unit
+    // Separator cannot occur in ref names, hashes, dates, or (practically)
+    // commit subjects, and Git passes it through the format string verbatim.
+    const SEPARATOR = '\x1f';
     const format = `%(refname)${SEPARATOR}%(objectname:short)${SEPARATOR}%(*objectname:short)${SEPARATOR}%(committerdate:unix)${SEPARATOR}%(*committerdate:unix)${SEPARATOR}%(subject)${SEPARATOR}%(*subject)${SEPARATOR}%(upstream:track)${SEPARATOR}%(authorname)${SEPARATOR}%(*authorname)`;
     const { stdout: branchesOutput } = await this.#execGitCommand([
       'for-each-ref',
@@ -276,12 +284,15 @@ export class GitExecutor {
       .filter((line) => line.length > 0)
       .map((line) => {
         /**
-         * parse remote branches like:
+         * parse remote branches like (\x1f shown here as "|"):
          * refs/heads/feature/add-extension-and-refactoring|8aaf984|Minor fixes|unixTimeStamp|1 2
          * refs/remotes/origin/feature/add-extension-and-refactoring|8aaf984|Minor fixes
          * refs/tags/v1.2.3|8aaf984|Minor fixes
          * */
 
+        // Cap the split at the number of fields in the format string so that an
+        // unexpected separator in the final field cannot create extra entries.
+        const FIELD_COUNT = 10;
         const [
           ref,
           hash,
@@ -293,7 +304,7 @@ export class GitExecutor {
           upstreamTrack,
           authorName,
           dereferredAuthorName,
-        ] = line.split(SEPARATOR);
+        ] = line.split(SEPARATOR, FIELD_COUNT);
 
         const parsedUpstreamTrack = this.#parseTrackData(upstreamTrack);
 

--- a/src/test/e2e/refListSeparator.test.ts
+++ b/src/test/e2e/refListSeparator.test.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+
+import { mockLogService } from './helpers/mockLogService';
+
+/**
+ * Regression tests for ref-list parsing when a commit subject contains the
+ * character that used to be the field separator (`|`).
+ *
+ * Previously `for-each-ref` joined fields with `|` and the parser did
+ * `line.split('|')`, so a subject like `feat: add a | b parser` shifted every
+ * field after `%(subject)` — corrupting `upstream:track` (NaN ahead/behind)
+ * and the author name. The separator is now the ASCII Unit Separator (\x1f),
+ * which cannot occur in a commit subject.
+ */
+describe('GitExecutor.getAllRefListExtended — separator robustness', () => {
+  const PIPE_SUBJECT = 'feat: add a | b parser';
+  const AUTHOR_NAME = 'Pipe Author';
+
+  let repoPath: string;
+  let remoteRepoPath: string;
+  let git: GitExecutor;
+
+  function exec(cmd: string) {
+    execSync(cmd, { cwd: repoPath, stdio: 'pipe' });
+  }
+
+  before(() => {
+    remoteRepoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-sep-remote-'));
+    execSync('git init --bare', { cwd: remoteRepoPath, stdio: 'pipe' });
+
+    repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-sep-test-'));
+    exec('git init -b main');
+    exec('git config user.email "pipe@test.local"');
+    exec(`git config user.name "${AUTHOR_NAME}"`);
+
+    fs.writeFileSync(path.join(repoPath, 'file1.txt'), 'initial content\n');
+    exec('git add file1.txt');
+    exec('git commit -m "init: initial commit"');
+
+    // Track a real remote so %(upstream:track) is populated.
+    exec(`git remote add origin "${remoteRepoPath}"`);
+    exec('git push -u origin main');
+
+    // A commit whose subject contains the legacy separator character. main is
+    // now 1 commit ahead of its upstream origin/main.
+    exec(`git commit --allow-empty -m "${PIPE_SUBJECT}"`);
+
+    git = new GitExecutor(repoPath, mockLogService);
+  });
+
+  after(() => {
+    fs.rmSync(repoPath, { recursive: true, force: true });
+    fs.rmSync(remoteRepoPath, { recursive: true, force: true });
+  });
+
+  it('preserves the full subject (pipe is not treated as a field boundary)', async () => {
+    const refs = await git.getAllRefListExtended();
+    const mainRef = refs.find((ref) => !ref.isTag && !ref.remote && ref.name === 'main');
+
+    assert.ok(mainRef, 'main branch should be present in the ref list');
+    assert.strictEqual(mainRef!.comment, PIPE_SUBJECT, 'subject with a pipe must be kept intact');
+  });
+
+  it('parses author name correctly despite a pipe in the subject', async () => {
+    const refs = await git.getAllRefListExtended();
+    const mainRef = refs.find((ref) => !ref.isTag && !ref.remote && ref.name === 'main');
+
+    assert.ok(mainRef, 'main branch should be present in the ref list');
+    assert.strictEqual(
+      mainRef!.authorName,
+      AUTHOR_NAME,
+      'author name must not be shifted by a pipe in the subject'
+    );
+  });
+
+  it('parses ahead/behind tracking info without NaN despite a pipe in the subject', async () => {
+    const refs = await git.getAllRefListExtended();
+    const mainRef = refs.find((ref) => !ref.isTag && !ref.remote && ref.name === 'main');
+
+    assert.ok(mainRef, 'main branch should be present in the ref list');
+    // local main is 1 commit ahead of origin/main (the empty pipe commit), 0 behind.
+    assert.deepStrictEqual(
+      mainRef!.parsedUpstreamTrack,
+      [1, 0],
+      'ahead/behind must be parsed correctly, not shifted into NaN'
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`GitExecutor.getAllRefListExtended` (and `createBranch`) built a `git for-each-ref` format string joining fields with `|`, then parsed each line with `line.split('|')`. Commit subjects routinely contain `|` (e.g. `feat: add a | b parser`). Any such subject shifted every field parsed after `%(subject)`:

- `upstream:track` received a subject fragment, so `#parseTrackData` produced garbage / `NaN` ahead-behind values.
- `authorName` (and other trailing fields) were wrong.

## Fix

Switch the separator to the ASCII Unit Separator `'\x1f'`, embedded directly in the `for-each-ref` format string. Git passes it through verbatim, and it cannot occur in ref names, hashes, dates, or (practically) commit subjects, so fields can no longer shift. The parser split is also capped at the fixed field count to bound any unexpected data. The same separator change is applied to the `for-each-ref` call in `createBranch`.

## Tests

Added `src/test/e2e/refListSeparator.test.ts`: a fixture repo with a tracked remote and a commit whose subject contains `|`. It asserts that `getAllRefListExtended` returns the full subject intact, the correct author name, and `parsedUpstreamTrack === [1, 0]` (not shifted / `NaN`). Verified the test fails against the old `|` separator and passes with the fix.

`yarn compile` passes; the new e2e test (3 cases) passes.