### PR TITLE
fix: Use 24-hour stash timestamps

### DIFF
--- a/docs/checkout-with-stash.md
+++ b/docs/checkout-with-stash.md
@@ -31,6 +31,8 @@ If a branch is already checked out in another Git worktree, the checkout picker 
 | Auto stash and apply in new branch | Stashes current changes, checks out the target branch, then applies the stash onto the target branch while keeping the stash entry available. |
 | No auto stash | Runs checkout without automatic stash handling. Git may block the checkout if local changes would be overwritten. |
 
+Temporary stashes used by the pop/apply flows are named `auto-stash-<branch>-<yyyy-MM-ddTHH:mm:ss>`, with `HH` recorded in 24-hour time.
+
 > [!TIP]
 > Set the default behavior with `Git Smart Checkout: Switch Mode` or the status bar item. When the mode is `manual`, this command asks you to select a stash mode each time.
 

--- a/src/commands/utils/getStashMessage.ts
+++ b/src/commands/utils/getStashMessage.ts
@@ -1,9 +1,9 @@
 import { format } from 'date-fns';
 import { AUTO_STASH_PREFIX } from '../checkoutToCommand/constants';
 
-export const getStashMessage = (branch: string, addDate = false) => {
+export const getStashMessage = (branch: string, addDate = false, now: Date | number = Date.now()) => {
   if (addDate) {
-    return `${AUTO_STASH_PREFIX}-${branch}-${format(Date.now(), 'yyyy-MM-ddThh:mm:ss')}`;
+    return `${AUTO_STASH_PREFIX}-${branch}-${format(now, "yyyy-MM-dd'T'HH:mm:ss")}`;
   }
 
   return `${AUTO_STASH_PREFIX}-${branch}`;

--- a/src/test/unit/getStashMessage.test.ts
+++ b/src/test/unit/getStashMessage.test.ts
@@ -1,0 +1,23 @@
+import * as assert from 'assert';
+
+import { getStashMessage } from '../../commands/utils/getStashMessage';
+
+describe('getStashMessage', () => {
+  it('keeps the branch-only stash name unchanged', () => {
+    assert.strictEqual(getStashMessage('feature/example'), 'auto-stash-feature/example');
+  });
+
+  it('uses a quoted T and 24-hour time for dated stash names', () => {
+    const morning = new Date(2026, 5, 12, 1, 23, 45);
+    const afternoon = new Date(2026, 5, 12, 13, 23, 45);
+
+    assert.strictEqual(
+      getStashMessage('feature/example', true, morning),
+      'auto-stash-feature/example-2026-06-12T01:23:45'
+    );
+    assert.strictEqual(
+      getStashMessage('feature/example', true, afternoon),
+      'auto-stash-feature/example-2026-06-12T13:23:45'
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- format dated stash names with a literal `T` and 24-hour `HH`
- make the timestamp input injectable for deterministic tests
- cover morning and afternoon values and document the name format

## Why
The 12-hour format produced identical stash messages twelve hours apart, allowing message-based restore flows to select the wrong stash.

## Validation
- typecheck, lint, and test compilation passed
- focused unit tests passed
- 24 stash e2e tests passed