### PR TITLE
fix: Recover from in-place PR clone failures

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -36,6 +36,11 @@ When conflicts occur during cherry-picking, you can:
 
 The process is tracked with progress indicators and can be safely cancelled.
 
+If an in-place clone fails during branch setup, cherry-picking, push, or pull request creation,
+the extension stops the progress notification, attempts to restore the original branch and
+stashed changes, removes the temporary feature branch when possible, and re-enables the clone
+controls.
+
 ## Related Settings
 
 - `git-smart-checkout.defaultTargetBranch`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -271,7 +271,7 @@ export function activate(context: vscode.ExtensionContext) {
   const prCancelCloneMenuCommand = commands.registerCommand(
     `${EXTENSION_NAME}.prCancelCloneMenu`,
     async () => {
-      prCloneService.abortClonePR();
+      await prCloneService.abortClonePR();
     }
   );
 

--- a/src/services/prCloneError.ts
+++ b/src/services/prCloneError.ts
@@ -1,0 +1,6 @@
+export class PrCloneReportedError extends Error {
+  constructor(readonly originalError: unknown) {
+    super(originalError instanceof Error ? originalError.message : String(originalError));
+    this.name = 'PrCloneReportedError';
+  }
+}

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -1,8 +1,7 @@
-import { CancellationToken, commands, env, Progress, ProgressLocation, Uri, window } from 'vscode';
+import { commands, env, Progress, Uri, window } from 'vscode';
 
 import { GitExecutor } from '../common/git/gitExecutor';
 import { GitHubClient } from '../common/api/ghClient';
-import { EXTENSION_NAME } from '../const';
 import { LoggingService } from '../logging/loggingService';
 import { GitHubPR } from '../types/dataTypes';
 import { getStashMessage } from '../commands/utils/getStashMessage';
@@ -17,12 +16,12 @@ import {
 } from '../utils/setContext';
 import { PrCloneServiceBase } from './prCloneServiceBase';
 import { AnalyticsEvent, capture, captureException } from '../analytics/analytics';
+import { PrCloneReportedError } from './prCloneError';
 
 interface IServiceStore {
   originalBranch?: string;
   createdBranchName?: string;
   stashMessage?: string;
-  isAborting?: boolean;
   originalPrData?: PrCloneData;
 }
 
@@ -55,42 +54,47 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
     const nextCommit = await this.commitGenerator!.next();
     if (nextCommit?.done) {
-      this.updateProgress?.report({ message: 'All commits were applied' });
+      try {
+        this.updateProgress?.report({ message: 'All commits were applied' });
 
-      // push branch and proceed to PR creation
-      await this.git.pushBranchToGitHub(this.serviceStore.createdBranchName!);
+        // push branch and proceed to PR creation
+        await this.git.pushBranchToGitHub(this.serviceStore.createdBranchName!);
 
-      const { targetBranch, prData, description, isDraft } = this.serviceStore.originalPrData || {
-        targetBranch: '',
-        prData: undefined,
-        description: '',
-        isDraft: true,
-      };
+        const { targetBranch, prData, description, isDraft } = this.serviceStore.originalPrData || {
+          targetBranch: '',
+          prData: undefined,
+          description: '',
+          isDraft: true,
+        };
 
-      const newPr = await this.createGitHubPR(
-        prData!,
-        this.serviceStore.createdBranchName!,
-        targetBranch!,
-        description!,
-        isDraft!
-      );
+        const newPr = await this.createGitHubPR(
+          prData!,
+          this.serviceStore.createdBranchName!,
+          targetBranch!,
+          description!,
+          isDraft!
+        );
 
-      capture(AnalyticsEvent.PrCloneCompleted, {
-        is_draft: isDraft,
-        commit_count: this.serviceStore.originalPrData?.selectedCommits.length,
-      });
+        capture(AnalyticsEvent.PrCloneCompleted, {
+          is_draft: isDraft,
+          commit_count: this.serviceStore.originalPrData?.selectedCommits.length,
+        });
 
-      const openAction = await window.showInformationMessage(
-        `PR #${newPr.number} created successfully!`,
-        'Open'
-      );
+        const openAction = await window.showInformationMessage(
+          `PR #${newPr.number} created successfully!`,
+          'Open'
+        );
 
-      if (openAction === 'Open') {
-        await env.openExternal(Uri.parse(newPr.html_url));
+        if (openAction === 'Open') {
+          await env.openExternal(Uri.parse(newPr.html_url));
+        }
+
+        this.finishProgress?.();
+        await this.cleanUp();
+      } catch (error) {
+        await this.recoverFromFailure(error);
+        throw new PrCloneReportedError(error);
       }
-
-      this.finishProgress?.();
-      this.cleanUp();
     } else {
       // apply commit and proceed to the next commit
       this.updateProgress?.report({
@@ -104,7 +108,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
         };
 
         if (conflicts) {
-          setContextIsCherryPickConflict(true);
+          await setContextIsCherryPickConflict(true);
           this.updateProgress?.report({
             message: `There are conflicts on commit ${nextCommit.value.sha}, (${nextCommit.value.current} of ${nextCommit.value.total})`,
           });
@@ -115,44 +119,24 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
           await this.cherryPickNext();
         }
       } catch (error) {
-        // Handle conflicts - show a message and let the user resolve manually
-        const errorMessage = `Cannot apply cherry pick, reverting changes`;
+        if (error instanceof PrCloneReportedError) {
+          throw error;
+        }
 
         this.loggingService.error(`Cannot cherry-pick a commit '${nextCommit.value}': ${error}`);
 
-        await window.showWarningMessage(errorMessage, { modal: true });
-
-        this.cancelProgress?.();
-        this.cleanUp();
-
-        // The cherry-pick process is now in the user's hands
-        // They need to resolve conflicts manually and continue
-        // throw new Error('Cherry-pick conflicts require manual resolution');
+        await this.recoverFromFailure(error);
+        throw new PrCloneReportedError(error);
       }
     }
   }
 
-  async cleanUp(isAborting = false) {
+  async cleanUp(isAborting = false): Promise<void> {
     this.updateProgress?.report({ message: 'Clean up' });
 
     try {
-      this.cleanUpActionBegin.forEach((action) => action());
-
-      // Check if there's an active cherry-pick operation and abort it
-      if (await this.git.isCherryPickInProgress()) {
-        try {
-          await this.git.cherryPickAbort();
-          setContextIsCherryPickConflict(false);
-        } catch (error) {
-          this.loggingService.warn(`Failed to abort cherry-pick: ${error}`);
-        }
-      }
-
-      // Hard reset to reset all changes in workdir
-      try {
-        await this.git.reset(true);
-      } catch (error) {
-        this.loggingService.warn(`Failed to reset working directory: ${error}`);
+      for (const action of this.cleanUpActionBegin) {
+        await action();
       }
 
       await setContextIsCloning(false);
@@ -161,34 +145,77 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       if (!this.serviceStore.originalBranch) {
         return;
       }
-      await this.git.checkout(this.serviceStore.originalBranch);
 
-      if (this.serviceStore.stashMessage) {
-        await this.git.popStash(this.serviceStore.stashMessage);
+      // Check if there's an active cherry-pick operation and abort it
+      try {
+        if (await this.git.isCherryPickInProgress()) {
+          await this.git.cherryPickAbort();
+        }
+      } catch (error) {
+        this.loggingService.warn(`Failed to abort cherry-pick: ${error}`);
       }
 
-      if (!this.serviceStore.isAborting && !isAborting) {
+      if (this.serviceStore.createdBranchName) {
+        try {
+          await this.git.reset(true);
+        } catch (error) {
+          this.loggingService.warn(`Failed to reset working directory: ${error}`);
+        }
+      }
+
+      let restoredOriginalBranch = false;
+      try {
+        await this.git.checkout(this.serviceStore.originalBranch);
+        restoredOriginalBranch = true;
+      } catch (error) {
+        this.loggingService.warn(
+          `Failed to restore original branch '${this.serviceStore.originalBranch}': ${error}`
+        );
+      }
+
+      if (restoredOriginalBranch && this.serviceStore.stashMessage) {
+        try {
+          await this.git.popStash(this.serviceStore.stashMessage);
+        } catch (error) {
+          this.loggingService.warn(
+            `Failed to restore stashed changes '${this.serviceStore.stashMessage}': ${error}`
+          );
+        }
+      }
+
+      if (!isAborting) {
         await this.hideActivityBar();
         return;
       }
-      // below only aborting clean up
 
-      if (!this.serviceStore.createdBranchName) {
+      if (!this.serviceStore.createdBranchName || !restoredOriginalBranch) {
         return;
       }
 
-      // if operation abort requested, clean up leftovers (new branch)
       capture(AnalyticsEvent.PrCloneAborted);
-      await this.git.deleteLocalBranch(this.serviceStore.createdBranchName);
+      try {
+        await this.git.deleteLocalBranch(this.serviceStore.createdBranchName);
+      } catch (error) {
+        this.loggingService.warn(
+          `Failed to delete clone branch '${this.serviceStore.createdBranchName}': ${error}`
+        );
+      }
     } finally {
-      this.cleanUpActionEnd.forEach((action) => action());
+      try {
+        for (const action of this.cleanUpActionEnd) {
+          await action();
+        }
+      } finally {
+        this.resetOperationState();
+      }
     }
   }
 
   async clonePR(data: PrCloneData): Promise<void> {
     this.loggingService.debug('Start cloning PR using in-place cherry-pick...');
 
-    // branch to roll back after PR creation or cancels
+    this.resetOperationState();
+    this.serviceStore.originalPrData = data;
 
     const { finishProgress, cancelProgress, updateProgress } = createWithProcess(
       `Cloning PR #${data.prData.number} (In-Place)`,
@@ -200,8 +227,6 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
     this.updateProgress = updateProgress;
 
     try {
-      this.serviceStore.originalPrData = data;
-
       capture(AnalyticsEvent.PrCloneStarted, { commit_count: data.selectedCommits.length, is_draft: data.isDraft });
 
       // Step 1: Store original branch and stash changes if needed
@@ -251,7 +276,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       );
 
       if (this.serviceStore.createdBranchName !== data.featureBranch) {
-        window.showInformationMessage(
+        await window.showInformationMessage(
           `Branch name '${data.featureBranch}' already exists. Using '${this.serviceStore.createdBranchName}' instead.`
         );
       }
@@ -267,15 +292,47 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       ]();
 
       // start cherry picking
-      this.cherryPickNext();
+      await this.cherryPickNext();
     } catch (error) {
-      captureException(error);
+      if (error instanceof PrCloneReportedError) {
+        throw error;
+      }
+
+      await this.recoverFromFailure(error);
+      throw new PrCloneReportedError(error);
     }
   }
 
   dispose() {
     this.cleanUpActionEnd = [];
     this.cleanUpActionBegin = [];
+    this.resetOperationState();
+  }
+
+  protected async showCloneError(error: unknown): Promise<void> {
+    await window.showErrorMessage(
+      `Failed to clone PR: ${error instanceof Error ? error.message : error}`
+    );
+  }
+
+  private async recoverFromFailure(error: unknown): Promise<void> {
+    this.loggingService.error(`Failed to clone PR: ${error}`);
+    captureException(error);
+
+    // Error recovery completes the notification. The current createWithProcess
+    // cancel handle rejects its internal promise, so invoking it here would
+    // create an unhandled rejection until item 8 changes that API.
+    this.finishProgress?.();
+    await this.cleanUp(true);
+    await this.showCloneError(error);
+  }
+
+  private resetOperationState(): void {
+    this.serviceStore = {};
+    this.commitGenerator = undefined;
+    this.updateProgress = undefined;
+    this.finishProgress = undefined;
+    this.cancelProgress = undefined;
   }
 
   private async createGitHubPR(

--- a/src/services/prCloneService.ts
+++ b/src/services/prCloneService.ts
@@ -20,8 +20,8 @@ export interface PrCloneData {
 }
 
 export interface ICleanUpActions {
-  cleanUpActionBegin?: () => void;
-  cleanUpActionEnd?: () => void;
+  cleanUpActionBegin?: () => void | Promise<void>;
+  cleanUpActionEnd?: () => void | Promise<void>;
 }
 
 export class PrCloneService {
@@ -101,12 +101,17 @@ export class PrCloneService {
   async clonePR(data: PrCloneData): Promise<void> {
     const config = this.configurationManager.get();
 
-    setContextIsCloning(true);
+    await setContextIsCloning(true);
 
-    if (config.useInPlaceCherryPick) {
-      await this.InPlaceService.clonePR(data);
-    } else {
-      await this.TempWorktreeService.clonePR(data);
+    try {
+      if (config.useInPlaceCherryPick) {
+        await this.InPlaceService.clonePR(data);
+      } else {
+        await this.TempWorktreeService.clonePR(data);
+      }
+    } catch (error) {
+      await setContextIsCloning(false);
+      throw error;
     }
   }
 
@@ -121,7 +126,7 @@ export class PrCloneService {
   }
 
   async abortClonePR() {
-    this.InPlaceService.abortClonePR();
+    await this.InPlaceService.abortClonePR();
   }
 
   isDevMode() {

--- a/src/services/prCloneServiceBase.ts
+++ b/src/services/prCloneServiceBase.ts
@@ -7,8 +7,8 @@ import { ICleanUpActions } from './prCloneService';
 export abstract class PrCloneServiceBase extends Disposable {
   protected finishProgress: (() => void) | undefined;
   protected cancelProgress: (() => void) | undefined;
-  protected cleanUpActionBegin: (() => void)[] = [];
-  protected cleanUpActionEnd: (() => void)[] = [];
+  protected cleanUpActionBegin: (() => void | Promise<void>)[] = [];
+  protected cleanUpActionEnd: (() => void | Promise<void>)[] = [];
 
   constructor(
     protected git: GitExecutor,
@@ -34,8 +34,8 @@ export abstract class PrCloneServiceBase extends Disposable {
     }
   }
 
-  abortClonePR() {
-    this.cancelProgress?.();
-    this.cleanUp(true);
+  async abortClonePR(): Promise<void> {
+    this.finishProgress?.();
+    await this.cleanUp(true);
   }
 }

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -145,8 +145,12 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
   }
 
   protected async cleanUp(): Promise<void> {
-    this.cleanUpActionBegin.forEach((action) => action());
-    this.cleanUpActionEnd.forEach((action) => action());
+    for (const action of this.cleanUpActionBegin) {
+      await action();
+    }
+    for (const action of this.cleanUpActionEnd) {
+      await action();
+    }
   }
 
   private async createTempWorktree(targetBranch: string): Promise<string> {

--- a/src/test/unit/prCloneErrorRecovery.test.ts
+++ b/src/test/unit/prCloneErrorRecovery.test.ts
@@ -1,0 +1,212 @@
+import * as assert from 'assert';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import { PrCloneReportedError } from '../../services/prCloneError';
+import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
+import { PrCloneData, PrCloneService } from '../../services/prCloneService';
+import { GitHubPR } from '../../types/dataTypes';
+import { WebviewCommand } from '../../types/webviewCommands';
+import { PrCloneWebViewProvider } from '../../view/PrCloneWebViewProvider';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const prData = {
+  number: 42,
+  title: 'Test PR',
+  head: { ref: 'feature/source' },
+} as GitHubPR;
+
+const cloneData: PrCloneData = {
+  prData,
+  targetBranch: 'main',
+  featureBranch: 'feature/clone',
+  description: 'Clone description',
+  selectedCommits: [],
+  isDraft: false,
+};
+
+class TestPrCloneInPlaceService extends PrCloneInPlaceService {
+  readonly reportedErrors: unknown[] = [];
+
+  protected override async showCloneError(error: unknown): Promise<void> {
+    this.reportedErrors.push(error);
+  }
+}
+
+describe('PrCloneInPlaceService error recovery', () => {
+  it('restores the original branch without resetting or deleting when setup fails', async () => {
+    const events: string[] = [];
+    const setupError = new Error('target checkout failed');
+    let targetCheckoutAttempted = false;
+
+    const git = {
+      getCurrentBranch: async () => {
+        events.push('get-current-branch');
+        return 'original';
+      },
+      isWorkdirHasChanges: async () => false,
+      fetchSpecificBranch: async () => {},
+      checkout: async (branch: string) => {
+        events.push(`checkout:${branch}`);
+        if (branch === 'main' && !targetCheckoutAttempted) {
+          targetCheckoutAttempted = true;
+          throw setupError;
+        }
+      },
+      isCherryPickInProgress: async () => false,
+      reset: async () => {
+        events.push('reset');
+      },
+      deleteLocalBranch: async (branch: string) => {
+        events.push(`delete:${branch}`);
+      },
+    } as unknown as GitExecutor;
+
+    const service = new TestPrCloneInPlaceService(
+      git,
+      {} as GitHubClient,
+      mockLogService
+    );
+    let cleanupCompleted = false;
+    service.addCleanUpActions({
+      cleanUpActionEnd: () => {
+        cleanupCompleted = true;
+      },
+    });
+
+    await assert.rejects(
+      service.clonePR(cloneData),
+      (error: unknown) =>
+        error instanceof PrCloneReportedError && error.originalError === setupError
+    );
+
+    assert.strictEqual(cleanupCompleted, true);
+    assert.deepStrictEqual(service.reportedErrors, [setupError]);
+    assert.ok(events.includes('checkout:original'));
+    assert.ok(!events.includes('reset'));
+    assert.ok(!events.some((event) => event.startsWith('delete:')));
+  });
+
+  it('restores stash, removes the clone branch, and clears state after a push failure', async () => {
+    const events: string[] = [];
+    const pushError = new Error('push failed');
+    let run = 0;
+
+    const git = {
+      getCurrentBranch: async () => {
+        run++;
+        events.push(`get-current-branch:${run}`);
+        if (run === 2) {
+          throw new Error('second run failed before state capture');
+        }
+        return 'original';
+      },
+      isWorkdirHasChanges: async () => true,
+      createStash: async (message: string) => {
+        events.push(`stash:${message}`);
+      },
+      fetchSpecificBranch: async () => {},
+      checkout: async (branch: string) => {
+        events.push(`checkout:${branch}`);
+      },
+      pullCurrentBranch: async () => {},
+      createUniqueFeatureBranch: async () => 'feature/clone',
+      hasConflicts: async () => false,
+      getCommitTimestamp: async (sha: string) => ({ sha, timestamp: 1 }),
+      cherryPick: async () => ({ conflicts: false }),
+      pushBranchToGitHub: async () => {
+        events.push('push');
+        throw pushError;
+      },
+      isCherryPickInProgress: async () => false,
+      reset: async () => {
+        events.push('reset');
+      },
+      popStash: async (message: string) => {
+        events.push(`pop:${message}`);
+      },
+      deleteLocalBranch: async (branch: string) => {
+        events.push(`delete:${branch}`);
+      },
+    } as unknown as GitExecutor;
+
+    const service = new TestPrCloneInPlaceService(
+      git,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    await assert.rejects(
+      service.clonePR({ ...cloneData, selectedCommits: ['abc123'] }),
+      (error: unknown) =>
+        error instanceof PrCloneReportedError && error.originalError === pushError
+    );
+
+    assert.ok(events.includes('reset'));
+    assert.ok(events.includes('checkout:original'));
+    assert.ok(events.some((event) => event.startsWith('pop:')));
+    assert.ok(events.includes('delete:feature/clone'));
+
+    await assert.rejects(
+      service.clonePR(cloneData),
+      (error: unknown) => error instanceof PrCloneReportedError
+    );
+
+    assert.strictEqual(
+      events.filter((event) => event.startsWith('pop:')).length,
+      1,
+      'the old stash must not be reused'
+    );
+    assert.strictEqual(
+      events.filter((event) => event.startsWith('delete:')).length,
+      1,
+      'the old clone branch must not be reused'
+    );
+    assert.strictEqual(service.reportedErrors.length, 2);
+  });
+});
+
+describe('PrCloneWebViewProvider clone state recovery', () => {
+  it('posts a non-cloning state when the clone service rejects', async () => {
+    const messages: Array<{ command: WebviewCommand; isCloning?: boolean }> = [];
+    const cloneError = new PrCloneReportedError(new Error('push failed'));
+    const fakeCloneService = {
+      clonePR: async () => {
+        throw cloneError;
+      },
+    } as unknown as PrCloneService;
+
+    const provider = new PrCloneWebViewProvider(
+      {} as any,
+      mockLogService as LoggingService,
+      {} as any,
+      fakeCloneService
+    );
+
+    (provider as any).currentPrData = prData;
+    (provider as any).webviewView = {
+      webview: {
+        postMessage: async (message: { command: WebviewCommand; isCloning?: boolean }) => {
+          messages.push(message);
+          return true;
+        },
+      },
+    };
+
+    await (provider as any).handleClonePR({
+      targetBranch: 'main',
+      featureBranch: 'feature/clone',
+      description: '',
+      selectedCommits: [],
+      isDraft: false,
+    });
+
+    assert.deepStrictEqual(
+      messages
+        .filter((message) => message.command === WebviewCommand.UPDATE_CLONING_STATE)
+        .map((message) => message.isCloning),
+      [true, false]
+    );
+  });
+});

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -8,6 +8,7 @@ import { ConfigurationManager } from '../configuration/configurationManager';
 import { EXTENSION_NAME } from '../const';
 import { LoggingService } from '../logging/loggingService';
 import { PrCloneData, PrCloneService } from '../services/prCloneService';
+import { PrCloneReportedError } from '../services/prCloneError';
 import { GitHubCommit, GitHubPR } from '../types/dataTypes';
 import { WebviewCommand } from '../types/webviewCommands';
 import { getNonce } from '../utils/getNonce';
@@ -55,15 +56,15 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     if (!this.cloneServiceCleanUpAssigned) {
       // register clean up actions
       this.prCloneService.addCleanUpActions({
-        cleanUpActionEnd: () => {
-          webviewView.webview.postMessage({
+        cleanUpActionEnd: async () => {
+          await webviewView.webview.postMessage({
             command: WebviewCommand.UPDATE_CLONING_STATE,
             isCloning: false,
           });
 
-          this.updateCloningState(false);
+          await this.updateCloningState(false);
 
-          webviewView.webview.postMessage({
+          await webviewView.webview.postMessage({
             command: WebviewCommand.CANCEL_PR_CLONE,
           });
         },
@@ -280,7 +281,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   private async handleClonePR(data: any) {
     try {
       // Set loading state
-      this.updateCloningState(true);
+      await this.updateCloningState(true);
 
       if (!this.prCloneService || !this.currentPrData) {
         throw new Error('PR Clone service or PR data not initialized');
@@ -300,9 +301,12 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       await this.prCloneService.clonePR(prCloneData);
     } catch (error) {
       this.loggingService.error(`Failed to clone PR: ${error}`);
-      window.showErrorMessage(
-        `Failed to clone PR: ${error instanceof Error ? error.message : error}`
-      );
+      await this.updateCloningState(false);
+      if (!(error instanceof PrCloneReportedError)) {
+        await window.showErrorMessage(
+          `Failed to clone PR: ${error instanceof Error ? error.message : error}`
+        );
+      }
     }
   }
 
@@ -355,12 +359,12 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     }
   }
 
-  private updateCloningState(isCloning: boolean) {
+  private async updateCloningState(isCloning: boolean): Promise<void> {
     if (!this.webviewView) {
       return;
     }
 
-    this.webviewView.webview.postMessage({
+    await this.webviewView.webview.postMessage({
       command: WebviewCommand.UPDATE_CLONING_STATE,
       isCloning,
     });
@@ -371,7 +375,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     }
 
     // Update context to disable/enable interactions
-    setContextIsCloning(isCloning);
+    await setContextIsCloning(isCloning);
   }
 
   private async handleShowConfirmationDialog(message: string, details: string, data: any) {

--- a/src/view/PrCommitsWebViewProvider.ts
+++ b/src/view/PrCommitsWebViewProvider.ts
@@ -62,8 +62,8 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
     if (!this.cloneServiceCleanUpAssigned) {
       // register clean up actions
       this.prCloneService.addCleanUpActions({
-        cleanUpActionEnd: () => {
-          webviewView.webview.postMessage({
+        cleanUpActionEnd: async () => {
+          await webviewView.webview.postMessage({
             command: WebviewCommand.UPDATE_CLONING_STATE,
             isCloning: false,
           });


### PR DESCRIPTION
## What changed
- await the full in-place cherry-pick and PR creation flow
- report failures once, finish progress, restore the original branch/stash, and remove the temporary branch when possible
- reset extension and webview cloning state on every failure path
- make cleanup hooks awaitable and add setup/push/webview recovery tests
- document failure recovery behavior

## Why
In-place clone errors were swallowed or left unhandled, stranding the repository on a temporary branch while the progress UI and cloning context stayed active.

Related to #71.

## Validation
- `yarn build-all` passed
- 214 unit tests passed
- TypeScript, webview types, ESLint, and diff checks passed