### PR TITLE
fix: Handle stash preview fatal errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Website: https://git-smart-checkout.vradchuk.info
 
 ## Requirements
 
-- Git **2.38** or newer (required for conflict pre-flight detection in auto stash and pop/apply modes)
+- Git **2.38** or newer (required for tracked-file conflict pre-flight detection in auto stash and pop/apply modes; untracked-file conflicts are not previewed)
 
 ## Info
 

--- a/docs/checkout-with-stash.md
+++ b/docs/checkout-with-stash.md
@@ -39,7 +39,9 @@ If a branch is already checked out in another Git worktree, the checkout picker 
 
 ## Conflict Pre-Flight
 
-For auto stash and pop/apply modes, Git 2.38 or newer allows the extension to preview stash conflicts before switching branches. If conflicts are predicted, you can cancel before the checkout changes your working tree.
+For auto stash and pop/apply modes, Git 2.38 or newer allows the extension to preview tracked-file stash conflicts before switching branches. If conflicts are predicted, you can cancel before the checkout changes your working tree.
+
+The preview does not include untracked files. An untracked file may still conflict with a file on the target branch when the stash is restored.
 
 ## Media
 

--- a/src/commands/moveToNewWorktreeCommand/index.ts
+++ b/src/commands/moveToNewWorktreeCommand/index.ts
@@ -287,6 +287,7 @@ export class MoveToNewWorktreeCommand extends BaseCommand {
     const message =
       `Creating the worktree will ${operation} a stash that conflicts with the target branch.\n\n` +
       `Conflicting files:\n${fileList}\n\n` +
+      `This preview covers tracked files only; untracked files may still conflict.\n\n` +
       `Continue anyway? You will need to resolve conflicts manually in the new worktree.`;
     const choice = await vscode.window.showWarningMessage(
       message,

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -8,6 +8,31 @@ import { execCommand } from '../../utils/execCommand';
 import { VscodeGitProvider } from './vscodeGitProvider';
 import { IGitRef, IGitWorktree, TUpstreamTrack } from './types';
 
+type StashConflictPreviewError = ExecException & {
+  stdout?: string;
+  stderr?: string;
+};
+
+export function handleStashConflictPreviewError(
+  error: StashConflictPreviewError,
+  logService: Pick<LoggingService, 'warn'>
+): string[] {
+  if (error.code !== 1) {
+    logService.warn(
+      `Stash conflict preview unavailable: git merge-tree exited with code ${String(error.code ?? 'unknown')}.`,
+      { stderr: error.stderr ?? '' }
+    );
+    return [];
+  }
+
+  // Exit 1 = conflicts; stdout is "<tree-oid>\nfile1\nfile2\n...".
+  const lines = (error.stdout ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.slice(1);
+}
+
 export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   const worktrees: IGitWorktree[] = [];
   let current: IGitWorktree | undefined;
@@ -462,12 +487,12 @@ export class GitExecutor {
     return stdout.trim();
   }
 
-  // Predicts stash-apply conflicts before any destructive operations by materializing
-  // the working tree as a temporary commit via `git stash create` (non-destructive —
-  // no entry is pushed to refs/stash) and then running `git merge-tree` to simulate
-  // a 3-way merge of that commit onto targetRef. Requires Git >= 2.38.
-  // `merge-tree` exits non-zero and writes conflicting paths to stdout when conflicts
-  // are found, so we capture stdout from both the success and error paths.
+  // Predicts tracked-file stash conflicts before any destructive operations by
+  // materializing tracked working-tree changes as a temporary commit via
+  // `git stash create` (non-destructive; no entry is pushed to refs/stash) and
+  // running `git merge-tree` to simulate a 3-way merge onto targetRef.
+  // Untracked files are not included in this preview and may still conflict when
+  // the real stash, which includes untracked files, is restored. Requires Git >= 2.38.
   async getStashConflictPreview(targetRef: string): Promise<string[]> {
     const { stdout: stashSha } = await this.#execGitCommand(['stash', 'create']);
     const sha = stashSha.trim();
@@ -478,11 +503,11 @@ export class GitExecutor {
     try {
       await this.#execGitCommand(['merge-tree', '--write-tree', '--name-only', '--no-messages', targetRef, sha]);
       return []; // exit 0 = clean merge, no conflicts
-    } catch (e: any) {
-      // exit 1 = conflicts; stdout is "<tree-oid>\nfile1\nfile2\n…"
-      const out: string = e?.stdout ?? '';
-      const lines = out.split('\n').map((l: string) => l.trim()).filter(Boolean);
-      return lines.slice(1); // skip the tree OID on the first line
+    } catch (error) {
+      return handleStashConflictPreviewError(
+        error as StashConflictPreviewError,
+        this.#logService
+      );
     }
   }
 

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -281,6 +281,7 @@ export class AutoStashService {
     const message =
       `Switching branches will ${operation} a stash that conflicts with the target branch.\n\n` +
       `Conflicting files:\n${fileList}\n\n` +
+      `This preview covers tracked files only; untracked files may still conflict.\n\n` +
       `Continue anyway? You will need to resolve conflicts manually after checkout.`;
     const choice = await window.showWarningMessage(message, { modal: true }, 'Continue');
     return choice === 'Continue';

--- a/src/test/unit/stashConflictPreview.test.ts
+++ b/src/test/unit/stashConflictPreview.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import { ExecException } from 'child_process';
+
+import { handleStashConflictPreviewError } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+
+type PreviewError = ExecException & {
+  stdout?: string;
+  stderr?: string;
+};
+
+function makeError(code: number, stdout: string, stderr = ''): PreviewError {
+  return Object.assign(new Error('git merge-tree failed'), { code, stdout, stderr });
+}
+
+describe('handleStashConflictPreviewError', () => {
+  it('parses conflict paths only for exit code 1', () => {
+    const warnings: string[] = [];
+    const logService = {
+      warn: (message: string) => warnings.push(message),
+    } as Pick<LoggingService, 'warn'>;
+
+    const conflicts = handleStashConflictPreviewError(
+      makeError(1, 'tree-oid\nsrc/one.ts\nsrc/two.ts\n'),
+      logService
+    );
+
+    assert.deepStrictEqual(conflicts, ['src/one.ts', 'src/two.ts']);
+    assert.deepStrictEqual(warnings, []);
+  });
+
+  it('ignores stdout and warns for fatal exit codes', () => {
+    const warnings: string[] = [];
+    const logService = {
+      warn: (message: string) => warnings.push(message),
+    } as Pick<LoggingService, 'warn'>;
+
+    const conflicts = handleStashConflictPreviewError(
+      makeError(128, 'fatal-output\nnot-a-conflict-path.ts\n', 'fatal: unsupported option'),
+      logService
+    );
+
+    assert.deepStrictEqual(conflicts, []);
+    assert.deepStrictEqual(warnings, [
+      'Stash conflict preview unavailable: git merge-tree exited with code 128.',
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed
- parse merge-tree output only for Git exit code 1
- log and gracefully disable preview for fatal/unsupported-command exits
- clearly label the preview as tracked-files-only in code, dialogs, README, and checkout docs
- add focused error-code unit tests

## Why
Fatal Git output could be mistaken for conflict paths, while untracked files were silently outside the preview even though the real stash includes them.

## Validation
- typecheck, lint, and test compilation passed
- 213 unit tests passed