### PR TITLE
fix: Address assorted review defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Website: https://git-smart-checkout.vradchuk.info
 
 ## Requirements
 
-- Git **2.38** or newer (required for conflict pre-flight detection in auto stash and pop/apply modes)
+- Git **2.38** or newer is recommended for conflict pre-flight detection in auto stash and pop/apply modes. On older Git versions, the extension logs that the preview is unavailable and continues without it.
 
 ## Info
 
@@ -57,6 +57,7 @@ Click a setting ID to open that setting in VS Code.
 | ⚙️ [`git-smart-checkout.branchTemplate`](vscode://settings/git-smart-checkout.branchTemplate) (Branch template) | `string` | Template for **Create Branch from Template ...**. Supports `{jira-key}`, `{jira-title[:limit[:separator]]}`, `{f:...}`, `{b:...}`, `{r:...}`, `{s:...}`. Example: `vradchuk/{jira-key}-{jira-title:25:-}-{r:1}`. |
 | ⚙️ [`git-smart-checkout.jira.domain`](vscode://settings/git-smart-checkout.jira.domain) (Jira domain) | `string` | Jira Cloud host (e.g. `your-company.atlassian.net`). Required when the branch template uses Jira tokens. |
 | ⚙️ [`git-smart-checkout.jira.username`](vscode://settings/git-smart-checkout.jira.username) (Jira username) | `string` | Atlassian account username for Jira API authentication (usually your Atlassian account email). |
+| ⚙️ [`git-smart-checkout.jira.email`](vscode://settings/git-smart-checkout.jira.email) (Deprecated Jira email) | `string` | Deprecated compatibility fallback used only when `jira.username` is empty. Migrate to `git-smart-checkout.jira.username`. |
 | ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | Jira API token. See setting description for unscoped vs scoped token guidance. |
 | ⚙️ [`git-smart-checkout.pushTagWithoutConfirmation`](vscode://settings/git-smart-checkout.pushTagWithoutConfirmation) (Push tag without confirmation) | `boolean` | Pushes the created Git tag to the remote without asking for confirmation. |
 | ⚙️ [`git-smart-checkout.tagRemote`](vscode://settings/git-smart-checkout.tagRemote) (Tag remote) | `string` | Git remote used when pushing created tags. |

--- a/package.json
+++ b/package.json
@@ -339,6 +339,12 @@
           "default": "",
           "description": "Atlassian account username for Jira API authentication (usually the email address of your Atlassian account)."
         },
+        "git-smart-checkout.jira.email": {
+          "type": "string",
+          "default": "",
+          "description": "Deprecated Jira account email used for API authentication.",
+          "deprecationMessage": "Use git-smart-checkout.jira.username instead. This setting remains as a compatibility fallback."
+        },
         "git-smart-checkout.jira.token": {
           "type": "string",
           "default": "",
@@ -400,7 +406,7 @@
     "@types/node": "16.x",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/vscode": "^1.74.0",
+    "@types/vscode": "1.74.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vscode/test-cli": "^0.0.9",

--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -46,7 +46,11 @@ export class CheckoutToCommand extends BaseCommand {
     try {
       const git = await this.getGitExecutor(this.vscodeGitProvider);
 
-      const { currentBranch, selection, branchList } = await this.getSelectedOption(git);
+      const selectedOption = await this.getSelectedOption(git);
+      if (!selectedOption) {
+        return;
+      }
+      const { currentBranch, selection, branchList } = selectedOption;
 
       const newBranch = await this.getTargetBranch(git, selection, branchList);
 
@@ -96,7 +100,7 @@ export class CheckoutToCommand extends BaseCommand {
 
   async getSelectedOption(
     git: GitExecutor
-  ): Promise<{ currentBranch: string; selection: string; branchList: IGitRef[] }> {
+  ): Promise<{ currentBranch: string; selection: string; branchList: IGitRef[] } | undefined> {
     let currentBranch = '';
     try {
       currentBranch = await git.getCurrentBranch();
@@ -272,7 +276,7 @@ export class CheckoutToCommand extends BaseCommand {
     enrichSub?.dispose();
 
     if (!picked) {
-      throw new Error();
+      return undefined;
     }
 
     if (picked.kind === 'action') {

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -8,6 +8,23 @@ import { execCommand } from '../../utils/execCommand';
 import { VscodeGitProvider } from './vscodeGitProvider';
 import { IGitRef, IGitWorktree, TUpstreamTrack } from './types';
 
+export function parseGitVersion(output: string): [number, number, number] | undefined {
+  const match = output.match(/\bgit version (\d+)\.(\d+)(?:\.(\d+))?/i);
+  if (!match) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+export function supportsMergeTreeWriteTree(output: string): boolean {
+  const version = parseGitVersion(output);
+  if (!version) {
+    return false;
+  }
+  const [major, minor] = version;
+  return major > 2 || (major === 2 && minor >= 38);
+}
+
 export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   const worktrees: IGitWorktree[] = [];
   let current: IGitWorktree | undefined;
@@ -68,6 +85,8 @@ export class GitExecutor {
   #repositoryPath;
   #logService;
   #vscodeGitProvider: VscodeGitProvider | undefined;
+  #mergeTreeSupport?: Promise<boolean>;
+  #mergeTreeFallbackLogged = false;
 
   constructor(repositoryPath: string, logService: LoggingService, vscodeGitProvider?: VscodeGitProvider) {
     this.#repositoryPath = repositoryPath;
@@ -469,6 +488,16 @@ export class GitExecutor {
   // `merge-tree` exits non-zero and writes conflicting paths to stdout when conflicts
   // are found, so we capture stdout from both the success and error paths.
   async getStashConflictPreview(targetRef: string): Promise<string[]> {
+    if (!(await this.#supportsMergeTreeWriteTree())) {
+      if (!this.#mergeTreeFallbackLogged) {
+        this.#logService.warn(
+          'Skipping stash conflict preview because Git 2.38 or newer is required for merge-tree --write-tree.'
+        );
+        this.#mergeTreeFallbackLogged = true;
+      }
+      return [];
+    }
+
     const { stdout: stashSha } = await this.#execGitCommand(['stash', 'create']);
     const sha = stashSha.trim();
     if (!sha) {
@@ -484,6 +513,13 @@ export class GitExecutor {
       const lines = out.split('\n').map((l: string) => l.trim()).filter(Boolean);
       return lines.slice(1); // skip the tree OID on the first line
     }
+  }
+
+  async #supportsMergeTreeWriteTree(): Promise<boolean> {
+    this.#mergeTreeSupport ??= this.#execGitCommand(['--version'])
+      .then(({ stdout }) => supportsMergeTreeWriteTree(stdout))
+      .catch(() => false);
+    return this.#mergeTreeSupport;
   }
 
   async getConflictedFiles() {
@@ -588,6 +624,10 @@ export class GitExecutor {
   async worktreeRemove(workTreePath: string, force = true) {
     const { stdout } = await this.#execGitCommand(['worktree', 'remove', workTreePath, ...(force ? ['--force'] : [])]);
     return stdout;
+  }
+
+  async worktreePrune(): Promise<void> {
+    await this.#execGitCommand(['worktree', 'prune']);
   }
 
   async worktreeAdd(workTreePath: string, targetBranch: string) {

--- a/src/common/vscode/webviewState.ts
+++ b/src/common/vscode/webviewState.ts
@@ -1,0 +1,18 @@
+export interface WebviewStateApi<State> {
+  getState(): State | undefined;
+  setState(state: State): State;
+}
+
+export function readWebviewState<State>(
+  api: WebviewStateApi<State>,
+  fallback: State
+): State {
+  return api.getState() ?? fallback;
+}
+
+export function writeWebviewState<State>(
+  api: WebviewStateApi<State>,
+  state: State
+): void {
+  api.setState(state);
+}

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -14,35 +14,17 @@ export class ConfigurationManager {
   private config: ExtensionConfig;
 
   constructor() {
-    const vscodeConfig = workspace.getConfiguration(EXTENSION_NAME);
-
-    this.config = {
-      mode: vscodeConfig.get('mode', AUTO_STASH_MODE_MANUAL),
-      useFastBranchList: vscodeConfig.get('useFastBranchList', true),
-      showStatusBar: vscodeConfig.get('showStatusBar', true),
-      defaultTargetBranch: vscodeConfig.get('defaultTargetBranch', 'main'),
-      defaultWorktreeDirectory: vscodeConfig.get('defaultWorktreeDirectory', ''),
-      prBranchPrefix: vscodeConfig.get('prBranchPrefix', ''),
-      useInPlaceCherryPick: vscodeConfig.get('useInPlaceCherryPick', true),
-      preferredRefs: vscodeConfig.get('preferredRefs', {} as PreferredRefsMap),
-      logging: {
-        enabled: vscodeConfig.get('logging.enabled', true),
-      },
-      telemetry: {
-        enabled: vscodeConfig.get('telemetry.enabled', true),
-      },
-      tagTemplate: vscodeConfig.get('tagTemplate', ''),
-      pushTagWithoutConfirmation: vscodeConfig.get('pushTagWithoutConfirmation', false),
-      tagRemote: vscodeConfig.get('tagRemote', 'origin'),
-      branchTemplate: vscodeConfig.get('branchTemplate', ''),
-      jira: this.readJiraConfig(vscodeConfig),
-    };
+    this.config = this.readConfig();
   }
 
   public reload() {
+    this.config = this.readConfig();
+  }
+
+  private readConfig(): ExtensionConfig {
     const vscodeConfig = workspace.getConfiguration(EXTENSION_NAME);
 
-    this.config = {
+    return {
       mode: vscodeConfig.get('mode', AUTO_STASH_MODE_MANUAL),
       useFastBranchList: vscodeConfig.get('useFastBranchList', true),
       showStatusBar: vscodeConfig.get('showStatusBar', true),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -304,6 +304,7 @@ export function activate(context: vscode.ExtensionContext) {
     telemetryChangeListener,
     statusBarManager,
     logService,
+    { dispose: () => prCloneService.dispose() },
     clonePullRequestCommand,
     updateSelectedCommitsCommand,
     showNotificationCommand,
@@ -321,11 +322,10 @@ export function activate(context: vscode.ExtensionContext) {
   // Show status bar
   statusBarManager.show();
 
-  // Store command manager in context for testing
-  context.globalState.update('commandManager', commandManager);
+  return { commandManager };
 }
 
 export async function deactivate() {
-  console.log('Extension "my-vscode-extension" is now deactivated!');
+  console.log(`Extension "${EXTENSION_NAME}" is now deactivated!`);
   await shutdownAnalytics();
 }

--- a/src/services/branchTemplateService.ts
+++ b/src/services/branchTemplateService.ts
@@ -143,7 +143,7 @@ export async function resolveBranchTemplate(
     if (!title) {
       ctx.logger.warn('[Create Branch] Jira title token present but no Jira issue title available.');
     }
-    result = result.replace(token.full, value);
+    result = result.replace(token.full, () => value);
   }
 
   const tagCtx: TagTemplateContext = {

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -15,6 +15,23 @@ import { CommitsGenerator } from '../utils/commitsGenerator';
 
 const TEMP_WORKDIR_PREFIX = `${EXTENSION_NAME}-pr-clone`;
 
+export function isExistingExtensionTempWorktree(worktree: string, tempDir: string): boolean {
+  try {
+    if (!fs.existsSync(worktree) || !fs.lstatSync(worktree).isDirectory()) {
+      return false;
+    }
+    const relativePath = path.relative(tempDir, worktree);
+    return (
+      relativePath !== '' &&
+      !relativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativePath) &&
+      path.basename(worktree).startsWith(`${TEMP_WORKDIR_PREFIX}-`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export class PrCloneTempWorktreeService extends PrCloneServiceBase {
   private tempWorkspacePath?: string;
   private tempGit?: GitExecutor;
@@ -263,18 +280,20 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     try {
       this.loggingService.info(`Cleaning up temp worktree: ${tempPath}`);
       await this.git.worktreeRemove(tempPath);
+    } catch (error) {
+      this.loggingService.warn(`Failed to unregister temp worktree: ${error}`);
+    }
 
-      // Ensure directory is removed if it still exists
+    try {
       if (fs.existsSync(tempPath)) {
         fs.rmSync(tempPath, { recursive: true, force: true });
       }
-
-      // Clean up other temporary worktrees if enabled
-      if (cleanUpOtherTempWorktrees) {
-        await this.cleanupOtherTempWorktrees();
-      }
     } catch (error) {
-      this.loggingService.warn(`Failed to cleanup temp worktree: ${error}`);
+      this.loggingService.warn(`Failed to remove temp worktree directory: ${error}`);
+    }
+
+    if (cleanUpOtherTempWorktrees) {
+      await this.cleanupOtherTempWorktrees();
     }
   }
 
@@ -282,21 +301,22 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     try {
       const tempDir = os.tmpdir();
 
+      await this.git.worktreePrune();
+
       // Get list of all git worktrees
       const allWorktrees: string[] = await this.git.worktreeList(true);
-      const tempWorktrees = allWorktrees.filter((worktree) => {
-        return (
-          fs.lstatSync(worktree).isDirectory() &&
-          worktree.includes(tempDir) &&
-          worktree.includes(TEMP_WORKDIR_PREFIX)
-        );
-      });
-      const tempWorktreesPromises = tempWorktrees.map((worktree) =>
-        this.git.worktreeRemove(worktree)
+      const tempWorktrees = allWorktrees.filter((worktree) =>
+        isExistingExtensionTempWorktree(worktree, tempDir)
       );
-
-      // remove all worktrees created by extension
-      await Promise.all(tempWorktreesPromises);
+      await Promise.all(
+        tempWorktrees.map(async (worktree) => {
+          try {
+            await this.git.worktreeRemove(worktree);
+          } catch (error) {
+            this.loggingService.warn(`Failed to cleanup stale temp worktree ${worktree}: ${error}`);
+          }
+        })
+      );
     } catch (error) {
       this.loggingService.warn(`Failed to cleanup other temp worktrees: ${error}`);
     }

--- a/src/services/tagTemplateService.ts
+++ b/src/services/tagTemplateService.ts
@@ -332,13 +332,13 @@ export async function resolveTagTemplate(
     const colonIdx = token.args.indexOf(':');
     if (colonIdx === -1) {
       ctx.logger.warn(`[Create Tag] Malformed file token: ${token.full}`);
-      result = result.replace(token.full, '');
+      result = result.replace(token.full, () => '');
       continue;
     }
     const filePath = token.args.substring(0, colonIdx).trim();
     const jsonPath = token.args.substring(colonIdx + 1).trim();
     const value = await resolveFileToken(filePath, jsonPath, ctx);
-    result = result.replace(token.full, value);
+    result = result.replace(token.full, () => value);
   }
 
   // Step 2: resolve {s:...} tokens (throws ScriptTokenError on failure)
@@ -348,7 +348,7 @@ export async function resolveTagTemplate(
     const stream = colonIdx === -1 ? 'stdout' : token.args.substring(0, colonIdx).trim().toLowerCase();
     const scriptPath = colonIdx === -1 ? token.args.trim() : token.args.substring(colonIdx + 1).trim();
     const value = await resolveScriptToken(stream, scriptPath, ctx);
-    result = result.replace(token.full, value);
+    result = result.replace(token.full, () => value);
   }
 
   // Step 3: resolve {b:...} tokens
@@ -374,7 +374,7 @@ export async function resolveTagTemplate(
         ctx.logger.info(`[Create Tag] Branch regex token found: ${token.args}`);
         value = extractFirstRegexMatch(branch, token.args, ctx.logger);
       }
-      result = result.replace(token.full, value);
+      result = result.replace(token.full, () => value);
     }
   }
 
@@ -391,7 +391,7 @@ export async function resolveTagTemplate(
   const buildCandidate = (suffix: string): string => {
     let candidate = result;
     for (const token of recurringTokens) {
-      candidate = candidate.replace(token.full, suffix);
+      candidate = candidate.replace(token.full, () => suffix);
     }
     return candidate;
   };

--- a/src/test/unit/checkoutToDismissal.test.ts
+++ b/src/test/unit/checkoutToDismissal.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+
+import { CheckoutToCommand } from '../../commands/checkoutToCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { LoggingService } from '../../logging/loggingService';
+import { AutoStashService } from '../../services/autoStashService';
+import { IGitRef } from '../../common/git/types';
+
+class DismissedCheckoutToCommand extends CheckoutToCommand {
+  targetBranchRequested = false;
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {} as GitExecutor;
+  }
+
+  async getSelectedOption(): Promise<undefined> {
+    return undefined;
+  }
+
+  async getTargetBranch(
+    _git: GitExecutor,
+    _selection: string,
+    _branchList: IGitRef[]
+  ): Promise<IGitRef> {
+    this.targetBranchRequested = true;
+    throw new Error('Target branch should not be requested after dismissal.');
+  }
+}
+
+describe('CheckoutToCommand dismissal', () => {
+  it('returns without treating picker dismissal as an error', async () => {
+    const command = new DismissedCheckoutToCommand(
+      {} as ConfigurationManager,
+      {} as LoggingService,
+      {} as AutoStashService
+    );
+
+    await command.execute();
+
+    assert.strictEqual(command.targetBranchRequested, false);
+  });
+});

--- a/src/test/unit/configurationManager.test.ts
+++ b/src/test/unit/configurationManager.test.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { EXTENSION_NAME } from '../../const';
+
+describe('ConfigurationManager', () => {
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+
+  afterEach(async () => {
+    await config.update('jira.username', undefined, vscode.ConfigurationTarget.Global);
+    await config.update('jira.email', undefined, vscode.ConfigurationTarget.Global);
+  });
+
+  it('uses deprecated jira.email only when jira.username is empty', async () => {
+    await config.update('jira.username', '', vscode.ConfigurationTarget.Global);
+    await config.update('jira.email', 'legacy@example.com', vscode.ConfigurationTarget.Global);
+
+    const manager = new ConfigurationManager();
+    assert.strictEqual(manager.get().jira.username, 'legacy@example.com');
+
+    await config.update('jira.username', 'current@example.com', vscode.ConfigurationTarget.Global);
+    manager.reload();
+
+    assert.strictEqual(manager.get().jira.username, 'current@example.com');
+  });
+});

--- a/src/test/unit/extensionActivation.test.ts
+++ b/src/test/unit/extensionActivation.test.ts
@@ -1,0 +1,24 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { EXTENSION_NAME } from '../../const';
+
+interface ExtensionApi {
+  commandManager: {
+    getCommand(commandId: string): unknown;
+  };
+}
+
+describe('extension activation API', () => {
+  it('exposes the command manager without persisting it in global state', async () => {
+    const extension = vscode.extensions.all.find(
+      (candidate) => candidate.packageJSON?.name === EXTENSION_NAME
+    );
+    assert.ok(extension);
+
+    const api = await extension.activate() as ExtensionApi;
+
+    assert.ok(api.commandManager);
+    assert.ok(api.commandManager.getCommand(`${EXTENSION_NAME}.checkoutTo`));
+  });
+});

--- a/src/test/unit/getGitExecutor.test.ts
+++ b/src/test/unit/getGitExecutor.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveGitRepositoryRoot } from '../../utils/getGitExecutor';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('resolveGitRepositoryRoot', () => {
+  const tempPaths: string[] = [];
+
+  afterEach(() => {
+    for (const tempPath of tempPaths.splice(0)) {
+      fs.rmSync(tempPath, { recursive: true, force: true });
+    }
+  });
+
+  function makeDirectory(prefix: string): string {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempPaths.push(directory);
+    return directory;
+  }
+
+  function initRepository(directory: string): void {
+    execFileSync('git', ['init', '-b', 'main'], { cwd: directory, stdio: 'pipe' });
+  }
+
+  it('resolves the repository root from an opened subdirectory', async () => {
+    const repository = makeDirectory('gsc-root-');
+    initRepository(repository);
+    const subdirectory = path.join(repository, 'packages', 'app');
+    fs.mkdirSync(subdirectory, { recursive: true });
+
+    assert.strictEqual(
+      await resolveGitRepositoryRoot(subdirectory, mockLogService),
+      fs.realpathSync(repository)
+    );
+  });
+
+  it('prefers a nested repository when its subdirectory is selected', async () => {
+    const outerRepository = makeDirectory('gsc-outer-');
+    initRepository(outerRepository);
+    const nestedRepository = path.join(outerRepository, 'vendor', 'nested');
+    fs.mkdirSync(nestedRepository, { recursive: true });
+    initRepository(nestedRepository);
+    const nestedSubdirectory = path.join(nestedRepository, 'src');
+    fs.mkdirSync(nestedSubdirectory);
+
+    assert.strictEqual(
+      await resolveGitRepositoryRoot(nestedSubdirectory, mockLogService),
+      fs.realpathSync(nestedRepository)
+    );
+  });
+
+  it('reports a clear error for a folder outside a repository', async () => {
+    const directory = makeDirectory('gsc-not-repo-');
+
+    await assert.rejects(
+      () => resolveGitRepositoryRoot(directory, mockLogService),
+      /is not inside a Git repository/
+    );
+  });
+});

--- a/src/test/unit/gitVersion.test.ts
+++ b/src/test/unit/gitVersion.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  GitExecutor,
+  parseGitVersion,
+  supportsMergeTreeWriteTree,
+} from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+
+describe('Git merge-tree compatibility', () => {
+  it('parses standard and Apple Git version strings', () => {
+    assert.deepStrictEqual(parseGitVersion('git version 2.38.0'), [2, 38, 0]);
+    assert.deepStrictEqual(
+      parseGitVersion('git version 2.39.5 (Apple Git-154)'),
+      [2, 39, 5]
+    );
+    assert.strictEqual(parseGitVersion('unknown'), undefined);
+  });
+
+  it('requires Git 2.38 or newer', () => {
+    assert.strictEqual(supportsMergeTreeWriteTree('git version 2.37.9'), false);
+    assert.strictEqual(supportsMergeTreeWriteTree('git version 2.38.0'), true);
+    assert.strictEqual(supportsMergeTreeWriteTree('git version 3.0.0'), true);
+  });
+
+  it('checks an unsupported Git version once and skips merge-tree', async () => {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-fake-git-'));
+    const gitLog = path.join(fakeBin, 'commands.log');
+    const gitPath = path.join(fakeBin, 'git');
+    fs.writeFileSync(
+      gitPath,
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$*" >> "$GSC_GIT_TEST_LOG"',
+        'if [ "$1" = "--version" ]; then',
+        '  echo "git version 2.37.9"',
+        '  exit 0',
+        'fi',
+        'exit 99',
+        '',
+      ].join('\n'),
+      { mode: 0o755 }
+    );
+
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_GIT_TEST_LOG;
+    const warnings: string[] = [];
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_GIT_TEST_LOG = gitLog;
+
+    const logger = {
+      info: () => {},
+      warn: (message: string) => warnings.push(message),
+      error: () => {},
+      debug: () => {},
+      dispose: () => {},
+    } as unknown as LoggingService;
+
+    try {
+      const git = new GitExecutor(fakeBin, logger);
+      assert.deepStrictEqual(await git.getStashConflictPreview('main'), []);
+      assert.deepStrictEqual(await git.getStashConflictPreview('feature'), []);
+
+      assert.deepStrictEqual(
+        fs.readFileSync(gitLog, 'utf8').trim().split('\n'),
+        ['--version']
+      );
+      assert.strictEqual(warnings.length, 1);
+      assert.ok(warnings.every((message) => message.includes('Git 2.38')));
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) {
+        delete process.env.GSC_GIT_TEST_LOG;
+      } else {
+        process.env.GSC_GIT_TEST_LOG = oldLog;
+      }
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test/unit/prCloneOwnership.test.ts
+++ b/src/test/unit/prCloneOwnership.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import { ExtensionContext } from 'vscode';
+
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { LoggingService } from '../../logging/loggingService';
+import { PrCloneService } from '../../services/prCloneService';
+import { PrCloneWebViewProvider } from '../../view/PrCloneWebViewProvider';
+
+describe('PrCloneWebViewProvider disposal', () => {
+  it('does not dispose the shared PR clone service it does not own', () => {
+    let disposeCalls = 0;
+    const service = {
+      dispose: () => {
+        disposeCalls++;
+      },
+    } as unknown as PrCloneService;
+    const provider = new PrCloneWebViewProvider(
+      {} as ExtensionContext,
+      {} as LoggingService,
+      {} as ConfigurationManager,
+      service
+    );
+
+    provider.dispose();
+
+    assert.strictEqual(disposeCalls, 0);
+  });
+});

--- a/src/test/unit/prCloneTempWorktreeService.test.ts
+++ b/src/test/unit/prCloneTempWorktreeService.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { GitHubClient } from '../../common/api/ghClient';
+import { EXTENSION_NAME } from '../../const';
+import {
+  isExistingExtensionTempWorktree,
+  PrCloneTempWorktreeService,
+} from '../../services/prCloneTempWorktreeService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('PrCloneTempWorktreeService cleanup', () => {
+  it('prunes stale metadata and still removes existing extension worktrees', async () => {
+    const existing = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${EXTENSION_NAME}-pr-clone-test-`)
+    );
+    const missing = path.join(
+      os.tmpdir(),
+      `${EXTENSION_NAME}-pr-clone-missing-${Date.now()}`
+    );
+    const calls: string[] = [];
+    const git = {
+      worktreePrune: async () => {
+        calls.push('prune');
+      },
+      worktreeList: async () => {
+        calls.push('list');
+        return [missing, existing];
+      },
+      worktreeRemove: async (worktree: string) => {
+        calls.push(`remove:${worktree}`);
+      },
+    } as unknown as GitExecutor;
+
+    const service = new PrCloneTempWorktreeService(
+      git,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    try {
+      await (service as any).cleanupOtherTempWorktrees();
+      assert.deepStrictEqual(calls, ['prune', 'list', `remove:${existing}`]);
+      assert.strictEqual(isExistingExtensionTempWorktree(missing, os.tmpdir()), false);
+    } finally {
+      fs.rmSync(existing, { recursive: true, force: true });
+    }
+  });
+
+  it('still prunes other worktrees when unregistering the current one fails', async () => {
+    const tempPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${EXTENSION_NAME}-pr-clone-current-`)
+    );
+    const calls: string[] = [];
+    const git = {
+      worktreeRemove: async () => {
+        calls.push('remove-current');
+        throw new Error('stale registration');
+      },
+      worktreePrune: async () => {
+        calls.push('prune');
+      },
+      worktreeList: async () => {
+        calls.push('list');
+        return [];
+      },
+    } as unknown as GitExecutor;
+
+    const service = new PrCloneTempWorktreeService(
+      git,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    await (service as any).cleanupTempWorktree(tempPath);
+
+    assert.deepStrictEqual(calls, ['remove-current', 'prune', 'list']);
+    assert.strictEqual(fs.existsSync(tempPath), false);
+  });
+});

--- a/src/test/unit/tagTemplateService.test.ts
+++ b/src/test/unit/tagTemplateService.test.ts
@@ -219,6 +219,15 @@ describe('tagTemplateService', () => {
       assert.ok(logger.warnings.some((w) => w.includes('not found')));
     });
 
+    it('inserts replacement metacharacters from file values literally', async () => {
+      const ctx = makeCtx({
+        readFile: async () => JSON.stringify({ version: "$'" }),
+        realpath: async (p) => p,
+      });
+      const result = await resolveTagTemplate('v{f:package.json:.version}', ctx);
+      assert.strictEqual(result.tag, "v$'");
+    });
+
     it('resolves branch token to empty string on invalid regex', async () => {
       const logger = makeLogger();
       const ctx = makeCtx({
@@ -353,6 +362,15 @@ describe('tagTemplateService', () => {
         });
         const result = await resolveTagTemplate('v{s:stdout:./get-version.sh}', ctx);
         assert.strictEqual(result.tag, 'v2.0.0');
+      });
+
+      it('inserts replacement metacharacters from script output literally', async () => {
+        const ctx = makeCtx({
+          realpath: async (p) => p,
+          runScript: async () => ({ stdout: '$&', stderr: '', exitCode: 0 }),
+        });
+        const result = await resolveTagTemplate('v{s:stdout:./get-version.sh}', ctx);
+        assert.strictEqual(result.tag, 'v$&');
       });
 
       it('{s:./script.sh} without stream defaults to stdout', async () => {

--- a/src/test/unit/webviewState.test.ts
+++ b/src/test/unit/webviewState.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+
+import {
+  readWebviewState,
+  WebviewStateApi,
+  writeWebviewState,
+} from '../../common/vscode/webviewState';
+
+interface TestState {
+  view: 'input' | 'clone';
+}
+
+describe('webview state persistence', () => {
+  it('loads and saves state through the VS Code webview API', () => {
+    let persisted: TestState | undefined = { view: 'clone' };
+    const api: WebviewStateApi<TestState> = {
+      getState: () => persisted,
+      setState: (state) => {
+        persisted = state;
+        return state;
+      },
+    };
+
+    assert.deepStrictEqual(readWebviewState(api, { view: 'input' }), {
+      view: 'clone',
+    });
+
+    writeWebviewState(api, { view: 'input' });
+    assert.deepStrictEqual(persisted, { view: 'input' });
+  });
+
+  it('uses the initial state when VS Code has no persisted state', () => {
+    const api: WebviewStateApi<TestState> = {
+      getState: () => undefined,
+      setState: (state) => state,
+    };
+
+    assert.deepStrictEqual(readWebviewState(api, { view: 'input' }), {
+      view: 'input',
+    });
+  });
+});

--- a/src/utils/getGitExecutor.ts
+++ b/src/utils/getGitExecutor.ts
@@ -3,6 +3,32 @@ import { GitExecutor } from '../common/git/gitExecutor';
 import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
 import { getWorkspaceFoldersFormatted } from '../common/vscode';
 import { LoggingService } from '../logging/loggingService';
+import { execCommand } from './execCommand';
+
+type RepositoryQuickPickItem = QuickPickItem & {
+  path: string;
+};
+
+export async function resolveGitRepositoryRoot(
+  folderPath: string,
+  logService: LoggingService
+): Promise<string> {
+  try {
+    const { stdout } = await execCommand(
+      'git',
+      ['rev-parse', '--show-toplevel'],
+      logService,
+      { cwd: folderPath }
+    );
+    const repositoryRoot = stdout.trim();
+    if (!repositoryRoot) {
+      throw new Error('Git returned an empty repository root.');
+    }
+    return repositoryRoot;
+  } catch {
+    throw new Error(`Workspace folder "${folderPath}" is not inside a Git repository.`);
+  }
+}
 
 export const getGitExecutor = async (
   logService: LoggingService,
@@ -16,11 +42,14 @@ export const getGitExecutor = async (
   }
 
   if (wsFolders.length === 1) {
-    return new GitExecutor(wsFolders[0].path, logService, vscodeGitProvider);
+    const repositoryRoot = await resolveGitRepositoryRoot(wsFolders[0].path, logService);
+    return new GitExecutor(repositoryRoot, logService, vscodeGitProvider);
   }
 
-  const repositoryOptions: QuickPickItem[] = wsFolders.map((wsf) => ({
+  const repositoryOptions: RepositoryQuickPickItem[] = wsFolders.map((wsf) => ({
     label: wsf.name,
+    description: wsf.path,
+    path: wsf.path,
   }));
 
   const selectedOption = await window.showQuickPick(repositoryOptions, {
@@ -32,7 +61,9 @@ export const getGitExecutor = async (
     throw new Error('No repository selected');
   }
 
-  const repository = wsFolders.find(({ name }) => name === selectedOption.label);
-
-  return new GitExecutor(repository!.path, logService, vscodeGitProvider);
+  const repositoryRoot = await resolveGitRepositoryRoot(
+    (selectedOption as RepositoryQuickPickItem).path,
+    logService
+  );
+  return new GitExecutor(repositoryRoot, logService, vscodeGitProvider);
 };

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -492,8 +492,6 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   dispose(): void {
-    if (this.prCloneService) {
-      this.prCloneService.dispose();
-    }
+    // The shared PrCloneService is owned and disposed by extension.ts.
   }
 }

--- a/src/webview/Apps/PR/App/index.tsx
+++ b/src/webview/Apps/PR/App/index.tsx
@@ -1,26 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
 import { useLogger } from '@/hooks';
 import { PrCloneForm } from '@/Apps/PR/pages/PrCloneForm';
 import { PrInputForm } from '@/Apps/PR/pages/PrInputForm';
 import { AppState } from '@/types/dataTypes';
-import React, { useEffect, useState } from 'react';
-
 import { WebviewCommand } from '@/types/commands';
-import { useSendMessage } from '@/hooks/useSendMessage';
-
-const STORAGE_KEY = 'pr-clone-app-state';
+import { getVsCodeApi, useSendMessage } from '@/hooks/useSendMessage';
+import {
+  readWebviewState,
+  writeWebviewState,
+} from '../../../../common/vscode/webviewState';
 
 export const App: React.FC = () => {
   const logger = useLogger(false);
   const sendMessage = useSendMessage();
+  const vscode = getVsCodeApi<AppState>();
   
   const [state, setState] = useState<AppState>(() => {
-    // Initialize state from localStorage on component mount
     try {
-      const savedState = localStorage.getItem(STORAGE_KEY);
-      logger.debug(`Loading saved app state: ${savedState?.substring(0, 25)}...`);
-      if (savedState) {
-        return JSON.parse(savedState);
-      }
+      const savedState = readWebviewState(vscode, { view: 'input' });
+      logger.debug(`Loading saved app state: ${savedState.view}`);
+      return savedState;
     } catch (error) {
       logger.warn(`Failed to load saved app state: ${error}`);
     }
@@ -32,14 +32,13 @@ export const App: React.FC = () => {
     owner: 'owner'
   });
 
-  // Save state to localStorage whenever it changes
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      writeWebviewState(vscode, state);
     } catch (error) {
       logger.warn(`Failed to save app state: ${error}`);
     }
-  }, [state]);
+  }, [state, vscode, logger]);
 
   const handleFetchPR = (prInput: string) => {
     sendMessage(WebviewCommand.FETCH_PR, { prInput } )
@@ -59,13 +58,6 @@ export const App: React.FC = () => {
     logger.info('Starting over ...');
     const newState: AppState = { view: 'input', isCloning: false };
     setState(newState);
-    // Clear saved state when starting over
-    try {
-      logger.info(`Clearing app state from localStorage: ${STORAGE_KEY}`);
-      localStorage.removeItem(STORAGE_KEY);
-    } catch (error) {
-      logger.warn(`Failed to clear saved app state: ${error}`);
-    }
   };
 
   // Handle messages from VS Code extension
@@ -106,7 +98,6 @@ export const App: React.FC = () => {
           }));
           break;
         case message.command === WebviewCommand.CLEAR_STATE:
-          // Clear state and localStorage when commanded by extension
           handleStartOver();
           break;
         case message.command === WebviewCommand.UPDATE_CLONING_STATE:

--- a/src/webview/hooks/useSendMessage.ts
+++ b/src/webview/hooks/useSendMessage.ts
@@ -1,16 +1,28 @@
 import { useCallback } from 'react';
+
 import { WebviewCommand } from '@/types/commands';
+
+export interface VsCodeApi<State = unknown> {
+  postMessage(message: unknown): void;
+  getState(): State | undefined;
+  setState(state: State): State;
+}
+
+export function getVsCodeApi<State = unknown>(): VsCodeApi<State> {
+  if (typeof window === 'undefined' || !(window as any).vscode) {
+    throw new Error('VS Code webview API is not available.');
+  }
+  return (window as any).vscode as VsCodeApi<State>;
+}
 
 export const useSendMessage = () => {
   const sendMessage = useCallback((command: WebviewCommand, data?: any) => {
-    if (typeof window !== 'undefined' && (window as any).vscode) {
-      console.debug(`[Webview]: Sending command: ${command}`);
+    console.debug(`[Webview]: Sending command: ${command}`);
 
-      (window as any).vscode.postMessage({
-        command,
-        ...data,
-      });
-    }
+    getVsCodeApi().postMessage({
+      command,
+      ...data,
+    });
   }, []);
 
   return sendMessage;

--- a/tsconfig.webview.json
+++ b/tsconfig.webview.json
@@ -31,6 +31,10 @@
     },
     "composite": true
   },
-  "include": ["src/webview/**/*", "src/webview/types/**/*"],
+  "include": [
+    "src/webview/**/*",
+    "src/webview/types/**/*",
+    "src/common/vscode/webviewState.ts"
+  ],
   "exclude": ["node_modules", "dist", "out"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,10 +1896,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/vscode@^1.74.0":
-  version "1.120.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.120.0.tgz#af36ef6e9952aa643e3682468197e319be80b4ae"
-  integrity sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==
+"@types/vscode@1.74.0":
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.74.0.tgz#4adc21b4e7f527b893de3418c21a91f1e503bdcd"
+  integrity sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==
 
 "@types/ws@^8.5.10":
   version "8.18.1"


### PR DESCRIPTION
## What changed
- stop persisting the command manager and expose it from activation; fix deactivation naming
- deduplicate configuration reads and declare the deprecated Jira email fallback
- persist PR webview state through the official VS Code API
- make extension activation the sole owner of PR clone service disposal
- resolve actual Git roots for workspace folders
- prune and safely skip stale temp-worktree paths
- preserve `$` replacement text in branch/tag templates
- treat checkout picker dismissal as normal control flow
- pin VS Code 1.74 API types, verify activation on 1.74.3, and gate merge-tree preview on Git 2.38
- add focused coverage and update requirements/settings documentation
- merge current `main` while preserving the PR behavior alongside newer PR clone cancellation, recovery, ordering, and loading-state fixes

## Why
This closes the smaller lifecycle, compatibility, persistence, parsing, and cleanup defects grouped under FABLE review item 21.

## Validation
- 290 unit tests passed
- 143 standard e2e tests passed
- 14 heavy-repository e2e tests passed
- VS Code 1.74.3 activation smoke passed
- type checks, lint, production package, and webview build passed
- VSIX packaging passed
- GitHub build, E2E, and CodeQL checks passed on `e0ca3a0`