### PR TITLE
fix: Treat temp-worktree clone cancellation normally

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -35,6 +35,7 @@ When conflicts occur during cherry-picking, you can:
 - Cancel the process and restore the original state.
 
 The process is tracked with progress indicators and can be safely cancelled.
+In temporary-worktree mode, cancellation is reported as a normal outcome, and the temporary branch and worktree are cleaned up.
 
 ## Related Settings
 

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -15,6 +15,19 @@ import { CommitsGenerator } from '../utils/commitsGenerator';
 
 const TEMP_WORKDIR_PREFIX = `${EXTENSION_NAME}-pr-clone`;
 
+export class OperationCancelledError extends Error {
+  constructor() {
+    super('PR clone cancelled');
+    this.name = 'OperationCancelledError';
+  }
+}
+
+function throwIfCancellationRequested(token: CancellationToken): void {
+  if (token.isCancellationRequested) {
+    throw new OperationCancelledError();
+  }
+}
+
 export class PrCloneTempWorktreeService extends PrCloneServiceBase {
   private tempWorkspacePath?: string;
   private tempGit?: GitExecutor;
@@ -41,17 +54,13 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
             progress.report({ message: 'Creating temporary worktree...' });
             tempPath = await this.createTempWorktree(data.targetBranch);
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 2: Pull all branches
             progress.report({ message: 'Fetching latest branches...' });
             await this.fetchAllBranches();
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 3: Create and validate branch name
             progress.report({ message: 'Creating feature branch...' });
@@ -61,25 +70,19 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
             );
             createdBranchName = finalBranchName;
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 4: Cherry-pick commits
             progress.report({ message: 'Cherry-picking selected commits...' });
             await this.cherryPickCommits(data.selectedCommits, token);
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 5: Push branch to GitHub
             progress.report({ message: 'Pushing branch to GitHub...' });
             await this.tempGit?.pushBranchToGitHub(finalBranchName);
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 6: Create PR
             progress.report({ message: 'Creating pull request...' });
@@ -91,9 +94,7 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
               data.isDraft
             );
 
-            if (token.isCancellationRequested) {
-              throw new Error('Cancel operation');
-            }
+            throwIfCancellationRequested(token);
 
             // Step 7: Show success notification
             const openAction = await window.showInformationMessage(
@@ -114,7 +115,11 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
         }
       );
     } catch (error) {
-      this.loggingService.error(`PR cloning failed: ${error}`);
+      if (error instanceof OperationCancelledError) {
+        this.loggingService.info('PR clone cancelled by user');
+      } else {
+        this.loggingService.error(`PR cloning failed: ${error}`);
+      }
 
       // Clean up created branch if it exists and operation failed
       if (createdBranchName && this.tempWorkspacePath) {
@@ -128,9 +133,13 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
         }
       }
 
-      window.showErrorMessage(
-        `Failed to clone PR: ${error instanceof Error ? error.message : error}`
-      );
+      if (error instanceof OperationCancelledError) {
+        window.showInformationMessage('PR clone cancelled');
+      } else {
+        window.showErrorMessage(
+          `Failed to clone PR: ${error instanceof Error ? error.message : error}`
+        );
+      }
     } finally {
       // Step 9: Cleanup temp worktree
       if (tempPath) {
@@ -216,9 +225,7 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
 
     this.loggingService.info('Cherry-picking commits in chronological order:', sortedCommits);
 
-    if (token.isCancellationRequested) {
-      throw new Error('Cancel operation');
-    }
+    throwIfCancellationRequested(token);
 
     try {
       await this.tempGit.cherryPick(sortedCommits, false, 'skip');

--- a/src/test/unit/prCloneTempWorktreeService.test.ts
+++ b/src/test/unit/prCloneTempWorktreeService.test.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import {
+  OperationCancelledError,
+  PrCloneTempWorktreeService,
+} from '../../services/prCloneTempWorktreeService';
+import { PrCloneData } from '../../services/prCloneService';
+
+function makeCloneData(): PrCloneData {
+  return {
+    prData: {
+      number: 42,
+      title: 'Test PR',
+      body: '',
+      head: {
+        ref: 'source',
+        sha: 'abc123',
+        repo: { full_name: 'owner/repo', clone_url: '' },
+      },
+      base: { ref: 'main', repo: { full_name: 'owner/repo' } },
+      html_url: 'https://github.com/owner/repo/pull/42',
+      labels: [],
+      assignees: [],
+    },
+    targetBranch: 'main',
+    featureBranch: 'feature',
+    description: '',
+    selectedCommits: ['abc123'],
+    isDraft: false,
+  };
+}
+
+describe('PrCloneTempWorktreeService cancellation', () => {
+  it('uses a typed cancellation sentinel', () => {
+    const error = new OperationCancelledError();
+
+    assert.ok(error instanceof Error);
+    assert.strictEqual(error.name, 'OperationCancelledError');
+    assert.strictEqual(error.message, 'PR clone cancelled');
+  });
+
+  it('reports cancellation as information and preserves branch and worktree cleanup', async () => {
+    const tempPath = '/tmp/git-smart-checkout-pr-clone-test';
+    const deletedBranches: string[] = [];
+    const removedWorktrees: string[] = [];
+    const infoMessages: string[] = [];
+    const errorMessages: string[] = [];
+    const logErrors: string[] = [];
+    const logInfo: string[] = [];
+    const cleanupActions: string[] = [];
+    let cancelled = false;
+
+    const git = {
+      worktreeRemove: async (worktreePath: string) => {
+        removedWorktrees.push(worktreePath);
+      },
+      worktreeList: async () => [],
+    } as unknown as GitExecutor;
+    const loggingService = {
+      error: (message: string) => logErrors.push(message),
+      warn: () => {},
+      info: (message: string) => logInfo.push(message),
+      debug: () => {},
+    } as unknown as LoggingService;
+    const service = new PrCloneTempWorktreeService(
+      git,
+      {} as GitHubClient,
+      loggingService
+    );
+
+    (service as any).createTempWorktree = async () => {
+      (service as any).tempWorkspacePath = tempPath;
+      (service as any).tempGit = {
+        deleteLocalBranch: async (branchName: string) => {
+          deletedBranches.push(branchName);
+        },
+      };
+      return tempPath;
+    };
+    (service as any).fetchAllBranches = async () => {};
+    (service as any).createUniqueFeatureBranch = async () => {
+      cancelled = true;
+      return 'feature';
+    };
+    service.addCleanUpActions({
+      cleanUpActionBegin: () => cleanupActions.push('begin'),
+      cleanUpActionEnd: () => cleanupActions.push('end'),
+    });
+
+    const originalWithProgress = vscode.window.withProgress.bind(vscode.window);
+    const originalShowInformationMessage =
+      vscode.window.showInformationMessage.bind(vscode.window);
+    const originalShowErrorMessage = vscode.window.showErrorMessage.bind(vscode.window);
+
+    (vscode.window as any).withProgress = async (
+      _options: vscode.ProgressOptions,
+      task: (
+        progress: vscode.Progress<{ message?: string; increment?: number }>,
+        token: vscode.CancellationToken
+      ) => Promise<void>
+    ) => task(
+      { report: () => {} },
+      {
+        get isCancellationRequested() {
+          return cancelled;
+        },
+        onCancellationRequested: () => ({ dispose: () => {} }),
+      } as vscode.CancellationToken
+    );
+    (vscode.window as any).showInformationMessage = async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    };
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      errorMessages.push(message);
+      return undefined;
+    };
+
+    try {
+      await service.clonePR(makeCloneData());
+
+      assert.deepStrictEqual(infoMessages, ['PR clone cancelled']);
+      assert.deepStrictEqual(errorMessages, []);
+      assert.deepStrictEqual(logErrors, []);
+      assert.ok(logInfo.includes('PR clone cancelled by user'));
+      assert.deepStrictEqual(deletedBranches, ['feature']);
+      assert.deepStrictEqual(removedWorktrees, [tempPath]);
+      assert.deepStrictEqual(cleanupActions, ['begin', 'end']);
+    } finally {
+      (vscode.window as any).withProgress = originalWithProgress;
+      (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+      (service as any).tempWorkspacePath = undefined;
+      service.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- introduce a typed cancellation sentinel for temporary-worktree PR cloning
- report user cancellation as information instead of an error
- retain branch, worktree, and registered cleanup behavior
- add cancellation messaging/cleanup tests and update PR clone docs

## Why
A normal user cancellation was displayed as `Failed to clone PR: Cancel operation`, making a successful abort look like a failure.

Related to #71.

## Validation
- typecheck, lint, and compile passed
- focused cancellation tests passed
- 213 unit tests passed