### PR TITLE
fix: correctly detect in-progress cherry-pick via CHERRY_PICK_HEAD

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -547,8 +547,8 @@ export class GitExecutor {
 
   async isCherryPickInProgress(): Promise<boolean> {
     try {
-      const { stdout } = await this.#execGitCommand(['status', '--porcelain=v1']);
-      return stdout.includes('You are currently cherry-picking');
+      await this.#execGitCommand(['rev-parse', '-q', '--verify', 'CHERRY_PICK_HEAD']);
+      return true;
     } catch {
       return false;
     }

--- a/src/test/e2e/cherryPickInProgress.test.ts
+++ b/src/test/e2e/cherryPickInProgress.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+
+import { createRebaseConflictTestRepo, TestRepo } from './helpers/gitTestRepo';
+
+/**
+ * isCherryPickInProgress() must detect an in-progress cherry-pick by checking
+ * for the CHERRY_PICK_HEAD ref (the previous implementation grepped human-readable
+ * status text that never appears in porcelain output, so it always returned false).
+ *
+ * createRebaseConflictTestRepo gives main and feature divergent committed versions
+ * of file1.txt, so cherry-picking feature's tip onto main conflicts and leaves the
+ * cherry-pick in progress.
+ */
+describe('GitExecutor.isCherryPickInProgress', () => {
+  let repo: TestRepo;
+  before(() => {
+    repo = createRebaseConflictTestRepo();
+    repo.exec('git checkout main');
+  });
+  after(() => { repo.cleanup(); });
+
+  it('returns false when no cherry-pick is in progress', async () => {
+    assert.strictEqual(await repo.git.isCherryPickInProgress(), false);
+  });
+
+  it('returns true while a conflicting cherry-pick is in progress', async () => {
+    // Cherry-pick feature's tip onto main; conflicts on file1.txt and stops mid-pick.
+    try {
+      repo.exec('git cherry-pick feature');
+    } catch {
+      // expected: conflict makes cherry-pick exit non-zero
+    }
+
+    assert.strictEqual(await repo.git.isCherryPickInProgress(), true, 'CHERRY_PICK_HEAD should exist after a conflicting cherry-pick');
+  });
+
+  it('returns false again after the cherry-pick is aborted', async () => {
+    repo.exec('git cherry-pick --abort');
+
+    assert.strictEqual(await repo.git.isCherryPickInProgress(), false, 'CHERRY_PICK_HEAD should be gone after abort');
+  });
+});


### PR DESCRIPTION
## Bug

`GitExecutor.isCherryPickInProgress()` checked for an in-progress cherry-pick by grepping `git status --porcelain=v1` output for the human-readable string `"You are currently cherry-picking"`. That sentence only appears in human-readable `git status`; porcelain v1 output is strictly `XY <path>` lines, so the method **always returned `false`**.

As a consequence, `PrCloneInPlaceService.cleanUp()` never invoked `cherryPickAbort()`, leaving the repository stuck mid-cherry-pick with `CHERRY_PICK_HEAD` present.

## Fix

Detect the state reliably via the `CHERRY_PICK_HEAD` ref:

```ts
async isCherryPickInProgress(): Promise<boolean> {
  try {
    await this.#execGitCommand(['rev-parse', '-q', '--verify', 'CHERRY_PICK_HEAD']);
    return true;
  } catch {
    return false;
  }
}
```

## Tests

Adds `src/test/e2e/cherryPickInProgress.test.ts` using a conflict fixture repo:
- asserts `false` when no cherry-pick is in progress
- starts a conflicting cherry-pick, asserts `isCherryPickInProgress()` returns `true`
- after `cherry-pick --abort`, asserts it returns `false`

All 3 new tests pass. `yarn compile` passes. (Other pre-existing e2e failures in this sandbox are caused by `git symbolic-ref` behavior in bare-repo helpers and are unrelated to this change.)