### PR TITLE
fix: Stop the PR fetch spinner on errors

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -25,6 +25,8 @@ The GitHub PR Clone feature creates a new pull request by cherry-picking selecte
 6. Select the commits to cherry-pick.
 7. Let the extension create the branch, cherry-pick commits, and create the new PR or draft PR.
 
+If the source PR cannot be loaded, the extension shows the error and resets **Fetch PR Data** so you can correct the PR number or retry.
+
 During the cherry-pick process, the extension stashes uncommitted workspace changes, switches to the target branch, pulls the latest changes, creates a feature branch, and cherry-picks the selected commits one by one.
 
 ## Conflict Handling

--- a/src/test/unit/fetchPRLoadingState.test.ts
+++ b/src/test/unit/fetchPRLoadingState.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+
+import { WebviewCommand } from '../../types/webviewCommands';
+import { fetchPRLoadingReducer } from '../../webview/Apps/PR/App/fetchPRLoadingState';
+
+describe('fetchPRLoadingReducer', () => {
+  it('starts loading when a PR fetch is submitted', () => {
+    assert.strictEqual(fetchPRLoadingReducer(false, WebviewCommand.FETCH_PR), true);
+  });
+
+  it('stops loading when PR data is received', () => {
+    assert.strictEqual(fetchPRLoadingReducer(true, WebviewCommand.SHOW_PR_DATA), false);
+  });
+
+  it('stops loading when the PR fetch fails', () => {
+    assert.strictEqual(fetchPRLoadingReducer(true, WebviewCommand.FETCH_PR_ERROR), false);
+  });
+
+  it('stops loading when the user cancels', () => {
+    assert.strictEqual(fetchPRLoadingReducer(true, WebviewCommand.CANCEL_PR_CLONE), false);
+  });
+
+  it('preserves loading state for unrelated messages', () => {
+    assert.strictEqual(fetchPRLoadingReducer(true, WebviewCommand.UPDATE_REPO_INFO), true);
+  });
+});

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import { type Webview } from 'vscode';
+
+import { WebviewCommand } from '../../types/webviewCommands';
+import { postFetchPRError } from '../../view/PrCloneWebViewProvider';
+
+describe('postFetchPRError', () => {
+  it('posts the fetch failure to the PR webview', async () => {
+    const messages: unknown[] = [];
+    const webview = {
+      postMessage: async (message: unknown) => {
+        messages.push(message);
+        return true;
+      },
+    } as Pick<Webview, 'postMessage'>;
+
+    const posted = await postFetchPRError(webview, new Error('PR not found'));
+
+    assert.strictEqual(posted, true);
+    assert.deepStrictEqual(messages, [
+      {
+        command: WebviewCommand.FETCH_PR_ERROR,
+        message: 'Error: PR not found',
+      },
+    ]);
+  });
+});

--- a/src/types/webviewCommands.ts
+++ b/src/types/webviewCommands.ts
@@ -18,6 +18,7 @@ export enum WebviewCommand {
 
   // Commands sent from extension to webview
   SHOW_PR_DATA = 'showPRData',
+  FETCH_PR_ERROR = 'fetchPRError',
   TARGET_BRANCH_SELECTED = 'targetBranchSelected',
   CLEAR_STATE = 'clearState',
   UPDATE_CLONING_STATE = 'updateCloningState',

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -1,6 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { commands, ExtensionContext, Uri, WebviewView, WebviewViewProvider, window } from 'vscode';
+import {
+  commands,
+  ExtensionContext,
+  Uri,
+  type Webview,
+  WebviewView,
+  WebviewViewProvider,
+  window,
+} from 'vscode';
 
 import { GitHubClient } from '../common/api/ghClient';
 import { GitExecutor } from '../common/git/gitExecutor';
@@ -17,6 +25,16 @@ import {
   setContextShowPRClone,
   setContextShowPRCommits,
 } from '../utils/setContext';
+
+export function postFetchPRError(
+  webview: Pick<Webview, 'postMessage'> | undefined,
+  error: unknown
+): Thenable<boolean> | undefined {
+  return webview?.postMessage({
+    command: WebviewCommand.FETCH_PR_ERROR,
+    message: String(error),
+  });
+}
 
 export class PrCloneWebViewProvider implements WebviewViewProvider {
   private webviewView?: WebviewView;
@@ -125,11 +143,11 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async handleFetchPR(prInput: string) {
-    if (!this.git || !this.ghClient) {
-      throw new Error('Git client is not initialized');
-    }
-
     try {
+      if (!this.git || !this.ghClient) {
+        throw new Error('Git client is not initialized');
+      }
+
       const prNumber = this.extractPRNumber(prInput);
 
       const prData = await this.ghClient.fetchPullRequest(prNumber);
@@ -159,6 +177,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       this.updateWebviewWithPRData(prData, detailedCommits, branches);
     } catch (error) {
       this.loggingService.error(`Failed to fetch PR: ${error}`);
+      await postFetchPRError(this.webviewView?.webview, error);
       await window.showErrorMessage(
         `Failed to fetch PR: ${error instanceof Error ? error.message : error}`,
         'OK'

--- a/src/webview/Apps/PR/App/fetchPRLoadingState.ts
+++ b/src/webview/Apps/PR/App/fetchPRLoadingState.ts
@@ -1,0 +1,14 @@
+import { WebviewCommand } from '../../../types/commands';
+
+export function fetchPRLoadingReducer(isLoading: boolean, command: WebviewCommand): boolean {
+  switch (command) {
+    case WebviewCommand.FETCH_PR:
+      return true;
+    case WebviewCommand.SHOW_PR_DATA:
+    case WebviewCommand.FETCH_PR_ERROR:
+    case WebviewCommand.CANCEL_PR_CLONE:
+      return false;
+    default:
+      return isLoading;
+  }
+}

--- a/src/webview/Apps/PR/App/index.tsx
+++ b/src/webview/Apps/PR/App/index.tsx
@@ -1,18 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
 import { useLogger } from '@/hooks';
 import { PrCloneForm } from '@/Apps/PR/pages/PrCloneForm';
 import { PrInputForm } from '@/Apps/PR/pages/PrInputForm';
 import { AppState } from '@/types/dataTypes';
-import React, { useEffect, useState } from 'react';
-
 import { WebviewCommand } from '@/types/commands';
 import { useSendMessage } from '@/hooks/useSendMessage';
+
+import { fetchPRLoadingReducer } from './fetchPRLoadingState';
 
 const STORAGE_KEY = 'pr-clone-app-state';
 
 export const App: React.FC = () => {
   const logger = useLogger(false);
   const sendMessage = useSendMessage();
-  
+
+  const [isFetchingPR, updateFetchPRLoading] = React.useReducer(
+    fetchPRLoadingReducer,
+    false
+  );
+
   const [state, setState] = useState<AppState>(() => {
     // Initialize state from localStorage on component mount
     try {
@@ -42,7 +49,8 @@ export const App: React.FC = () => {
   }, [state]);
 
   const handleFetchPR = (prInput: string) => {
-    sendMessage(WebviewCommand.FETCH_PR, { prInput } )
+    updateFetchPRLoading(WebviewCommand.FETCH_PR);
+    sendMessage(WebviewCommand.FETCH_PR, { prInput });
   };
 
   const handleClonePR = (data: any) => {
@@ -51,6 +59,7 @@ export const App: React.FC = () => {
   };
 
   const handleCancel = () => {
+    updateFetchPRLoading(WebviewCommand.CANCEL_PR_CLONE);
     // Send message to VS Code extension to close activity bar and hide webview
     sendMessage(WebviewCommand.CANCEL_PR_CLONE);
   };
@@ -76,6 +85,7 @@ export const App: React.FC = () => {
 
       switch (true) {
         case message.command === WebviewCommand.SHOW_PR_DATA:
+          updateFetchPRLoading(WebviewCommand.SHOW_PR_DATA);
           // Show notification about the fetched PR
           const prData = message.prData;
           
@@ -98,6 +108,9 @@ export const App: React.FC = () => {
             defaultTargetBranch: message.defaultTargetBranch,
             prBranchPrefix: message.prBranchPrefix
           });
+          break;
+        case message.command === WebviewCommand.FETCH_PR_ERROR:
+          updateFetchPRLoading(WebviewCommand.FETCH_PR_ERROR);
           break;
         case message.command === WebviewCommand.TARGET_BRANCH_SELECTED:
           setState(prev => ({
@@ -156,8 +169,9 @@ export const App: React.FC = () => {
     <PrInputForm 
       repoName={repoInfo.repo}
       repoOwner={repoInfo.owner}
-      onFetchPR={handleFetchPR} 
+      onFetchPR={handleFetchPR}
       onCancel={handleCancel}
+      isLoading={isFetchingPR}
     />
   );
 };

--- a/src/webview/Apps/PR/pages/PrInputForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrInputForm/index.tsx
@@ -1,9 +1,9 @@
+import React, { useEffect, useRef, useState } from 'react';
+
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Text } from '@/components/Text';
 import { useLogger } from '@/hooks';
-import { useLoadingState } from '@/hooks/useLoadingState';
-import React, { useState, useEffect, useRef } from 'react';
 
 import styles from './module.css';
 
@@ -12,16 +12,17 @@ interface PrInputFormProps {
   repoName?: string;
   onFetchPR: (prInput: string) => void;
   onCancel: () => void;
+  isLoading: boolean;
 }
 
 export const PrInputForm: React.FC<PrInputFormProps> = ({
-    repoOwner = 'owner',
-    repoName = 'repo',
-    onFetchPR,
-    onCancel
-  }) => {
+  repoOwner = 'owner',
+  repoName = 'repo',
+  onFetchPR,
+  onCancel,
+  isLoading,
+}) => {
   const [prInput, setPrInput] = useState('');
-  const loadPullRequestData = useLoadingState();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const logger = useLogger();
@@ -42,30 +43,22 @@ export const PrInputForm: React.FC<PrInputFormProps> = ({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [loadPullRequestData.isLoading]);
+  }, [isLoading]);
 
   const handleCancel = () => {
-    if (loadPullRequestData.isLoading) {
-      // Cancel the fetch process but don't close panel
-      loadPullRequestData.finish();
+    if (isLoading) {
       logger.info('PR fetch cancelled by user');
-      // todo: remove onCancel and send message to provider to cancer running request
-      onCancel();
-    } else {
-      // Close the panel when not fetching
-      onCancel();
     }
+    onCancel();
   };
 
   const handleSubmit = (e: React.FormEvent) => {
-    logger.info('Fetching PR data ...')
+    logger.info('Fetching PR data ...');
     e.preventDefault();
     if (!prInput.trim()) {
       alert('Please enter a PR number or URL');
       return;
     }
-    
-    loadPullRequestData.start();
     onFetchPR(prInput.trim());
   };
 
@@ -94,7 +87,7 @@ export const PrInputForm: React.FC<PrInputFormProps> = ({
           <Button 
             type="submit" 
             variant="primary" 
-            loading={loadPullRequestData.isLoading}
+            loading={isLoading}
             disabled={!prInput.trim()}
           >
             Fetch PR Data


### PR DESCRIPTION
## What changed
- add a `FETCH_PR_ERROR` extension-to-webview message
- centralize PR fetch loading state in the app and clear it on success, failure, and cancel
- notify the webview before showing extension-host errors
- add provider/reducer tests and document retry behavior

## Why
Failed PR lookups left the Fetch PR Data button spinning until the user manually cancelled.

Related to #71.

## Validation
- extension and webview TypeScript passed
- ESLint and webview production build passed
- 217 unit tests passed