### PR TITLE
fix: Fix diverged branch tracking counts

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -64,6 +64,29 @@ export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   return worktrees;
 }
 
+/**
+ * Parses Git's `%(upstream:track)` output into `[ahead, behind]` counts.
+ * Missing directions are treated as zero; missing or gone upstreams have no counts.
+ */
+export function parseUpstreamTrack(upstreamTrack: string): TUpstreamTrack {
+  if (!upstreamTrack || upstreamTrack === '[gone]') {
+    return;
+  }
+
+  const arr = upstreamTrack.slice(1, -1).split(',');
+  if (arr.length === 1) {
+    if (arr[0].startsWith('ahead')) {
+      arr.push('behind 0');
+    } else {
+      arr.unshift('ahead 0');
+    }
+  }
+
+  const [ahead, behind] = arr.map((item) => Number(item.trim().split(' ')[1]));
+
+  return [ahead, behind];
+}
+
 export class GitExecutor {
   #repositoryPath;
   #logService;
@@ -95,33 +118,6 @@ export class GitExecutor {
 
   async #execGitCommand(args: string[]) {
     return await this.#execGitCommandWithOptions(args, {});
-  }
-
-  /*
-   * convert following strings:
-   * [ahead 3, behind 2]
-   * [ahead 3]
-   * [behind 2]
-   * [gone]
-   **/
-
-  #parseTrackData(upstreamTrack: string): TUpstreamTrack {
-    if (!upstreamTrack || upstreamTrack === '[gone]') {
-      return;
-    }
-
-    const arr = upstreamTrack.slice(1, -1).split(',');
-    if (arr.length === 1) {
-      if (arr[0].startsWith('ahead')) {
-        arr.push('behind 0');
-      } else {
-        arr.unshift('ahead 0');
-      }
-    }
-
-    const [ahead, behind] = arr.map((i) => Number(i.split(' ')[1]));
-
-    return [ahead, behind];
   }
 
   async #checkLocalBranchExists(branchName: string): Promise<boolean> {
@@ -295,7 +291,7 @@ export class GitExecutor {
           dereferredAuthorName,
         ] = line.split(SEPARATOR);
 
-        const parsedUpstreamTrack = this.#parseTrackData(upstreamTrack);
+        const parsedUpstreamTrack = parseUpstreamTrack(upstreamTrack);
 
         const branchArr = ref.split('/');
         const [_, refType, ...other] = branchArr;

--- a/src/test/unit/upstreamTrackParser.test.ts
+++ b/src/test/unit/upstreamTrackParser.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+
+import { parseUpstreamTrack } from '../../common/git/gitExecutor';
+
+describe('parseUpstreamTrack', () => {
+  it('parses branches that are both ahead and behind', () => {
+    assert.deepStrictEqual(parseUpstreamTrack('[ahead 3, behind 2]'), [3, 2]);
+  });
+
+  it('defaults a missing behind count to zero', () => {
+    assert.deepStrictEqual(parseUpstreamTrack('[ahead 3]'), [3, 0]);
+  });
+
+  it('defaults a missing ahead count to zero', () => {
+    assert.deepStrictEqual(parseUpstreamTrack('[behind 2]'), [0, 2]);
+  });
+
+  it('returns undefined when the upstream is gone or absent', () => {
+    assert.strictEqual(parseUpstreamTrack('[gone]'), undefined);
+    assert.strictEqual(parseUpstreamTrack(''), undefined);
+  });
+});


### PR DESCRIPTION
## What changed
- trim each upstream tracking segment before parsing ahead/behind counts
- expose the parser for focused unit coverage
- document the parser contract in code
- merge the latest `main` and resolve the parser-helper conflict

## Why
Git formats diverged branches as `[ahead N, behind M]`. The leading space before `behind` previously produced `NaN`, which leaked into the checkout picker.

## Validation
- `yarn check-types`
- `yarn lint`
- `yarn compile-tests`
- `yarn test:unit` (242 passing)
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all yarn test:e2e` (138 passing)