### PR TITLE
fix: Use supported status bar background colors

### DIFF
--- a/docs/switch-mode.md
+++ b/docs/switch-mode.md
@@ -26,7 +26,9 @@ For rebase, `autoStashAndPop` and `autoStashAndApply` are treated as "Auto stash
 
 ## Status Bar
 
-The status bar item shows the current mode and opens the same mode picker. Hide it with:
+The status bar item shows the current mode and opens the same mode picker. Manual mode uses
+the normal status bar background, while automatic modes use the warning background to remain
+visually distinct. Hide the item with:
 
 ```json
 "git-smart-checkout.showStatusBar": false

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -18,6 +18,14 @@ import {
 } from '../configuration/extensionConfig';
 import { AnalyticsEvent, capture } from '../analytics/analytics';
 
+export function getStatusBarBackgroundColor(
+  mode: TAutoStashModeConfig
+): ThemeColor | undefined {
+  return mode === AUTO_STASH_MODE_MANUAL
+    ? undefined
+    : new ThemeColor('statusBarItem.warningBackground');
+}
+
 export class StatusBarManager implements Disposable {
   private statusBarItem: StatusBarItem;
   private configManager: ConfigurationManager;
@@ -41,12 +49,7 @@ export class StatusBarManager implements Disposable {
     this.statusBarItem.text = `${modeDetails.icon} ${modeDetails.briefLabel}`;
     this.statusBarItem.tooltip = `${EXTENSION_NAME}\nCurrent mode: ${modeDetails.label}\nClick to switch modes`;
 
-    const statusBarColor =
-      config.mode === AUTO_STASH_MODE_MANUAL
-        ? 'statusBarItem.descriptionForeground'
-        : 'statusBarItem.warningBackground';
-
-    this.statusBarItem.backgroundColor = new ThemeColor(statusBarColor);
+    this.statusBarItem.backgroundColor = getStatusBarBackgroundColor(config.mode);
 
     if (config.showStatusBar) {
       this.statusBarItem.show();
@@ -69,7 +72,7 @@ export class StatusBarManager implements Disposable {
     });
 
     const selection = await window.showQuickPick(items, {
-      title: 'Select Auto Stash Checkout  Mode',
+      title: 'Select Auto Stash Checkout Mode',
       placeHolder: 'Choose the operating mode for your extension',
     });
 
@@ -77,7 +80,7 @@ export class StatusBarManager implements Disposable {
       return;
     }
 
-    this.loggingService.info(`Auto Stash Checkout  Mode: ${selection?.label}`);
+    this.loggingService.info(`Auto Stash Checkout Mode: ${selection?.label}`);
 
     const [_, ...rest] = selection.label.split(' ');
     const newModeLabel = rest.join(' ');

--- a/src/test/unit/statusBarManager.test.ts
+++ b/src/test/unit/statusBarManager.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert';
+
+import { ThemeColor } from 'vscode';
+import {
+  AUTO_STASH_MODE_APPLY,
+  AUTO_STASH_MODE_BRANCH,
+  AUTO_STASH_MODE_MANUAL,
+  AUTO_STASH_MODE_POP,
+} from '../../configuration/extensionConfig';
+import { getStatusBarBackgroundColor } from '../../statusBar/statusBarManager';
+
+describe('getStatusBarBackgroundColor', () => {
+  it('uses the default status bar background in manual mode', () => {
+    assert.strictEqual(getStatusBarBackgroundColor(AUTO_STASH_MODE_MANUAL), undefined);
+  });
+
+  for (const mode of [
+    AUTO_STASH_MODE_BRANCH,
+    AUTO_STASH_MODE_POP,
+    AUTO_STASH_MODE_APPLY,
+  ] as const) {
+    it(`uses the warning background in ${mode} mode`, () => {
+      const color = getStatusBarBackgroundColor(mode);
+
+      assert.ok(color instanceof ThemeColor);
+      assert.strictEqual(color.id, 'statusBarItem.warningBackground');
+    });
+  }
+});


### PR DESCRIPTION
## What changed
- restore the default background in manual mode
- keep the supported warning background for automatic modes
- fix the duplicate-space picker and log text
- add focused theme-color tests and update mode documentation

## Why
VS Code ignores `statusBarItem.descriptionForeground` when assigned as a status bar background color.

## Validation
- `yarn compile` passed
- 215 unit tests passed
- focused status bar tests passed