### PR TITLE
feat: Preserve cloned PR labels and assignees

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -27,6 +27,8 @@ The GitHub PR Clone feature creates a new pull request by cherry-picking selecte
 
 During the cherry-pick process, the extension stashes uncommitted workspace changes, switches to the target branch, pulls the latest changes, creates a feature branch, and cherry-picks the selected commits one by one.
 
+The new PR also copies labels and assignees from the original PR. These metadata updates are best effort: if GitHub rejects one of them, the new PR is still created and the failure is logged.
+
 ## Conflict Handling
 
 When conflicts occur during cherry-picking, you can:

--- a/src/common/api/ghClient.ts
+++ b/src/common/api/ghClient.ts
@@ -10,7 +10,9 @@ export class GitHubClient {
 
   constructor(
     private readonly _owner: string,
-    private readonly _repo: string
+    private readonly _repo: string,
+    private readonly warn: (message: string, error: unknown) => void = (message, error) =>
+      console.warn(message, error)
   ) {}
 
   get owner(): string {
@@ -220,15 +222,33 @@ export class GitHubClient {
       draft: isDraft,
     };
 
-    // Add labels and assignees if provided
-    if (labels && labels.length > 0) {
-      requestBody.labels = labels;
-    }
-    if (assignees && assignees.length > 0) {
-      requestBody.assignees = assignees;
+    const newPr = await this.makeRequest<GitHubPR>(endpoint, 'POST', requestBody);
+
+    if (labels?.length) {
+      try {
+        await this.makeRequest(
+          `/repos/${this.owner}/${this.repo}/issues/${newPr.number}/labels`,
+          'POST',
+          { labels }
+        );
+      } catch (error) {
+        this.warn(`Failed to copy labels to PR #${newPr.number}:`, error);
+      }
     }
 
-    return this.makeRequest<GitHubPR>(endpoint, 'POST', requestBody);
+    if (assignees?.length) {
+      try {
+        await this.makeRequest(
+          `/repos/${this.owner}/${this.repo}/issues/${newPr.number}/assignees`,
+          'POST',
+          { assignees }
+        );
+      } catch (error) {
+        this.warn(`Failed to copy assignees to PR #${newPr.number}:`, error);
+      }
+    }
+
+    return newPr;
   }
 
   /**

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -237,6 +237,8 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     isDraft: boolean
   ): Promise<GitHubPR> {
     const prBody = description;
+    const labels = originalPr.labels?.map((label) => label.name) || [];
+    const assignees = originalPr.assignees?.map((assignee) => assignee.login) || [];
 
     // Create PR using the GitHub API
     const newPr = await this.ghClient.createPullRequest(
@@ -244,7 +246,9 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
       prBody,
       featureBranch,
       targetBranch,
-      isDraft
+      isDraft,
+      labels,
+      assignees
     );
 
     this.loggingService.info(`Created PR #${newPr.number}: ${newPr.title}`);

--- a/src/test/unit/ghClient.test.ts
+++ b/src/test/unit/ghClient.test.ts
@@ -1,0 +1,183 @@
+import * as assert from 'assert';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { PrCloneTempWorktreeService } from '../../services/prCloneTempWorktreeService';
+import { GitHubPR } from '../../types/dataTypes';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+interface RequestCall {
+  endpoint: string;
+  method?: string;
+  body?: unknown;
+}
+
+function createPullRequest(number = 42): GitHubPR {
+  return {
+    number,
+    title: 'Original PR',
+    body: 'Body',
+    head: {
+      ref: 'feature/original',
+      sha: 'abc123',
+    },
+    base: {
+      ref: 'main',
+    },
+    html_url: `https://github.com/owner/repo/pull/${number}`,
+    labels: [
+      {
+        id: 1,
+        name: 'bug',
+        description: null,
+        color: 'ff0000',
+        default: false,
+      },
+    ],
+    assignees: [
+      {
+        id: 2,
+        login: 'octocat',
+        avatar_url: 'https://github.com/octocat.png',
+      },
+    ],
+  };
+}
+
+describe('GitHubClient.createPullRequest', () => {
+  it('creates the PR before copying labels and assignees through the Issues API', async () => {
+    const client = new GitHubClient('owner', 'repo');
+    const newPr = createPullRequest();
+    const requests: RequestCall[] = [];
+
+    (client as any).makeRequest = async (
+      endpoint: string,
+      method?: string,
+      body?: unknown
+    ) => {
+      requests.push({ endpoint, method, body });
+      return newPr;
+    };
+
+    const result = await client.createPullRequest(
+      'Cloned PR',
+      'Description',
+      'feature/cloned',
+      'main',
+      true,
+      ['bug', 'priority'],
+      ['octocat']
+    );
+
+    assert.strictEqual(result, newPr);
+    assert.deepStrictEqual(requests, [
+      {
+        endpoint: '/repos/owner/repo/pulls',
+        method: 'POST',
+        body: {
+          title: 'Cloned PR',
+          body: 'Description',
+          head: 'feature/cloned',
+          base: 'main',
+          draft: true,
+        },
+      },
+      {
+        endpoint: '/repos/owner/repo/issues/42/labels',
+        method: 'POST',
+        body: { labels: ['bug', 'priority'] },
+      },
+      {
+        endpoint: '/repos/owner/repo/issues/42/assignees',
+        method: 'POST',
+        body: { assignees: ['octocat'] },
+      },
+    ]);
+  });
+
+  it('warns on metadata failures and still returns the created PR', async () => {
+    const newPr = createPullRequest();
+    const requests: RequestCall[] = [];
+    const warnings: Array<{ message: string; error: unknown }> = [];
+    const client = new GitHubClient('owner', 'repo', (message, error) => {
+      warnings.push({ message, error });
+    });
+
+    (client as any).makeRequest = async (
+      endpoint: string,
+      method?: string,
+      body?: unknown
+    ) => {
+      requests.push({ endpoint, method, body });
+      if (endpoint.endsWith('/labels')) {
+        throw new Error('labels forbidden');
+      }
+      if (endpoint.endsWith('/assignees')) {
+        throw new Error('assignees forbidden');
+      }
+      return newPr;
+    };
+
+    const result = await client.createPullRequest(
+      'Cloned PR',
+      'Description',
+      'feature/cloned',
+      'main',
+      false,
+      ['bug'],
+      ['octocat']
+    );
+
+    assert.strictEqual(result, newPr);
+    assert.deepStrictEqual(
+      requests.map(({ endpoint }) => endpoint),
+      [
+        '/repos/owner/repo/pulls',
+        '/repos/owner/repo/issues/42/labels',
+        '/repos/owner/repo/issues/42/assignees',
+      ]
+    );
+    assert.strictEqual(warnings.length, 2);
+    assert.match(warnings[0].message, /Failed to copy labels to PR #42/);
+    assert.match(warnings[1].message, /Failed to copy assignees to PR #42/);
+  });
+});
+
+describe('PrCloneTempWorktreeService metadata parity', () => {
+  it('passes original labels and assignees when creating the cloned PR', async () => {
+    const calls: unknown[][] = [];
+    const newPr = createPullRequest(84);
+    const ghClient = {
+      createPullRequest: async (...args: unknown[]) => {
+        calls.push(args);
+        return newPr;
+      },
+    } as unknown as GitHubClient;
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      ghClient,
+      mockLogService
+    );
+
+    const result = await (service as any).createGitHubPR(
+      createPullRequest(),
+      'feature/cloned',
+      'release',
+      'Description',
+      true
+    );
+
+    assert.strictEqual(result, newPr);
+    assert.deepStrictEqual(calls, [
+      [
+        'Original PR',
+        'Description',
+        'feature/cloned',
+        'release',
+        true,
+        ['bug'],
+        ['octocat'],
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed
- create the cloned PR first, then copy labels and assignees through the Issues API
- keep metadata updates best effort so a permission failure does not discard the new PR
- pass metadata through temp-worktree mode for parity
- add mocked API/service tests and document the behavior

## Why
GitHub ignores labels and assignees in the pull creation endpoint, so cloned PRs silently lost that metadata.

Closes #28.

## Validation
- typecheck, lint, and compile passed
- 214 unit tests passed