### PR TITLE
fix: Reinitialize PR clone services per repository

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -27,6 +27,8 @@ The GitHub PR Clone feature creates a new pull request by cherry-picking selecte
 
 During the cherry-pick process, the extension stashes uncommitted workspace changes, switches to the target branch, pulls the latest changes, creates a feature branch, and cherry-picks the selected commits one by one.
 
+In a multi-root workspace, the command asks which repository to use each time it runs. Switching repositories refreshes the repository shown in the PR Clone view and all subsequent PR data and Git operations use the newly selected repository.
+
 ## Conflict Handling
 
 When conflicts occur during cherry-picking, you can:

--- a/src/services/prCloneService.ts
+++ b/src/services/prCloneService.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, ExtensionMode } from 'vscode';
+import { Event, EventEmitter, ExtensionContext, ExtensionMode } from 'vscode';
 
 import { GitHubClient } from '../common/api/ghClient';
 import { GitExecutor } from '../common/git/gitExecutor';
@@ -29,6 +29,8 @@ export class PrCloneService {
   private _inPlaceService?: PrCloneInPlaceService;
   private _git?: GitExecutor;
   private _ghClient?: GitHubClient;
+  private readonly cleanUpActions: ICleanUpActions[] = [];
+  private readonly repositoryChangedEmitter = new EventEmitter<void>();
 
   private _isInited = false;
 
@@ -42,6 +44,10 @@ export class PrCloneService {
 
   get isInited(): boolean {
     return this._isInited;
+  }
+
+  get onDidChangeRepository(): Event<void> {
+    return this.repositoryChangedEmitter.event;
   }
 
   get TempWorktreeService(): PrCloneTempWorktreeService {
@@ -79,23 +85,34 @@ export class PrCloneService {
   //#endregion properties
 
   init(git: GitExecutor, ghClient: GitHubClient) {
-    if (!this.isInited) {
-      this._isInited = true;
-      this._git = git;
-      this._ghClient = ghClient;
-
-      this._tempWorktreeService = new PrCloneTempWorktreeService(
-        this.git,
-        this.ghClient,
-        this.loggingService
-      );
-
-      this._inPlaceService = new PrCloneInPlaceService(
-        this.git,
-        this.ghClient,
-        this.loggingService
-      );
+    if (
+      this.isInited &&
+      this.git.repositoryPath === git.repositoryPath &&
+      this.ghClient.owner === ghClient.owner &&
+      this.ghClient.repo === ghClient.repo
+    ) {
+      return;
     }
+
+    this._tempWorktreeService?.dispose();
+    this._inPlaceService?.dispose();
+
+    this._git = git;
+    this._ghClient = ghClient;
+    this._tempWorktreeService = new PrCloneTempWorktreeService(
+      git,
+      ghClient,
+      this.loggingService
+    );
+    this._inPlaceService = new PrCloneInPlaceService(git, ghClient, this.loggingService);
+
+    for (const cleanUpActions of this.cleanUpActions) {
+      this._tempWorktreeService.addCleanUpActions(cleanUpActions);
+      this._inPlaceService.addCleanUpActions(cleanUpActions);
+    }
+
+    this._isInited = true;
+    this.repositoryChangedEmitter.fire();
   }
 
   async clonePR(data: PrCloneData): Promise<void> {
@@ -129,16 +146,17 @@ export class PrCloneService {
   }
 
   addCleanUpActions(cleanUpActions: ICleanUpActions) {
+    this.cleanUpActions.push(cleanUpActions);
     this.InPlaceService.addCleanUpActions(cleanUpActions);
     this.TempWorktreeService.addCleanUpActions(cleanUpActions);
   }
 
   dispose(): void {
-    if (!this.isInited) {
-      return;
+    if (this.isInited) {
+      this.TempWorktreeService.dispose();
+      this.InPlaceService.dispose();
     }
 
-    this.TempWorktreeService.dispose();
-    this.InPlaceService.dispose();
+    this.repositoryChangedEmitter.dispose();
   }
 }

--- a/src/test/unit/prCloneService.test.ts
+++ b/src/test/unit/prCloneService.test.ts
@@ -1,0 +1,166 @@
+import * as assert from 'assert';
+import { ExtensionContext, ExtensionMode } from 'vscode';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { PrCloneService } from '../../services/prCloneService';
+import { PrCloneServiceBase } from '../../services/prCloneServiceBase';
+import { PrCloneWebViewProvider } from '../../view/PrCloneWebViewProvider';
+import { WebviewCommand } from '../../types/webviewCommands';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const context = {
+  extensionMode: ExtensionMode.Test,
+} as ExtensionContext;
+
+const configurationManager = {} as ConfigurationManager;
+
+function createGit(repositoryPath: string): GitExecutor {
+  return new GitExecutor(repositoryPath, mockLogService);
+}
+
+function getCleanUpActionCount(service: PrCloneServiceBase): number {
+  return (
+    service as unknown as {
+      cleanUpActionEnd: (() => void)[];
+    }
+  ).cleanUpActionEnd.length;
+}
+
+describe('PrCloneService re-initialization', () => {
+  it('keeps services when repository identity is unchanged', () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+    const git = createGit('/repo/a');
+    const ghClient = new GitHubClient('owner', 'repo');
+    let changes = 0;
+    service.onDidChangeRepository(() => changes++);
+
+    service.init(git, ghClient);
+    const tempWorktreeService = service.TempWorktreeService;
+    const inPlaceService = service.InPlaceService;
+
+    service.init(createGit('/repo/a'), new GitHubClient('owner', 'repo'));
+
+    assert.strictEqual(service.TempWorktreeService, tempWorktreeService);
+    assert.strictEqual(service.InPlaceService, inPlaceService);
+    assert.strictEqual(service.git, git);
+    assert.strictEqual(service.ghClient, ghClient);
+    assert.strictEqual(changes, 1);
+
+    service.dispose();
+  });
+
+  it('disposes and rebuilds services when the repository path changes', () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+    service.init(createGit('/repo/a'), new GitHubClient('owner', 'repo-a'));
+
+    const oldTempWorktreeService = service.TempWorktreeService;
+    const oldInPlaceService = service.InPlaceService;
+    let tempDisposeCount = 0;
+    let inPlaceDisposeCount = 0;
+    oldTempWorktreeService.dispose = () => tempDisposeCount++;
+    oldInPlaceService.dispose = () => inPlaceDisposeCount++;
+
+    const nextGit = createGit('/repo/b');
+    const nextClient = new GitHubClient('owner', 'repo-b');
+    service.init(nextGit, nextClient);
+
+    assert.strictEqual(tempDisposeCount, 1);
+    assert.strictEqual(inPlaceDisposeCount, 1);
+    assert.notStrictEqual(service.TempWorktreeService, oldTempWorktreeService);
+    assert.notStrictEqual(service.InPlaceService, oldInPlaceService);
+    assert.strictEqual(service.git, nextGit);
+    assert.strictEqual(service.ghClient, nextClient);
+
+    service.dispose();
+  });
+
+  it('rebuilds services when the GitHub repository changes at the same path', () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+    const git = createGit('/repo/a');
+    service.init(git, new GitHubClient('owner', 'old-repo'));
+    const oldTempWorktreeService = service.TempWorktreeService;
+
+    const nextClient = new GitHubClient('other-owner', 'new-repo');
+    service.init(git, nextClient);
+
+    assert.notStrictEqual(service.TempWorktreeService, oldTempWorktreeService);
+    assert.strictEqual(service.ghClient, nextClient);
+
+    service.dispose();
+  });
+
+  it('re-registers cleanup actions on rebuilt services', () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+    service.init(createGit('/repo/a'), new GitHubClient('owner', 'repo-a'));
+    service.addCleanUpActions({ cleanUpActionEnd: () => {} });
+
+    service.init(createGit('/repo/b'), new GitHubClient('owner', 'repo-b'));
+
+    assert.strictEqual(getCleanUpActionCount(service.TempWorktreeService), 1);
+    assert.strictEqual(getCleanUpActionCount(service.InPlaceService), 1);
+
+    service.dispose();
+  });
+});
+
+describe('PrCloneWebViewProvider repository refresh', () => {
+  it('clears stale PR data and posts updated repository info after re-init', () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+    const provider = new PrCloneWebViewProvider(
+      context,
+      mockLogService,
+      configurationManager,
+      service
+    );
+    const messages: { command: WebviewCommand; repoInfo?: { owner: string; repo: string } }[] = [];
+
+    (
+      provider as unknown as {
+        webviewView: {
+          webview: {
+            postMessage: (message: {
+              command: WebviewCommand;
+              repoInfo?: { owner: string; repo: string };
+            }) => Promise<boolean>;
+          };
+        };
+        currentPrData: object;
+      }
+    ).webviewView = {
+      webview: {
+        postMessage: async (message) => {
+          messages.push(message);
+          return true;
+        },
+      },
+    };
+
+    service.init(createGit('/repo/a'), new GitHubClient('owner-a', 'repo-a'));
+    (
+      provider as unknown as {
+        currentPrData: object;
+      }
+    ).currentPrData = {};
+    service.init(createGit('/repo/b'), new GitHubClient('owner-b', 'repo-b'));
+
+    const repoInfoMessages = messages.filter(
+      (message) => message.command === WebviewCommand.UPDATE_REPO_INFO
+    );
+    assert.deepStrictEqual(repoInfoMessages.at(-1)?.repoInfo, {
+      owner: 'owner-b',
+      repo: 'repo-b',
+    });
+    assert.strictEqual(
+      (
+        provider as unknown as {
+          currentPrData?: object;
+        }
+      ).currentPrData,
+      undefined
+    );
+
+    provider.dispose();
+  });
+});

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { commands, ExtensionContext, Uri, WebviewView, WebviewViewProvider, window } from 'vscode';
 
-import { GitHubClient } from '../common/api/ghClient';
 import { GitExecutor } from '../common/git/gitExecutor';
 import { ConfigurationManager } from '../configuration/configurationManager';
 import { EXTENSION_NAME } from '../const';
@@ -23,9 +22,6 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   private commitsProvider?: PrCommitsWebViewProvider;
   private currentPrData?: GitHubPR;
 
-  private git?: GitExecutor;
-  private ghClient?: GitHubClient;
-
   private cloneServiceCleanUpAssigned = false;
 
   constructor(
@@ -33,14 +29,16 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     private loggingService: LoggingService,
     private configurationManager: ConfigurationManager,
     private prCloneService: PrCloneService
-  ) {}
+  ) {
+    this.prCloneService.onDidChangeRepository(() => {
+      this.clearState();
+      this.updateRepoInfo();
+    });
+  }
 
   resolveWebviewView(webviewView: WebviewView) {
     this.loggingService.info('...Resolve webview');
     this.webviewView = webviewView;
-
-    this.git = this.prCloneService.git;
-    this.ghClient = this.prCloneService.ghClient;
 
     const extensionUri = this.context.extensionUri;
 
@@ -109,13 +107,17 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async handleWebViewReady() {
+    this.updateRepoInfo();
+  }
+
+  private updateRepoInfo() {
     if (!this.webviewView) {
       return;
     }
 
     const repoInfo = {
-      repo: this.ghClient?.repo,
-      owner: this.ghClient?.owner,
+      repo: this.prCloneService.ghClient.repo,
+      owner: this.prCloneService.ghClient.owner,
     };
 
     this.webviewView.webview.postMessage({
@@ -125,20 +127,18 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async handleFetchPR(prInput: string) {
-    if (!this.git || !this.ghClient) {
-      throw new Error('Git client is not initialized');
-    }
-
     try {
+      const git = this.prCloneService.git;
+      const ghClient = this.prCloneService.ghClient;
       const prNumber = this.extractPRNumber(prInput);
 
-      const prData = await this.ghClient.fetchPullRequest(prNumber);
+      const prData = await ghClient.fetchPullRequest(prNumber);
       this.currentPrData = prData; // Store PR data for later use
 
       // Fetch the latest changes for the PR's specific branch
       this.loggingService.info(`Fetching latest changes for PR branch: ${prData.head.ref}`);
       try {
-        await this.git.fetchSpecificBranch(prData.head.ref);
+        await git.fetchSpecificBranch(prData.head.ref);
         this.loggingService.info(
           `Successfully fetched latest changes for branch: ${prData.head.ref}`
         );
@@ -149,12 +149,12 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
         // Continue with PR fetching even if fetch fails
       }
 
-      const commits = await this.ghClient.fetchPullRequestCommits(prNumber);
+      const commits = await ghClient.fetchPullRequestCommits(prNumber);
 
       // Fetch detailed information for each commit including files
-      const detailedCommits = await this.ghClient.fetchCommitsDetails(commits);
+      const detailedCommits = await ghClient.fetchCommitsDetails(commits);
 
-      const branches = await this.getBranches(this.git);
+      const branches = await this.getBranches(git);
 
       this.updateWebviewWithPRData(prData, detailedCommits, branches);
     } catch (error) {
@@ -258,9 +258,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   public clearState() {
-    if (!this.webviewView) {
-      return;
-    }
+    this.currentPrData = undefined;
 
     this.loggingService.info('...clear state command invoked...');
 
@@ -270,6 +268,10 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     // Clear commits data from the webview provider
     if (this.commitsProvider) {
       this.commitsProvider.clearState();
+    }
+
+    if (!this.webviewView) {
+      return;
     }
 
     this.webviewView.webview.postMessage({
@@ -411,13 +413,13 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async createPR(targetBranch: string, featureBranch: string, description: string) {
-    if (!this.ghClient) {
-      throw new Error('GitHub client not initialized');
-    }
-
     await commands.executeCommand('git.push');
 
-    const prUrl = this.ghClient.createPullRequestUrl(targetBranch, featureBranch, description);
+    const prUrl = this.prCloneService.ghClient.createPullRequestUrl(
+      targetBranch,
+      featureBranch,
+      description
+    );
     await commands.executeCommand('vscode.open', prUrl);
   }
 


### PR DESCRIPTION
## What changed
- rebuild PR clone sub-services when the selected repository identity changes
- preserve registered cleanup callbacks across rebuilds
- make providers resolve Git and GitHub clients lazily
- clear stale PR state and refresh repository info in an already-open webview
- add reinitialization/provider tests and multi-root documentation

## Why
The one-shot initializer kept using the first repository selected in a multi-root workspace, causing later GitHub requests and Git operations to target the wrong repo.

## Validation
- typecheck, lint, compile, and test compilation passed
- 216 unit tests passed