### PR TITLE
fix: Stabilize PR clone progress handles

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -34,7 +34,8 @@ When conflicts occur during cherry-picking, you can:
 - Resolve conflicts manually and continue.
 - Cancel the process and restore the original state.
 
-The process is tracked with progress indicators and can be safely cancelled.
+The process is tracked with a progress notification that remains active throughout initialization
+and can be safely cancelled at any point.
 
 ## Related Settings
 

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -206,7 +206,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
       // Step 1: Store original branch and stash changes if needed
       this.serviceStore.originalBranch = await this.git.getCurrentBranch();
-      updateProgress?.report({ message: 'Checking for uncommitted changes...' });
+      updateProgress.report({ message: 'Checking for uncommitted changes...' });
 
       const hasUncommittedChanges = await this.git.isWorkdirHasChanges();
       if (hasUncommittedChanges) {
@@ -223,7 +223,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       }
 
       // Step 2: Fetch the PR's origin branch
-      updateProgress?.report({ message: `Fetching PR branch: ${data.prData.head.ref}...` });
+      updateProgress.report({ message: `Fetching PR branch: ${data.prData.head.ref}...` });
       try {
         await this.git.fetchSpecificBranch(data.prData.head.ref);
         this.loggingService.info(`Fetched PR branch: ${data.prData.head.ref}`);
@@ -232,10 +232,10 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       }
 
       // Step 3: Switch to base branch and pull latest changes
-      updateProgress?.report({ message: `Switching to base branch: ${data.targetBranch}...` });
+      updateProgress.report({ message: `Switching to base branch: ${data.targetBranch}...` });
       await this.git.checkout(data.targetBranch);
 
-      updateProgress?.report({ message: 'Pulling latest changes...' });
+      updateProgress.report({ message: 'Pulling latest changes...' });
       try {
         await this.git.pullCurrentBranch();
         this.loggingService.info(`Pulled latest changes for ${data.targetBranch}`);
@@ -244,7 +244,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       }
 
       // Step 4: Create unique feature branch
-      updateProgress?.report({ message: 'Creating feature branch...' });
+      updateProgress.report({ message: 'Creating feature branch...' });
       this.serviceStore.createdBranchName = await this.git.createUniqueFeatureBranch(
         data.featureBranch,
         data.targetBranch

--- a/src/test/unit/createWithProcess.test.ts
+++ b/src/test/unit/createWithProcess.test.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import { CancellationToken, Progress } from 'vscode';
+
+import {
+  createWithProcess,
+  ProgressUpdate,
+  WithProgress,
+} from '../../utils/createWithProcess';
+
+interface ProgressHarness {
+  cancel: () => void;
+  completion: Promise<void>;
+  reports: ProgressUpdate[];
+  start: () => void;
+  withProgress: WithProgress;
+}
+
+function createProgressHarness(): ProgressHarness {
+  let cancellationListener: (() => void) | undefined;
+  let progressTask:
+    | ((progress: Progress<ProgressUpdate>, token: CancellationToken) => Thenable<void>)
+    | undefined;
+  let resolveCompletion: (() => void) | undefined;
+  let rejectCompletion: ((reason?: unknown) => void) | undefined;
+
+  const reports: ProgressUpdate[] = [];
+  const completion = new Promise<void>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+  const progress: Progress<ProgressUpdate> = {
+    report: (update) => reports.push(update),
+  };
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: (listener: () => void) => {
+      cancellationListener = listener;
+      return { dispose: () => undefined };
+    },
+  } as CancellationToken;
+
+  return {
+    cancel: () => cancellationListener?.(),
+    completion,
+    reports,
+    start: () => {
+      assert.ok(progressTask, 'withProgress task was not registered');
+      void Promise.resolve(progressTask(progress, token)).then(
+        () => resolveCompletion?.(),
+        (error) => rejectCompletion?.(error)
+      );
+    },
+    withProgress: (_options, task) => {
+      progressTask = task;
+      return completion;
+    },
+  };
+}
+
+function waitForAsyncHandlers(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('createWithProcess', () => {
+  it('returns usable handles and queues reports before the progress task starts', async () => {
+    const harness = createProgressHarness();
+    const handles = createWithProcess('Test progress', undefined, harness.withProgress);
+
+    handles.updateProgress.report({ message: 'Queued update' });
+    assert.deepStrictEqual(harness.reports, []);
+
+    harness.start();
+    assert.deepStrictEqual(harness.reports, [{ message: 'Queued update' }]);
+
+    handles.finishProgress();
+    await harness.completion;
+  });
+
+  it('remembers finish requests made before the progress task starts', async () => {
+    const harness = createProgressHarness();
+    const handles = createWithProcess('Test progress', undefined, harness.withProgress);
+
+    handles.finishProgress();
+    harness.start();
+
+    await harness.completion;
+  });
+
+  it('remembers cancel requests made before the progress task starts', async () => {
+    const harness = createProgressHarness();
+    const handles = createWithProcess('Test progress', undefined, harness.withProgress);
+
+    handles.cancelProgress();
+    harness.start();
+
+    await harness.completion;
+  });
+
+  it('resolves cancellation and contains rejected asynchronous cleanup', async () => {
+    const harness = createProgressHarness();
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      let cleanUpCalled = false;
+      createWithProcess(
+        'Test progress',
+        async () => {
+          cleanUpCalled = true;
+          throw new Error('cleanup failed');
+        },
+        harness.withProgress
+      );
+
+      harness.start();
+      harness.cancel();
+      await harness.completion;
+      await waitForAsyncHandlers();
+
+      assert.strictEqual(cleanUpCalled, true);
+      assert.deepStrictEqual(unhandledRejections, []);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection);
+    }
+  });
+});

--- a/src/utils/createWithProcess.ts
+++ b/src/utils/createWithProcess.ts
@@ -1,38 +1,88 @@
-import { Progress, ProgressLocation, window } from 'vscode';
+import { CancellationToken, Progress, ProgressLocation, ProgressOptions, window } from 'vscode';
 
-export const createWithProcess = (title: string, cleanUp?: (isAborting: boolean) => void) => {
-  let finishProgress: (() => void) | undefined;
-  let cancelProgress: (() => void) | undefined;
-  let updateProgress:
-    | Progress<{
-        message?: string;
-        increment?: number;
-      }>
-    | undefined;
+export interface ProgressUpdate {
+  message?: string;
+  increment?: number;
+}
 
-  window.withProgress(
+export type WithProgress = (
+  options: ProgressOptions,
+  task: (progress: Progress<ProgressUpdate>, token: CancellationToken) => Thenable<void>
+) => Thenable<void>;
+
+export const createWithProcess = (
+  title: string,
+  cleanUp?: (isAborting: boolean) => void | Promise<void>,
+  withProgress: WithProgress = (options, task) => window.withProgress(options, task)
+) => {
+  let resolveProgress: (() => void) | undefined;
+  let progressRef: Progress<ProgressUpdate> | undefined;
+  let isSettled = false;
+  let cancellationHandled = false;
+  const pendingReports: ProgressUpdate[] = [];
+
+  const settleProgress = () => {
+    if (isSettled) {
+      return;
+    }
+
+    isSettled = true;
+    pendingReports.length = 0;
+    resolveProgress?.();
+  };
+
+  const updateProgress: Progress<ProgressUpdate> = {
+    report: (update) => {
+      if (isSettled) {
+        return;
+      }
+
+      if (progressRef) {
+        progressRef.report(update);
+      } else {
+        pendingReports.push(update);
+      }
+    },
+  };
+
+  const progressPromise = withProgress(
     {
       location: ProgressLocation.Notification,
       title,
       cancellable: true,
     },
-    async (progress, token) => {
-      return new Promise<void>((resolve, reject) => {
-        finishProgress = resolve;
-        cancelProgress = reject;
-        updateProgress = progress;
+    (progress, token) =>
+      new Promise<void>((resolve) => {
+        resolveProgress = resolve;
+        progressRef = progress;
 
+        pendingReports.splice(0).forEach((update) => progress.report(update));
         token.onCancellationRequested(() => {
-          reject(new Error('Cancel operation'));
-          cleanUp?.(true);
+          settleProgress();
+
+          if (cancellationHandled) {
+            return;
+          }
+
+          cancellationHandled = true;
+          void Promise.resolve()
+            .then(() => cleanUp?.(true))
+            .catch(() => undefined);
         });
-      });
-    }
+
+        if (isSettled) {
+          resolve();
+        }
+      })
   );
 
+  // VS Code owns this promise. Guard it so cancellation or host behavior cannot
+  // surface as an unhandled rejection in the extension host.
+  void Promise.resolve(progressPromise).catch(() => undefined);
+
   return {
-    finishProgress,
-    cancelProgress,
+    finishProgress: settleProgress,
+    cancelProgress: settleProgress,
     updateProgress,
   };
 };


### PR DESCRIPTION
## What changed
- return stable progress methods that close over asynchronously initialized handles
- queue early progress reports and settle early finish/cancel requests
- resolve cancellation and contain host/cleanup rejections
- add delayed-callback unit coverage and update PR clone docs

## Why
The old helper returned values before VS Code necessarily initialized them, allowing in-place clone notifications to spin forever and cancellation to become a no-op.

Related to #71.

## Validation
- TypeScript check passed
- ESLint passed
- 215 unit tests passed
- `git diff --check` passed