### PR TITLE
fix: allow checking out tags from "Checkout to..."

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -19,11 +19,9 @@ import {
   getRefDetails,
   getRefLabel,
   getRefLabelWithStar,
-  ICON_BRANCH,
   ICON_STAR_FILLED,
   ICON_FOLDER,
-  ICON_PLUS,
-  ICON_REMOTE_BRANCH
+  ICON_PLUS
 } from '../utils/refFormatting';
 import { findWorktreeForBranch, handleWorktreeBranchConflict } from '../utils/worktreeBranchConflict';
 
@@ -46,13 +44,17 @@ export class CheckoutToCommand extends BaseCommand {
     try {
       const git = await this.getGitExecutor(this.vscodeGitProvider);
 
-      const { currentBranch, selection, branchList } = await this.getSelectedOption(git);
-
-      const newBranch = await this.getTargetBranch(git, selection, branchList);
+      const { currentBranch, selection, selectedRef, branchList } =
+        await this.getSelectedOption(git);
 
       const isNewBranch =
         selection === LABEL_CREATE_NEW_BRANCH ||
         selection === LABEL_CREATE_NEW_BRANCH_FROM;
+
+      // For an existing ref the accepted quick-pick item already carries the
+      // full IGitRef, so use it directly instead of resolving from a display
+      // label (which broke tags, whose label is "$(tag) v1.2.3").
+      const newBranch = selectedRef ?? (await this.getTargetBranch(git, selection, branchList));
 
       if (!isNewBranch) {
         const conflictWorktree = await findWorktreeForBranch(git, newBranch.name);
@@ -96,7 +98,12 @@ export class CheckoutToCommand extends BaseCommand {
 
   async getSelectedOption(
     git: GitExecutor
-  ): Promise<{ currentBranch: string; selection: string; branchList: IGitRef[] }> {
+  ): Promise<{
+    currentBranch: string;
+    selection: string;
+    selectedRef?: IGitRef;
+    branchList: IGitRef[];
+  }> {
     let currentBranch = '';
     try {
       currentBranch = await git.getCurrentBranch();
@@ -286,6 +293,7 @@ export class CheckoutToCommand extends BaseCommand {
     return {
       currentBranch,
       selection: getRefLabel(picked.ref),
+      selectedRef: picked.ref,
       branchList,
     };
   }
@@ -295,24 +303,13 @@ export class CheckoutToCommand extends BaseCommand {
     selection: string,
     branchList: IGitRef[]
   ): Promise<IGitRef> {
-    const iconsToRemove = [ICON_BRANCH, ICON_REMOTE_BRANCH];
-
-    switch (true) {
-      case selection === LABEL_CREATE_NEW_BRANCH:
+    switch (selection) {
+      case LABEL_CREATE_NEW_BRANCH:
         return await this.createNewBranch(git);
-      case selection === LABEL_CREATE_NEW_BRANCH_FROM:
+      case LABEL_CREATE_NEW_BRANCH_FROM:
         return await this.createNewBranchFrom(git, branchList);
       default:
-        const branchName = iconsToRemove.reduce(
-          (prev, icon) => prev.replace(`${icon} `, ''),
-          selection
-        );
-        const branch = branchList.find((ref) => ref.fullName === branchName);
-        if (!branch) {
-          throw new Error(`Cannot find appropriate object for a ref ${branchName}`);
-        }
-
-        return branch;
+        throw new Error(`Cannot find appropriate object for a ref ${selection}`);
     }
   }
 

--- a/src/test/e2e/checkout.test.ts
+++ b/src/test/e2e/checkout.test.ts
@@ -139,6 +139,27 @@ describe('AutoStashService — checkoutAndStashChanges', () => {
     });
   });
 
+  describe('tag checkout', () => {
+    let repo: TestRepo;
+    before(() => { repo = createTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('checks out a tag ref (detached HEAD at the tagged commit) without error', async () => {
+      // Reproduces the "Checkout to..." flow for a tag: the picked item carries
+      // the tag's IGitRef, which is passed straight to checkoutAndStashChanges.
+      const refs = await repo.git.getAllRefListExtended();
+      const tagRef = refs.find((ref) => ref.isTag && ref.name === 'v1.0.0');
+      assert.ok(tagRef, 'precondition: v1.0.0 tag ref should be listed');
+
+      const tagSha = repo.exec('git rev-parse v1.0.0').trim();
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, tagRef!, AUTO_STASH_IGNORE);
+
+      assert.strictEqual(repo.exec('git rev-parse HEAD').trim(), tagSha, 'HEAD should be at the tagged commit');
+      assert.strictEqual(repo.exec('git symbolic-ref -q HEAD || echo detached').trim(), 'detached', 'checking out a tag detaches HEAD');
+    });
+  });
+
   describe('AUTO_STASH_IGNORE: non-conflicting untracked changes', () => {
     let repo: TestRepo;
     before(() => { repo = createTestRepo(); });

--- a/src/test/e2e/helpers/gitTestRepo.ts
+++ b/src/test/e2e/helpers/gitTestRepo.ts
@@ -84,13 +84,16 @@ function createBareRepo(prefix: string): string {
 
 /**
  * Standard two-branch repo. main has file1.txt; feature adds feature.txt.
- * The branches do NOT conflict on shared files.
+ * The branches do NOT conflict on shared files. A `v1.0.0` tag points at the
+ * initial commit on main, used to exercise tag checkout.
  */
 export function createTestRepo(): TestRepo {
   return buildRepo('gsc-test-', (repoPath, exec) => {
     fs.writeFileSync(path.join(repoPath, 'file1.txt'), 'initial content\n');
     exec('git add file1.txt');
     exec('git commit -m "init: initial commit"');
+
+    exec('git tag v1.0.0');
 
     exec('git checkout -b feature');
     fs.writeFileSync(path.join(repoPath, 'feature.txt'), 'feature content\n');


### PR DESCRIPTION
## Bug

Selecting a tag from the **Checkout to...** picker always failed with:

```
Cannot find appropriate object for a ref $(tag) v1.2.3
```

`getSelectedOption` round-tripped the picked ref through its display label (`getRefLabel`, e.g. `"$(tag) v1.2.3"`). `getTargetBranch` then stripped only the branch / remote-branch icons before looking the ref up by `fullName`. For tags the `$(tag) ` prefix survived, so `branchList.find(ref => ref.fullName === branchName)` matched nothing and threw.

## Fix (structural — preferred variant)

The accepted quick-pick item already carries the full `IGitRef` (`picked.ref`), so there is no need to reconstruct it from a display string:

- `getSelectedOption` now also returns `selectedRef` (set to `picked.ref` for `kind === 'ref'`).
- `execute()` uses `selectedRef` directly for `checkoutAndStashChanges`, falling back to `getTargetBranch` only for the *Create new branch* / *Create new branch from...* actions.
- `getTargetBranch` no longer does icon-stripping label parsing (dead for refs now); the now-unused `ICON_BRANCH` / `ICON_REMOTE_BRANCH` imports were removed.

This fixes tags and is also more robust for branches (no fragile label parsing).

## Tests

- Added a `v1.0.0` tag to the standard `createTestRepo` fixture.
- Added an e2e test that pulls the real tag `IGitRef` from `getAllRefListExtended`, runs the checkout flow, and asserts HEAD lands at the tagged commit in detached state without error.

## Verification

- `yarn compile` passes (type-check + lint + build).
- New tag-checkout e2e test passes; existing `AutoStashService`, rebase, and "Checkout to..." command suites pass. The 36 unrelated failures in this sandbox are environment-only (`safe.bareRepository is 'explicit'` makes the bare-repo test helpers fail before any extension code runs).