### PR TITLE
fix: Preserve GitHub PR commit order

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -25,7 +25,7 @@ The GitHub PR Clone feature creates a new pull request by cherry-picking selecte
 6. Select the commits to cherry-pick.
 7. Let the extension create the branch, cherry-pick commits, and create the new PR or draft PR.
 
-During the cherry-pick process, the extension stashes uncommitted workspace changes, switches to the target branch, pulls the latest changes, creates a feature branch, and cherry-picks the selected commits one by one.
+During the cherry-pick process, the extension stashes uncommitted workspace changes, switches to the target branch, pulls the latest changes, creates a feature branch, and cherry-picks the selected commits one by one. Selected commits retain the topological order returned by GitHub, including when multiple commits have identical timestamps.
 
 ## Conflict Handling
 

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -628,16 +628,6 @@ export class GitExecutor {
     await this.#execGitCommand(['push', '-u', 'origin', branchName]);
   }
 
-  async getCommitTimestamp(sha: string) {
-    try {
-      const { stdout } = await this.#execGitCommand(['show', '--format=%ct', '--no-patch', sha]);
-      const timestamp = parseInt(stdout.trim().replace(/"/g, ''));
-      return { sha, timestamp };
-    } catch (error) {
-      return { sha, timestamp: 0 };
-    }
-  }
-
   async tagExists(tagName: string): Promise<boolean> {
     try {
       await this.#execGitCommand(['show-ref', '--verify', '--quiet', `refs/tags/${tagName}`]);

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -262,9 +262,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       );
 
       // create commits generator
-      this.commitGenerator = new CommitsGenerator(this.git, data.selectedCommits)[
-        Symbol.asyncIterator
-      ]();
+      this.commitGenerator = new CommitsGenerator(data.selectedCommits)[Symbol.asyncIterator]();
 
       // start cherry picking
       this.cherryPickNext();

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -11,7 +11,6 @@ import { GitHubPR } from '../types/dataTypes';
 import { PrCloneData } from './prCloneService';
 import { setContextShowPRClone, setContextShowPRCommits } from '../utils/setContext';
 import { PrCloneServiceBase } from './prCloneServiceBase';
-import { CommitsGenerator } from '../utils/commitsGenerator';
 
 const TEMP_WORKDIR_PREFIX = `${EXTENSION_NAME}-pr-clone`;
 
@@ -209,22 +208,18 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
 
     this.loggingService.info('cherryPickCommits:', commitShas);
 
-    const sortedCommits: string[] = [];
-    for await (const item of new CommitsGenerator(this.git, commitShas)[Symbol.asyncIterator]()) {
-      sortedCommits.push(item.sha);
-    }
-
-    this.loggingService.info('Cherry-picking commits in chronological order:', sortedCommits);
+    const orderedCommits = [...commitShas];
+    this.loggingService.info('Cherry-picking commits in GitHub API order:', orderedCommits);
 
     if (token.isCancellationRequested) {
       throw new Error('Cancel operation');
     }
 
     try {
-      await this.tempGit.cherryPick(sortedCommits, false, 'skip');
+      await this.tempGit.cherryPick(orderedCommits, false, 'skip');
     } catch (error) {
       throw new Error(
-        `Failed to cherry-pick commit${sortedCommits.length > 1 ? 's' : ''}: ${error}`
+        `Failed to cherry-pick commit${orderedCommits.length > 1 ? 's' : ''}: ${error}`
       );
     }
   }

--- a/src/test/unit/commitOrder.test.ts
+++ b/src/test/unit/commitOrder.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert';
+import { CancellationToken } from 'vscode';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import { PrCloneTempWorktreeService } from '../../services/prCloneTempWorktreeService';
+import { orderSelectedCommits } from '../../utils/commitOrder';
+import { CommitGeneratorItem, CommitsGenerator } from '../../utils/commitsGenerator';
+
+async function collect(generator: CommitsGenerator): Promise<CommitGeneratorItem[]> {
+  const items: CommitGeneratorItem[] = [];
+  for await (const item of generator) {
+    items.push(item);
+  }
+  return items;
+}
+
+describe('PR commit ordering', () => {
+  it('filters selections using GitHub API order rather than selection order', () => {
+    const apiCommits = [{ sha: 'parent' }, { sha: 'middle' }, { sha: 'child' }];
+
+    assert.deepStrictEqual(orderSelectedCommits(apiCommits, ['child', 'parent']), [
+      'parent',
+      'child',
+    ]);
+  });
+
+  it('preserves input order and progress for commits with identical timestamps', async () => {
+    const commitsWithTheSameTimestamp = ['parent', 'middle', 'child'];
+
+    assert.deepStrictEqual(await collect(new CommitsGenerator(commitsWithTheSameTimestamp)), [
+      { sha: 'parent', current: 1, total: 3 },
+      { sha: 'middle', current: 2, total: 3 },
+      { sha: 'child', current: 3, total: 3 },
+    ]);
+  });
+
+  it('passes selected commits to the temp-worktree cherry-pick in input order', async () => {
+    const cherryPicks: Array<string | string[]> = [];
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      {} as GitHubClient,
+      { info: () => undefined } as unknown as LoggingService
+    );
+    const testableService = service as unknown as {
+      tempGit: GitExecutor;
+      cherryPickCommits(commitShas: string[], token: CancellationToken): Promise<void>;
+    };
+    testableService.tempGit = {
+      cherryPick: async (commits: string | string[]) => {
+        cherryPicks.push(commits);
+      },
+    } as GitExecutor;
+
+    await testableService.cherryPickCommits(
+      ['parent', 'middle', 'child'],
+      { isCancellationRequested: false } as CancellationToken
+    );
+
+    assert.deepStrictEqual(cherryPicks, [['parent', 'middle', 'child']]);
+  });
+});

--- a/src/utils/commitOrder.ts
+++ b/src/utils/commitOrder.ts
@@ -1,0 +1,7 @@
+export function orderSelectedCommits(
+  commits: ReadonlyArray<{ sha: string }>,
+  selectedCommits: readonly string[]
+): string[] {
+  const selected = new Set(selectedCommits);
+  return commits.filter((commit) => selected.has(commit.sha)).map((commit) => commit.sha);
+}

--- a/src/utils/commitsGenerator.ts
+++ b/src/utils/commitsGenerator.ts
@@ -1,35 +1,19 @@
-import { GitExecutor } from '../common/git/gitExecutor';
-
 export interface CommitGeneratorItem {
   sha: string;
-  timestamp: number;
   current: number;
   total: number;
 }
 
 export class CommitsGenerator {
-  constructor(
-    private git: GitExecutor,
-    private commits: string[]
-  ) {}
+  constructor(private commits: readonly string[]) {}
 
   async *[Symbol.asyncIterator]() {
-    // Sort commits by creation date to ensure proper chronological order
-    const commitDetails = await Promise.all(
-      this.commits.map(async (sha) => this.git.getCommitTimestamp(sha))
-    );
-
-    const sortedCommits: CommitGeneratorItem[] = commitDetails
-      .sort((a, b) => a.timestamp - b.timestamp)
-      .map((commit, i, arr) => ({
-        sha: commit.sha,
-        timestamp: commit.timestamp,
-        current: i + 1,
-        total: arr.length,
-      }));
-
-    for (const item of sortedCommits) {
-      yield item;
+    for (const [index, sha] of this.commits.entries()) {
+      yield {
+        sha,
+        current: index + 1,
+        total: this.commits.length,
+      };
     }
   }
 }

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -10,6 +10,7 @@ import { LoggingService } from '../logging/loggingService';
 import { PrCloneData, PrCloneService } from '../services/prCloneService';
 import { GitHubCommit, GitHubPR } from '../types/dataTypes';
 import { WebviewCommand } from '../types/webviewCommands';
+import { orderSelectedCommits } from '../utils/commitOrder';
 import { getNonce } from '../utils/getNonce';
 import { PrCommitsWebViewProvider } from './PrCommitsWebViewProvider';
 import {
@@ -22,6 +23,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   private webviewView?: WebviewView;
   private commitsProvider?: PrCommitsWebViewProvider;
   private currentPrData?: GitHubPR;
+  private currentCommits: GitHubCommit[] = [];
 
   private git?: GitExecutor;
   private ghClient?: GitHubClient;
@@ -204,6 +206,8 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private updateWebviewWithPRData(prData: GitHubPR, commits: GitHubCommit[], branches: string[]) {
+    this.currentCommits = commits;
+
     if (!this.webviewView) {
       return;
     }
@@ -246,18 +250,21 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   public updateSelectedCommits(selectedCommits: string[]) {
-    this.loggingService.debug('selectedCommits', selectedCommits);
+    const orderedSelectedCommits = orderSelectedCommits(this.currentCommits, selectedCommits);
+    this.loggingService.debug('selectedCommits', orderedSelectedCommits);
     if (!this.webviewView) {
       return;
     }
 
     this.webviewView.webview.postMessage({
       command: WebviewCommand.UPDATE_SELECTED_COMMITS,
-      selectedCommits,
+      selectedCommits: orderedSelectedCommits,
     });
   }
 
   public clearState() {
+    this.currentCommits = [];
+
     if (!this.webviewView) {
       return;
     }
@@ -292,7 +299,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
         targetBranch: data.targetBranch,
         featureBranch: data.featureBranch,
         description: data.description,
-        selectedCommits: data.selectedCommits,
+        selectedCommits: orderSelectedCommits(this.currentCommits, data.selectedCommits),
         isDraft: data.isDraft || false,
       };
 

--- a/src/view/PrCommitsWebViewProvider.ts
+++ b/src/view/PrCommitsWebViewProvider.ts
@@ -6,6 +6,7 @@ import { EXTENSION_NAME } from '../const';
 import { LoggingService } from '../logging/loggingService';
 import { GitHubCommit } from '../types/dataTypes';
 import { WebviewCommand } from '../types/webviewCommands';
+import { orderSelectedCommits } from '../utils/commitOrder';
 import { getNonce } from '../utils/getNonce';
 import { PrCloneService } from '../services/prCloneService';
 
@@ -35,7 +36,10 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
 
       if (savedState) {
         this.commits = savedState.commits || [];
-        this.selectedCommits = savedState.selectedCommits || [];
+        this.selectedCommits = orderSelectedCommits(
+          this.commits,
+          savedState.selectedCommits || []
+        );
       }
     } catch (error) {
       this.loggingService.warn(`Failed to load persisted commits state: ${error}`);
@@ -156,6 +160,7 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
     } else {
       this.selectedCommits = [...this.selectedCommits, sha];
     }
+    this.selectedCommits = orderSelectedCommits(this.commits, this.selectedCommits);
 
     this.savePersistedState();
     // Send updated commits due to user checkbox toggle


### PR DESCRIPTION
## What changed
- filter selected commits against the ordered GitHub API response
- preserve that order in both webviews and both clone implementations
- remove timestamp sorting and the unused timestamp lookup
- add order/progress/temp-worktree tests and document topological replay

## Why
Sorting by committer timestamp could reorder commits with identical or unavailable timestamps, creating avoidable cherry-pick conflicts.

## Validation
- `yarn compile` passed
- focused order tests passed
- 214 unit tests passed
- `git diff --check` passed