### PR TITLE
fix: Parse dotted GitHub repository names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Website: https://git-smart-checkout.vradchuk.info
 ## Requirements
 
 - Git **2.38** or newer (required for conflict pre-flight detection in auto stash and pop/apply modes)
+- GitHub features support HTTPS and SSH GitHub remotes, including repository names that contain dots.
 
 ## Info
 

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -64,6 +64,37 @@ export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   return worktrees;
 }
 
+export function parseGitHubRemoteUrl(remoteUrl: string): { owner: string; repo: string } | null {
+  const value = remoteUrl.trim();
+  const scpMatch = value.match(/^[^@\s]+@github\.com:([^/\s]+)\/([^/\s]+)\/?$/i);
+
+  let owner: string;
+  let repoWithSuffix: string;
+
+  if (scpMatch) {
+    [, owner, repoWithSuffix] = scpMatch;
+  } else {
+    try {
+      const url = new URL(value);
+      if (url.hostname.toLowerCase() !== 'github.com') {
+        return null;
+      }
+
+      const pathParts = url.pathname.split('/').filter(Boolean);
+      if (pathParts.length !== 2) {
+        return null;
+      }
+
+      [owner, repoWithSuffix] = pathParts;
+    } catch {
+      return null;
+    }
+  }
+
+  const repo = repoWithSuffix.replace(/\.git$/i, '');
+  return owner && repo ? { owner, repo } : null;
+}
+
 export class GitExecutor {
   #repositoryPath;
   #logService;
@@ -663,10 +694,7 @@ export class GitExecutor {
   async getRepoInfo(): Promise<{ owner: string; repo: string } | null> {
     try {
       const remoteUrl = await this.getRemoteUrl();
-      const match = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
-      if (match) {
-        return { owner: match[1], repo: match[2] };
-      }
+      return parseGitHubRemoteUrl(remoteUrl);
     } catch (error) {
       this.#logService.error(`Failed to get repo info: ${error}`);
     }

--- a/src/test/unit/repoInfoParser.test.ts
+++ b/src/test/unit/repoInfoParser.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+
+import { parseGitHubRemoteUrl } from '../../common/git/gitExecutor';
+
+describe('parseGitHubRemoteUrl', () => {
+  const cases: Array<[string, { owner: string; repo: string }]> = [
+    ['git@github.com:owner/repo.git', { owner: 'owner', repo: 'repo' }],
+    ['https://github.com/owner/repo', { owner: 'owner', repo: 'repo' }],
+    ['https://github.com/owner/repo.git', { owner: 'owner', repo: 'repo' }],
+    ['https://github.com/owner/next.js', { owner: 'owner', repo: 'next.js' }],
+    ['git@github.com:owner/my.repo.name.git', { owner: 'owner', repo: 'my.repo.name' }],
+  ];
+
+  for (const [remoteUrl, expected] of cases) {
+    it(`parses ${remoteUrl}`, () => {
+      assert.deepStrictEqual(parseGitHubRemoteUrl(remoteUrl), expected);
+    });
+  }
+
+  it('supports URL-form SSH remotes and trailing slashes', () => {
+    assert.deepStrictEqual(
+      parseGitHubRemoteUrl('ssh://git@github.com/owner/my.repo.git/'),
+      { owner: 'owner', repo: 'my.repo' }
+    );
+  });
+
+  it('rejects non-GitHub and malformed remote URLs', () => {
+    assert.strictEqual(parseGitHubRemoteUrl('https://github.example.com/owner/repo.git'), null);
+    assert.strictEqual(parseGitHubRemoteUrl('https://github.com/owner/repo/extra'), null);
+    assert.strictEqual(parseGitHubRemoteUrl('not a remote'), null);
+  });
+});


### PR DESCRIPTION
## What changed
- parse GitHub SSH and URL remotes structurally
- strip only a trailing `.git` suffix instead of treating dots as delimiters
- add coverage for dotted names, trailing slashes, malformed URLs, and both remote styles
- document dotted repository support

## Why
The previous regex truncated repositories such as `next.js`, causing GitHub API requests and repository IDs to target the wrong project.

## Validation
- typecheck and ESLint passed
- production package passed
- 218 unit tests passed