### PR TITLE
fix: Preserve colons in stash messages

### DIFF
--- a/docs/checkout-with-stash.md
+++ b/docs/checkout-with-stash.md
@@ -37,6 +37,8 @@ If a branch is already checked out in another Git worktree, the checkout picker 
 > [!TIP]
 > Stashes created by "Auto stash and apply in new branch" are not used by the automatic branch-restore flow. They remain available for manual stash access.
 
+Stashes are matched by their complete message after Git's `On <branch>: ` subject prefix. Message text containing `: ` is preserved when the extension locates a stash to pop or apply.
+
 ## Conflict Pre-Flight
 
 For auto stash and pop/apply modes, Git 2.38 or newer allows the extension to preview stash conflicts before switching branches. If conflicts are predicted, you can cancel before the checkout changes your working tree.

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -8,6 +8,11 @@ import { execCommand } from '../../utils/execCommand';
 import { VscodeGitProvider } from './vscodeGitProvider';
 import { IGitRef, IGitWorktree, TUpstreamTrack } from './types';
 
+function stripStashSubjectPrefix(subject: string): string {
+  const prefixEnd = subject.indexOf(': ');
+  return prefixEnd === -1 ? subject : subject.slice(prefixEnd + 2);
+}
+
 export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   const worktrees: IGitWorktree[] = [];
   let current: IGitWorktree | undefined;
@@ -353,10 +358,9 @@ export class GitExecutor {
     // Create a mapping of index to stash message
     const stashes = stashesStrings.map((message, index) => {
       // Remove the "On <branch>: " prefix
-      const formattedMessage = message.split(': ')[1];
       return {
         index,
-        message: formattedMessage,
+        message: stripStashSubjectPrefix(message),
       };
     });
 
@@ -446,10 +450,7 @@ export class GitExecutor {
         .trim()
         .split('\n')
         .filter((line) => line.trim() !== '');
-      const stashMessages = stashesStrings.map((msgWithPrefix) => {
-        const parts = msgWithPrefix.split(': ');
-        return parts.length > 1 ? parts.slice(1).join(': ') : msgWithPrefix;
-      });
+      const stashMessages = stashesStrings.map(stripStashSubjectPrefix);
 
       return stashMessages.some((msg) => msg === message);
     } catch {

--- a/src/test/e2e/stashMessages.test.ts
+++ b/src/test/e2e/stashMessages.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert';
+
+import { createTestRepo, TestRepo } from './helpers/gitTestRepo';
+
+describe('GitExecutor stash message matching', () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('finds and pops a stash whose message contains ": "', async () => {
+    const stashName = 'auto-stash-main: extra context';
+    repo.makeChange('file1.txt', 'colon pop content\n');
+
+    await repo.git.createStash(stashName);
+
+    assert.strictEqual(await repo.git.isStashWithMessageExists(stashName), true);
+
+    await repo.git.popStash(stashName);
+
+    assert.strictEqual(repo.readFile('file1.txt'), 'colon pop content\n');
+    assert.strictEqual(repo.stashCount(), 0, 'pop should remove the matching stash');
+  });
+
+  it('finds and applies a stash whose message contains multiple ": " delimiters', async () => {
+    const stashName = 'manual stash: review: checkpoint';
+    repo.makeChange('file1.txt', 'colon apply content\n');
+
+    await repo.git.createStash(stashName);
+    await repo.git.popStash(stashName, true);
+
+    assert.strictEqual(repo.readFile('file1.txt'), 'colon apply content\n');
+    assert.strictEqual(repo.stashCount(), 1, 'apply should preserve the matching stash');
+  });
+});


### PR DESCRIPTION
## What changed
- parse Git stash subjects with a shared prefix helper
- preserve the complete stash message when it contains `: `
- add pop/apply coverage and document exact-message matching

## Why
`popStash` previously truncated messages at the second colon, so it could report that a confirmed existing stash was missing and leave user changes stranded.

## Validation
- type checks, lint, and compile passed
- 211 unit tests passed
- focused stash-message e2e tests passed