### PR TITLE
feat: allow editing prefilled tag name on tag creation

### DIFF
--- a/docs/create-tag-from-template.md
+++ b/docs/create-tag-from-template.md
@@ -33,9 +33,15 @@ On branch `feature/FEAT-123-login` with `package.json` version `12.3.4`:
 mobile-v12.3.4-FEAT-123-3
 ```
 
+## Confirmation
+
+After resolving the template, an **editable input box** shows the tag name. Edit it if needed, then press **Enter** to create the tag. Press **Escape** to cancel.
+
+Tag names are validated against `git check-ref-format` rules and checked for collisions before creation. The collision check is skipped only while the field still holds a template result that used a `{r:...}` uniqueness suffix.
+
 ## Manual Tag Entry
 
-If `git-smart-checkout.tagTemplate` is empty, the command prompts for a tag name. The input is validated and checked for uniqueness before creation.
+If `git-smart-checkout.tagTemplate` is empty, the same input box opens empty so you can type a tag name. The input is validated and checked for uniqueness before creation.
 
 ## Pushing Tags
 

--- a/src/commands/createTagFromTemplateCommand/index.ts
+++ b/src/commands/createTagFromTemplateCommand/index.ts
@@ -11,7 +11,6 @@ import {
 import { validateTagName } from './validateTagName';
 import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
 
-const CREATE_TAG_ACTION = 'Create';
 const COPY_TAG_ACTION = 'Copy Tag';
 
 export class CreateTagFromTemplateCommand extends BaseCommand {
@@ -49,16 +48,10 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
     const template = (cfg.tagTemplate ?? '').trim();
     const remote = cfg.tagRemote || 'origin';
 
-    let tagName: string;
+    let initialTagName = '';
     let hadRecurringToken = false;
 
-    if (template === '') {
-      const input = await this.promptManualTagName(git);
-      if (!input) {
-        return;
-      }
-      tagName = input;
-    } else {
+    if (template !== '') {
       log(`Template: ${template}`);
       const ctx: TagTemplateContext = {
         workspaceRoot,
@@ -97,35 +90,41 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
         return;
       }
 
-      tagName = resolved.tag;
+      initialTagName = resolved.tag;
       hadRecurringToken = resolved.hadRecurringToken;
-      log(`Final tag: ${tagName}`);
-    }
+      log(`Final tag: ${initialTagName}`);
 
-    if (!tagName) {
-      await this.showErrorMessage(
-        'Generated tag is empty. Please check the tag template.'
-      );
-      return;
-    }
-
-    const validationError = validateTagName(tagName);
-    if (validationError) {
-      await this.showErrorMessage(`Invalid tag name "${tagName}": ${validationError}`);
-      return;
-    }
-
-    // If no {r:...} token, verify the tag doesn't already exist
-    if (!hadRecurringToken) {
-      const exists = await git.tagExists(tagName);
-      if (exists) {
-        await this.showErrorMessage(`Tag "${tagName}" already exists.`);
+      if (!initialTagName) {
+        await this.showErrorMessage(
+          'Generated tag is empty. Please check the tag template.'
+        );
         return;
+      }
+
+      const validationError = validateTagName(initialTagName);
+      if (validationError) {
+        await this.showErrorMessage(
+          `Invalid tag name "${initialTagName}": ${validationError}`
+        );
+        return;
+      }
+
+      // If no {r:...} token, verify the tag doesn't already exist
+      if (!hadRecurringToken) {
+        const exists = await git.tagExists(initialTagName);
+        if (exists) {
+          await this.showErrorMessage(`Tag "${initialTagName}" already exists.`);
+          return;
+        }
       }
     }
 
-    const confirm = await this.confirmCreateTag(tagName);
-    if (!confirm) {
+    const tagName = await this.promptEditableTagName(
+      initialTagName,
+      git,
+      hadRecurringToken
+    );
+    if (!tagName) {
       return;
     }
 
@@ -143,16 +142,24 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
     await this.handlePush(tagName, remote, cfg.pushTagWithoutConfirmation);
   }
 
-  private async promptManualTagName(
-    git: Awaited<ReturnType<typeof this.getGitExecutor>>
+  private async promptEditableTagName(
+    initialName: string,
+    git: Awaited<ReturnType<typeof this.getGitExecutor>>,
+    skipExistenceOnInitial: boolean
   ): Promise<string | undefined> {
-    const input = await this.showInputBox({
-      prompt: 'Enter Git tag name',
+    return this.showInputBox({
+      title: 'Create tag',
+      prompt: 'Edit the tag name if needed, then press Enter to create',
+      value: initialName,
       placeHolder: 'e.g. v1.2.3',
+      ignoreFocusOut: true,
       validateInput: async (value) => {
         const err = validateTagName(value);
         if (err) {
           return err;
+        }
+        if (value === initialName && skipExistenceOnInitial) {
+          return undefined;
         }
         if (await git.tagExists(value)) {
           return `Tag "${value}" already exists`;
@@ -160,8 +167,6 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
         return undefined;
       },
     });
-
-    return input;
   }
 
   private async handlePush(
@@ -201,18 +206,6 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
         `Tag "${tagName}" was created locally, but push failed.`,
         tagName
       );
-    }
-  }
-
-  private async confirmCreateTag(tagName: string): Promise<boolean> {
-    while (true) {
-      const action = await vscode.window.showInformationMessage(
-        `Create Git tag "${tagName}"?`,
-        { modal: true },
-        CREATE_TAG_ACTION,
-      );
-
-      return action === CREATE_TAG_ACTION;
     }
   }
 

--- a/src/test/e2e/commandInterface.test.ts
+++ b/src/test/e2e/commandInterface.test.ts
@@ -1746,11 +1746,11 @@ describe('VS Code command interface', () => {
 
   it('createTagFromTemplate creates and pushes a tag through command prompts', async () => {
     const repo = createTagTestRepo();
-    const restoreInput = stubInputBox('command-v1.0.0');
+    const restoreInput = stubInputBox((options) => {
+      assert.strictEqual(options.value, '', 'manual entry should open an empty input box');
+      return 'command-v1.0.0';
+    });
     const info = stubInformationMessages((message, items) => {
-      if (message.includes('Create Git tag')) {
-        return 'Create';
-      }
       if (message.includes('Push tag')) {
         return 'Push';
       }
@@ -1775,6 +1775,53 @@ describe('VS Code command interface', () => {
       errors.restore();
       info.restore();
       restoreInput();
+      repo.cleanup();
+    }
+  });
+
+  it('createTagFromTemplate prefills the resolved template and lets the user edit it', async () => {
+    const repo = createTagTestRepo();
+    const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+    const originalTemplate = config.inspect<string>('tagTemplate')?.globalValue;
+    await config.update('tagTemplate', 'release-candidate', vscode.ConfigurationTarget.Global);
+    await delay(50);
+
+    let prefilledValue: string | undefined;
+    const restoreInput = stubInputBox((options) => {
+      prefilledValue = options.value;
+      return 'release-candidate-edited';
+    });
+    const info = stubInformationMessages((message, items) => {
+      if (message.includes('Push tag')) {
+        return 'Push';
+      }
+      return items[0];
+    });
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('createTagFromTemplate'));
+
+        assert.deepStrictEqual(errors.messages, []);
+        assert.strictEqual(
+          prefilledValue,
+          'release-candidate',
+          'input box should prefill the resolved template, mirroring branch creation'
+        );
+        assert.strictEqual(await repo.git.tagExists('release-candidate-edited'), true);
+        assert.strictEqual(
+          await repo.git.tagExists('release-candidate'),
+          false,
+          'the edited name should be used instead of the prefilled template'
+        );
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      restoreInput();
+      await config.update('tagTemplate', originalTemplate, vscode.ConfigurationTarget.Global);
+      await delay(50);
       repo.cleanup();
     }
   });


### PR DESCRIPTION
## Summary

Aligns **Create Tag from Template** with **Create Branch from Template**. When a tag is about to be created, the resolved tag name is now shown in an **editable input box** (prefilled with the template result), so the user can adjust it before the tag is created — exactly like branch creation already does.

Previously the tag flow showed a read-only `Create Git tag "..."?` confirmation modal that gave no chance to tweak the name.

## Changes

- `createTagFromTemplateCommand`: replaced the confirmation modal (`confirmCreateTag`) and the separate manual-entry prompt (`promptManualTagName`) with a single `promptEditableTagName` that mirrors the branch command's `promptEditableBranchName` (prefilled `value`, `ignoreFocusOut`, live validation + collision check, `{r:...}` recurring-token existence skip).
- The empty-template (manual) path now flows through the same editable input box (opens empty), removing the redundant confirmation step.
- **Branch creation is untouched** — only the tag flow was aligned to it.
- Updated `docs/create-tag-from-template.md` with a "Confirmation" section describing the editable input box.
- Updated e2e tests and added a new test asserting the input box is prefilled with the resolved template and that an edited name is used.

## Testing

Run locally on macOS:

- `yarn check-types` — pass
- `yarn lint` — pass
- `yarn test` (unit, `--label unit`) — 211 passing
- e2e suite (`vscode-test --label e2e-manual`) — 127 passing, exit 0, including the two tag tests below.

Note: the local sandbox injects `safe.bareRepository=explicit` via `GIT_CONFIG_*` env vars, which makes the e2e test helper's bare-repo setup fail unrelated to this change. The passing e2e run was obtained by neutralizing that injected config (`GIT_CONFIG_COUNT=0`); CI is unaffected.

Tag tests covered:
  - `createTagFromTemplate creates and pushes a tag through command prompts`
  - `createTagFromTemplate prefills the resolved template and lets the user edit it`
