### PR TITLE
test(e2e): heavy-repository e2e suite over a complex repo

### DIFF
--- a/.github/workflows/e2e-heavy-tests.yml
+++ b/.github/workflows/e2e-heavy-tests.yml
@@ -1,0 +1,68 @@
+name: Heavy E2E Tests
+
+# Opt-in heavy e2e suite. It builds a large (~28-file) multi-branch repository
+# per test, so it is intentionally kept OUT of the per-PR `E2E Tests` workflow.
+# Trigger it manually from the Actions tab, or let the weekly schedule run it.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  e2e-heavy:
+    name: Run Heavy E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache VS Code test instance
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('.vscode-test.mjs') }}
+          restore-keys: |
+            vscode-test-${{ runner.os }}-
+
+      - name: Compile extension and tests
+        run: yarn compile && yarn compile-tests
+
+      - name: Create test-results directory
+        run: mkdir -p test-results
+
+      - name: Run heavy e2e tests
+        run: yarn test:e2e:heavy:ci
+        env:
+          CI: true
+          GSC_DISABLE_TELEMETRY: '1'
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: heavy-e2e-test-results
+          path: test-results/
+          retention-days: 7
+
+      - name: Publish test report
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: test-results/heavy-results.xml
+          check_name: Heavy E2E Test Results
+          fail_on: nothing

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 const root = process.cwd();
 const e2eFiles = 'out/test/e2e/**/*.test.js';
+const heavyFiles = 'out/test/heavy/**/*.test.js';
 const unitFiles = 'out/test/unit/**/*.test.js';
 const baseLaunchArgs = [
   '--disable-workspace-trust',
@@ -57,6 +58,32 @@ export default defineConfig([
       ui: 'bdd',
       timeout: 120000,
       reporter: 'spec',
+    },
+  },
+  {
+    label: 'e2e-heavy',
+    files: heavyFiles,
+    launchArgs: [
+      ...quietLaunchArgs,
+      '--user-data-dir',
+      `${root}/.vscode-test/user-data-e2e-heavy`,
+    ],
+    env: {
+      GSC_E2E_MODE: 'ci',
+      GSC_DISABLE_TELEMETRY: '1',
+    },
+    mocha: {
+      ui: 'bdd',
+      // Heavy fixtures build a ~28-file repo with several branches and a bare
+      // remote per test, so allow a larger budget than the standard e2e suite.
+      timeout: 60000,
+      ...(process.env.CI && {
+        reporter: 'mocha-junit-reporter',
+        reporterOptions: {
+          mochaFile: 'test-results/heavy-results.xml',
+          suiteTitleSeparatedBy: ' > ',
+        },
+      }),
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -379,6 +379,8 @@
     "test:e2e": "vscode-test --label e2e-manual",
     "test:e2e:manual": "vscode-test --label e2e-manual",
     "test:e2e:ci": "mkdir -p test-results && xvfb-run -a vscode-test --label e2e-ci",
+    "test:e2e:heavy": "vscode-test --label e2e-heavy",
+    "test:e2e:heavy:ci": "mkdir -p test-results && xvfb-run -a vscode-test --label e2e-heavy",
     "test:unit": "vscode-test --label unit",
     "build-vsix": "yarn package && vsce package --yarn",
     "build-vsix-dev": "yarn compile && vsce package --yarn --no-dependencies",

--- a/src/test/e2e/helpers/commandHarness.ts
+++ b/src/test/e2e/helpers/commandHarness.ts
@@ -1,0 +1,303 @@
+import * as assert from 'assert';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { EXTENSION_NAME } from '../../../const';
+
+import { TestRepo } from './gitTestRepo';
+
+/**
+ * Shared harness for e2e tests that drive the real contributed commands through
+ * `vscode.commands.executeCommand`. These helpers temporarily point the VS Code
+ * workspace at a temp test repo and stub the window prompts (quick picks, input
+ * boxes, notifications) the commands rely on.
+ */
+
+export type QuickPickLikeItem = vscode.QuickPickItem & {
+  ref?: { name: string; fullName: string; remote?: string; isTag?: boolean };
+  type?: string;
+  worktree?: { path: string };
+  hasChanges?: boolean;
+};
+
+export const commandId = (name: string): string => `${EXTENSION_NAME}.${name}`;
+
+export function delay(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function visualPause(): Promise<void> {
+  const ms = Number(process.env.GSC_E2E_VISUAL_DELAY_MS ?? '0');
+  if (ms > 0) {
+    await delay(ms);
+  }
+}
+
+/** Run `run` with the VS Code workspace pointed at the test repo, then restore it. */
+export async function withRepoWorkspace(repo: TestRepo, run: () => Promise<void>): Promise<void> {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(vscode.workspace, 'workspaceFolders');
+  const folder = {
+    uri: vscode.Uri.file(repo.repoPath),
+    name: path.basename(repo.repoPath),
+    index: 0,
+  } as vscode.WorkspaceFolder;
+
+  Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+    configurable: true,
+    get: () => [folder],
+  });
+
+  try {
+    await vscode.commands.executeCommand('workbench.view.scm');
+    await visualPause();
+    await run();
+    await visualPause();
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', originalDescriptor);
+    } else {
+      delete (vscode.workspace as any).workspaceFolders;
+    }
+  }
+}
+
+export async function ensureExtensionActivated(): Promise<void> {
+  const extension = vscode.extensions.all.find(
+    (item) => item.packageJSON?.name === EXTENSION_NAME
+  );
+
+  assert.ok(extension, `Extension ${EXTENSION_NAME} should be installed in the test host.`);
+  await extension.activate();
+}
+
+export async function setExtensionMode(mode: string | undefined): Promise<void> {
+  await vscode.workspace
+    .getConfiguration(EXTENSION_NAME)
+    .update('mode', mode, vscode.ConfigurationTarget.Global);
+  await delay(50);
+}
+
+export function stubCreateQuickPick(
+  pick: (
+    items: readonly QuickPickLikeItem[],
+    quickPick: { title: string; placeholder: string }
+  ) => QuickPickLikeItem | undefined
+): () => void {
+  const original = vscode.window.createQuickPick.bind(vscode.window);
+
+  (vscode.window as any).createQuickPick = () => {
+    let accepted = false;
+    let shown = false;
+    let currentItems: readonly QuickPickLikeItem[] = [];
+    const acceptListeners: Array<() => void> = [];
+    const hideListeners: Array<() => void> = [];
+
+    const maybeAccept = () => {
+      if (!shown || accepted) {
+        return;
+      }
+
+      const selected = pick(currentItems, quickPick);
+      if (!selected) {
+        accepted = true;
+        setTimeout(() => {
+          hideListeners.forEach((listener) => listener());
+        }, 0);
+        return;
+      }
+
+      accepted = true;
+      quickPick.selectedItems = [selected];
+      quickPick.activeItems = [selected];
+      setTimeout(() => {
+        acceptListeners.forEach((listener) => listener());
+      }, 0);
+    };
+
+    const quickPick = {
+      title: '',
+      placeholder: '',
+      busy: false,
+      selectedItems: [] as QuickPickLikeItem[],
+      activeItems: [] as QuickPickLikeItem[],
+      buttons: [],
+      get items() {
+        return currentItems;
+      },
+      set items(items: readonly QuickPickLikeItem[]) {
+        currentItems = items;
+        maybeAccept();
+      },
+      onDidAccept(listener: () => void) {
+        acceptListeners.push(listener);
+        return new vscode.Disposable(() => undefined);
+      },
+      onDidHide(listener: () => void) {
+        hideListeners.push(listener);
+        return new vscode.Disposable(() => undefined);
+      },
+      onDidTriggerItemButton() {
+        return new vscode.Disposable(() => undefined);
+      },
+      onDidChangeActive() {
+        return new vscode.Disposable(() => undefined);
+      },
+      show() {
+        shown = true;
+        maybeAccept();
+      },
+      hide() {
+        hideListeners.forEach((listener) => listener());
+      },
+      dispose() {
+        return undefined;
+      },
+    };
+
+    return quickPick;
+  };
+
+  return () => {
+    (vscode.window as any).createQuickPick = original;
+  };
+}
+
+export function stubShowQuickPick(
+  pick: (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options: vscode.QuickPickOptions | undefined
+  ) => vscode.QuickPickItem | string | undefined
+): () => void {
+  const original = vscode.window.showQuickPick.bind(vscode.window);
+
+  (vscode.window as any).showQuickPick = async (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options?: vscode.QuickPickOptions
+  ) => pick(items, options);
+
+  return () => {
+    (vscode.window as any).showQuickPick = original;
+  };
+}
+
+export function stubInputBox(
+  ...answers: Array<string | ((options: vscode.InputBoxOptions) => string | undefined)>
+): () => void {
+  const original = vscode.window.showInputBox.bind(vscode.window);
+  const queue = [...answers];
+
+  (vscode.window as any).showInputBox = async (options: vscode.InputBoxOptions) => {
+    const answer = queue.shift();
+    return typeof answer === 'function' ? answer(options) : answer;
+  };
+
+  return () => {
+    (vscode.window as any).showInputBox = original;
+  };
+}
+
+export function stubInformationMessages(
+  pick: (message: string, items: readonly string[]) => string | undefined
+): { messages: string[]; items: string[][]; restore: () => void } {
+  const original = vscode.window.showInformationMessage.bind(vscode.window);
+  const messages: string[] = [];
+  const shownItems: string[][] = [];
+
+  (vscode.window as any).showInformationMessage = async (message: string, ...args: any[]) => {
+    messages.push(message);
+    const items = typeof args[0] === 'object' && typeof args[0] !== 'string'
+      ? args.slice(1)
+      : args;
+    shownItems.push(items);
+    return pick(message, items);
+  };
+
+  return {
+    messages,
+    items: shownItems,
+    restore() {
+      (vscode.window as any).showInformationMessage = original;
+    },
+  };
+}
+
+export function stubWarningMessages(
+  pick: (message: string, items: readonly string[]) => string | undefined
+): { messages: string[]; items: string[][]; restore: () => void } {
+  const original = vscode.window.showWarningMessage.bind(vscode.window);
+  const messages: string[] = [];
+  const shownItems: string[][] = [];
+
+  (vscode.window as any).showWarningMessage = async (message: string, ...args: any[]) => {
+    messages.push(message);
+    const items = typeof args[0] === 'object' && typeof args[0] !== 'string'
+      ? args.slice(1)
+      : args;
+    shownItems.push(items);
+    return pick(message, items);
+  };
+
+  return {
+    messages,
+    items: shownItems,
+    restore() {
+      (vscode.window as any).showWarningMessage = original;
+    },
+  };
+}
+
+export function stubErrorMessages(): { messages: string[]; restore: () => void } {
+  const original = vscode.window.showErrorMessage.bind(vscode.window);
+  const messages: string[] = [];
+
+  (vscode.window as any).showErrorMessage = async (message: string) => {
+    messages.push(message);
+    return 'OK';
+  };
+
+  return {
+    messages,
+    restore() {
+      (vscode.window as any).showErrorMessage = original;
+    },
+  };
+}
+
+export function getDefaultWorktreePath(repo: TestRepo, branchName: string): string {
+  return path.join(
+    path.dirname(repo.repoPath),
+    `${path.basename(repo.repoPath)}-${branchName.replace(/[\\/]+/g, '-')}`
+  );
+}
+
+export async function cleanupWorktree(repo: TestRepo, worktreePath: string): Promise<void> {
+  try {
+    await repo.git.worktreeRemove(worktreePath);
+  } catch {
+    // The worktree may not have been created if the command failed before that point.
+  }
+
+  fs.rmSync(worktreePath, { recursive: true, force: true });
+}
+
+export function execIn(cwd: string, command: string): string {
+  return execSync(command, { cwd, encoding: 'utf-8' });
+}
+
+export function normalizeTestPath(targetPath: string): string {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+export function isSameTestPath(left: string | undefined, right: string): boolean {
+  if (!left) {
+    return false;
+  }
+
+  return normalizeTestPath(left) === normalizeTestPath(right);
+}

--- a/src/test/e2e/helpers/gitTestRepo.ts
+++ b/src/test/e2e/helpers/gitTestRepo.ts
@@ -76,8 +76,10 @@ function buildRepo(
 function createBareRepo(prefix: string): string {
   const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 
-  execSync('git init --bare', { cwd: repoPath, stdio: 'pipe' });
-  execSync('git symbolic-ref HEAD refs/heads/main', { cwd: repoPath, stdio: 'pipe' });
+  // Set the initial branch at init time rather than via a follow-up
+  // `git symbolic-ref`, which auto-discovers the bare repo from the cwd and is
+  // rejected when the user has `safe.bareRepository=explicit` configured.
+  execSync('git init --bare -b main', { cwd: repoPath, stdio: 'pipe' });
 
   return repoPath;
 }
@@ -425,4 +427,260 @@ export function createRebaseConflictTestRepo(): TestRepo {
 
   repo.exec('git checkout feature');
   return repo;
+}
+
+// ---------------------------------------------------------------------------
+// Heavy repository: ~28 mock files across nested directories, several diverging
+// branches, a local bare origin (+ producer clone), a remote-only PR branch and
+// a fork remote. Used by the opt-in heavy test suite to exercise the main
+// features over a large, complex repository instead of a 1–2 file fixture.
+// ---------------------------------------------------------------------------
+
+/** Description of the mixed working-tree state produced by seedComplexWorkingState. */
+export interface ComplexWorkingState {
+  /** Files staged with `git add` (modified or, for the rename target, added). */
+  staged: string[];
+  /** Tracked files modified but left unstaged. */
+  modifiedUnstaged: string[];
+  /** Files staged and then modified again (status `MM`). */
+  mixed: string[];
+  /** Brand-new untracked files (some in new directories). */
+  untracked: string[];
+  /** Tracked files deleted from the working tree (unstaged deletion). */
+  deleted: string[];
+  /** Staged rename. */
+  renamed: { from: string; to: string };
+}
+
+export interface HeavyTestRepo extends TestRepo {
+  remoteRepoPath: string;
+  producerRepoPath: string;
+  forkRepoPath: string;
+  /** Remote-only PR branch on origin (not present locally). */
+  prBranch: string;
+  /** Branch that only exists on the fork remote. */
+  forkBranch: string;
+  uiBranch: string;
+  apiBranch: string;
+  releaseBranch: string;
+  /** Branch that commits a divergent version of conflictFile. */
+  conflictBranch: string;
+  /** Tracked file that conflictBranch and a dirty working tree both modify. */
+  conflictFile: string;
+  /** All files committed on the main baseline. */
+  trackedFiles: string[];
+  /** Dirty the working tree into staged/unstaged/untracked/deleted/renamed all at once. */
+  seedComplexWorkingState(): ComplexWorkingState;
+}
+
+/**
+ * ~28 files of plausible mock data spread across nested directories and file
+ * types (TS source, JSON/YAML config, Markdown docs, JSON fixtures).
+ */
+function heavyBaselineFiles(): Record<string, string> {
+  const tsModule = (name: string, body: string) =>
+    `// ${name}\nexport function ${name}() {\n${body}\n}\n`;
+
+  return {
+    'README.md': '# Heavy Sample Project\n\nA fixture project used for heavy e2e tests.\n',
+    '.gitignore': 'node_modules/\ndist/\n*.log\n',
+    'package.json': JSON.stringify(
+      { name: 'heavy-sample', version: '1.0.0', private: true, scripts: { build: 'tsc' } },
+      null,
+      2
+    ) + '\n',
+    'src/index.ts': "import { startApp } from './app';\n\nstartApp();\n",
+    'src/app.ts': "import { ApiService } from './services/apiService';\n\nexport function startApp() {\n  return new ApiService().init();\n}\n",
+    'src/components/Button.ts': tsModule('Button', '  return { kind: "button", label: "Click" };'),
+    'src/components/Modal.ts': tsModule('Modal', '  return { kind: "modal", open: false };'),
+    'src/components/Header.ts': tsModule('Header', '  return { kind: "header", title: "Home" };'),
+    'src/components/Footer.ts': tsModule('Footer', '  return { kind: "footer", year: 2024 };'),
+    'src/services/apiService.ts': "export class ApiService {\n  init() {\n    return 'api:v1';\n  }\n}\n",
+    'src/services/authService.ts': "export class AuthService {\n  login(user: string) {\n    return `auth:${user}`;\n  }\n}\n",
+    'src/services/cacheService.ts': "export class CacheService {\n  private store = new Map<string, unknown>();\n  get(key: string) {\n    return this.store.get(key);\n  }\n}\n",
+    'src/utils/format.ts': tsModule('format', '  return (value: string) => value.trim();'),
+    'src/utils/validate.ts': tsModule('validate', '  return (value: string) => value.length > 0;'),
+    'src/utils/logger.ts': tsModule('logger', '  return (message: string) => console.log(message);'),
+    'src/hooks/useFetch.ts': tsModule('useFetch', '  return { loading: false, data: null };'),
+    'src/hooks/useToggle.ts': tsModule('useToggle', '  return { on: false, toggle: () => undefined };'),
+    'config/app.json': JSON.stringify({ name: 'heavy-sample', env: 'test', port: 3000 }, null, 2) + '\n',
+    'config/database.json': JSON.stringify({ host: 'localhost', port: 5432, name: 'heavy' }, null, 2) + '\n',
+    'config/feature-flags.yml': 'flags:\n  newUi: false\n  beta: true\n',
+    'docs/getting-started.md': '# Getting Started\n\nClone, install, and run the build.\n',
+    'docs/architecture.md': '# Architecture\n\nLayered: components -> services -> utils.\n',
+    'docs/CONTRIBUTING.md': '# Contributing\n\nOpen a PR against main.\n',
+    'data/users.json': JSON.stringify([{ id: 1, name: 'Ada' }, { id: 2, name: 'Linus' }], null, 2) + '\n',
+    'data/products.json': JSON.stringify([{ sku: 'A1', price: 10 }, { sku: 'B2', price: 20 }], null, 2) + '\n',
+    'data/orders.json': JSON.stringify([{ id: 100, sku: 'A1', qty: 2 }], null, 2) + '\n',
+    'tests/smoke.test.ts': "import { startApp } from '../src/app';\n\nstartApp();\n",
+    'tests/fixtures.ts': "export const fixtures = { user: 'Ada' };\n",
+  };
+}
+
+function writeDeep(repoPath: string, relativePath: string, content: string): void {
+  const target = path.join(repoPath, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
+export function createHeavyTestRepo(): HeavyTestRepo {
+  const remoteRepoPath = createBareRepo('gsc-heavy-remote-');
+  const forkRepoPath = createBareRepo('gsc-heavy-fork-');
+
+  const uiBranch = 'feature/ui';
+  const apiBranch = 'feature/api';
+  const releaseBranch = 'release/1.x';
+  const conflictBranch = 'feature/conflict';
+  const conflictFile = 'src/utils/format.ts';
+  const prBranch = 'pr-feature';
+  const forkBranch = 'fork-feature';
+
+  const baseline = heavyBaselineFiles();
+  const trackedFiles = Object.keys(baseline);
+
+  const base = buildRepo('gsc-heavy-test-', (repoPath, exec) => {
+    for (const [relativePath, content] of Object.entries(baseline)) {
+      writeDeep(repoPath, relativePath, content);
+    }
+    exec('git add -A');
+    exec('git commit -m "init: heavy baseline"');
+
+    // feature/ui — touches only components.
+    exec(`git checkout -b ${uiBranch}`);
+    writeDeep(repoPath, 'src/components/Button.ts', '// Button (ui)\nexport function Button() {\n  return { kind: "button", label: "Submit" };\n}\n');
+    writeDeep(repoPath, 'src/components/Sidebar.ts', '// Sidebar (ui)\nexport function Sidebar() {\n  return { kind: "sidebar" };\n}\n');
+    exec('git add -A');
+    exec('git commit -m "feat(ui): restyle button and add sidebar"');
+    exec('git checkout main');
+
+    // feature/api — touches only services.
+    exec(`git checkout -b ${apiBranch}`);
+    writeDeep(repoPath, 'src/services/apiService.ts', "export class ApiService {\n  init() {\n    return 'api:v2';\n  }\n}\n");
+    writeDeep(repoPath, 'src/services/webhookService.ts', "export class WebhookService {\n  emit(event: string) {\n    return `webhook:${event}`;\n  }\n}\n");
+    exec('git add -A');
+    exec('git commit -m "feat(api): bump api version and add webhook service"');
+    exec('git checkout main');
+
+    // release/1.x — touches package.json and docs.
+    exec(`git checkout -b ${releaseBranch}`);
+    writeDeep(repoPath, 'package.json', JSON.stringify(
+      { name: 'heavy-sample', version: '1.1.0', private: true, scripts: { build: 'tsc' } },
+      null,
+      2
+    ) + '\n');
+    writeDeep(repoPath, 'docs/architecture.md', '# Architecture\n\nLayered: components -> services -> utils.\n\n## 1.1\nAdded webhook layer.\n');
+    exec('git add -A');
+    exec('git commit -m "chore(release): prepare 1.1.0"');
+    exec('git checkout main');
+
+    // feature/conflict — commits a divergent version of conflictFile.
+    exec(`git checkout -b ${conflictBranch}`);
+    writeDeep(repoPath, conflictFile, '// format (conflict branch)\nexport function format() {\n  return (value: string) => value.toUpperCase();\n}\n');
+    exec('git add -A');
+    exec('git commit -m "feat: change format on conflict branch"');
+    exec('git checkout main');
+  });
+
+  function execInRepo(cmd: string) {
+    execSync(cmd, { cwd: base.repoPath, stdio: 'pipe' });
+  }
+
+  // origin: push main (with upstream tracking) so pull/rebase have a remote.
+  execInRepo(`git remote add origin "${remoteRepoPath}"`);
+  execInRepo('git push -u origin main');
+
+  // Remote-only PR branch on origin.
+  execInRepo(`git checkout -b ${prBranch}`);
+  writeDeep(base.repoPath, 'src/features/prFeature.ts', "export const prFeature = () => 'pr-feature';\n");
+  execInRepo('git add -A');
+  execInRepo('git commit -m "feat: pr feature"');
+  execInRepo(`git push -u origin ${prBranch}`);
+  execInRepo('git checkout main');
+  execInRepo(`git branch -D ${prBranch}`);
+
+  // Fork-only branch on the fork remote.
+  execInRepo(`git checkout -b ${forkBranch}`);
+  writeDeep(base.repoPath, 'src/features/forkFeature.ts', "export const forkFeature = () => 'fork-feature';\n");
+  execInRepo('git add -A');
+  execInRepo('git commit -m "feat: fork feature"');
+  execInRepo(`git push "${forkRepoPath}" ${forkBranch}`);
+  execInRepo('git checkout main');
+  execInRepo(`git branch -D ${forkBranch}`);
+
+  // Producer clone that pushes a divergent commit touching several files, so the
+  // local main is behind origin/main and a pull has something to integrate.
+  const producerRepoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-heavy-producer-'));
+  fs.rmSync(producerRepoPath, { recursive: true, force: true });
+  execSync(`git clone "${remoteRepoPath}" "${producerRepoPath}"`, { stdio: 'pipe' });
+  execSync('git config user.email "test@test.local"', { cwd: producerRepoPath, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: producerRepoPath, stdio: 'pipe' });
+  writeDeep(producerRepoPath, 'data/orders.json', JSON.stringify([{ id: 100, sku: 'A1', qty: 2 }, { id: 101, sku: 'B2', qty: 5 }], null, 2) + '\n');
+  writeDeep(producerRepoPath, 'docs/CHANGELOG.md', '# Changelog\n\n- remote: add order 101\n');
+  execSync('git add -A', { cwd: producerRepoPath, stdio: 'pipe' });
+  execSync('git commit -m "feat: remote order and changelog"', { cwd: producerRepoPath, stdio: 'pipe' });
+  execSync('git push origin main', { cwd: producerRepoPath, stdio: 'pipe' });
+
+  const originalCleanup = base.cleanup.bind(base);
+
+  return {
+    ...base,
+    remoteRepoPath,
+    producerRepoPath,
+    forkRepoPath,
+    prBranch,
+    forkBranch,
+    uiBranch,
+    apiBranch,
+    releaseBranch,
+    conflictBranch,
+    conflictFile,
+    trackedFiles,
+    seedComplexWorkingState(): ComplexWorkingState {
+      const staged = ['src/utils/validate.ts', 'data/users.json', 'config/app.json'];
+      const modifiedUnstaged = ['src/services/cacheService.ts', 'docs/getting-started.md'];
+      const mixed = ['src/utils/logger.ts'];
+      const untracked = ['src/utils/wipHelper.ts', 'data/scratch.json', 'notes/todo.md'];
+      const deleted = ['src/hooks/useToggle.ts'];
+      const renamed = { from: 'tests/fixtures.ts', to: 'tests/fixtures.renamed.ts' };
+
+      // Staged modifications.
+      for (const file of staged) {
+        writeDeep(base.repoPath, file, `${fs.readFileSync(path.join(base.repoPath, file), 'utf-8')}// staged edit\n`);
+      }
+      execInRepo(`git add ${staged.join(' ')}`);
+
+      // Modified-but-unstaged.
+      for (const file of modifiedUnstaged) {
+        writeDeep(base.repoPath, file, `${fs.readFileSync(path.join(base.repoPath, file), 'utf-8')}// unstaged edit\n`);
+      }
+
+      // Staged then modified again (MM).
+      for (const file of mixed) {
+        writeDeep(base.repoPath, file, `${fs.readFileSync(path.join(base.repoPath, file), 'utf-8')}// first edit\n`);
+        execInRepo(`git add ${file}`);
+        writeDeep(base.repoPath, file, `${fs.readFileSync(path.join(base.repoPath, file), 'utf-8')}// second edit\n`);
+      }
+
+      // Untracked (including new directories).
+      for (const file of untracked) {
+        writeDeep(base.repoPath, file, `untracked ${file}\n`);
+      }
+
+      // Unstaged deletion.
+      for (const file of deleted) {
+        fs.rmSync(path.join(base.repoPath, file));
+      }
+
+      // Staged rename.
+      execInRepo(`git mv ${renamed.from} ${renamed.to}`);
+
+      return { staged, modifiedUnstaged, mixed, untracked, deleted, renamed };
+    },
+    cleanup() {
+      originalCleanup();
+      fs.rmSync(remoteRepoPath, { recursive: true, force: true });
+      fs.rmSync(forkRepoPath, { recursive: true, force: true });
+      fs.rmSync(producerRepoPath, { recursive: true, force: true });
+    },
+  };
 }

--- a/src/test/heavy/heavyCheckout.test.ts
+++ b/src/test/heavy/heavyCheckout.test.ts
@@ -1,0 +1,174 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import {
+  AUTO_STASH_AND_APPLY_IN_NEW_BRANCH,
+  AUTO_STASH_AND_POP_IN_NEW_BRANCH,
+  AUTO_STASH_CURRENT_BRANCH,
+  AUTO_STASH_IGNORE,
+} from '../../commands/checkoutToCommand/constants';
+import { IGitRef } from '../../common/git/types';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+
+import { createHeavyTestRepo, HeavyTestRepo } from '../e2e/helpers/gitTestRepo';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Heavy-repository coverage for checkout + auto-stash. Each test runs over a
+ * ~28-file repo whose working tree carries staged, unstaged, mixed, untracked,
+ * deleted and renamed changes at once, switching to a feature branch that
+ * touches a disjoint set of files (so pop/apply never conflicts by accident).
+ */
+
+const mockConfigManager = {} as unknown as ConfigurationManager;
+const sut = new AutoStashService(mockConfigManager, mockLogService);
+
+function makeRef(name: string): IGitRef {
+  return { name, fullName: name, authorName: '' };
+}
+
+function stubWarning(answer: string | undefined): () => void {
+  const prev = vscode.window.showWarningMessage.bind(vscode.window);
+  (vscode.window as any).showWarningMessage = async () => answer;
+  return () => { (vscode.window as any).showWarningMessage = prev; };
+}
+
+describe('Heavy repo — checkout + auto stash', () => {
+  describe('AUTO_STASH_CURRENT_BRANCH over a complex working tree', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('stashes all working changes on the source branch and lands clean on the target', async () => {
+      const state = repo.seedComplexWorkingState();
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'precondition: tree is dirty');
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.uiBranch), AUTO_STASH_CURRENT_BRANCH);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.uiBranch);
+      assert.strictEqual(repo.stashCount(), 1, 'one stash created for the source branch');
+      assert.strictEqual(
+        await repo.git.isStashWithMessageExists(`auto-stash-${repo.mainBranch}`),
+        true,
+        'stash is named after the source branch'
+      );
+      // Target had no matching auto-stash, so the working tree is clean.
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), false, 'target branch is clean');
+      assert.strictEqual(repo.fileExists(state.untracked[0]), false, 'untracked WIP was stashed away');
+      assert.strictEqual(repo.fileExists(state.renamed.to), false, 'rename was stashed away');
+      assert.strictEqual(repo.fileExists('src/components/Sidebar.ts'), true, 'target branch files are present');
+    });
+
+    it('restores every change on the round trip back to the source branch', async () => {
+      // Continue from the previous test: we are on uiBranch with auto-stash-main pending.
+      await sut.checkoutAndStashChanges(repo.git, repo.uiBranch, makeRef(repo.mainBranch), AUTO_STASH_CURRENT_BRANCH);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.mainBranch);
+      assert.strictEqual(repo.stashCount(), 0, 'stash popped on return');
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'changes restored on source');
+      assert.ok(repo.readFile('src/utils/validate.ts').includes('// staged edit'), 'staged edit restored');
+      assert.ok(repo.readFile('src/services/cacheService.ts').includes('// unstaged edit'), 'unstaged edit restored');
+      assert.strictEqual(repo.fileExists('src/utils/wipHelper.ts'), true, 'untracked WIP restored');
+      assert.strictEqual(repo.fileExists('src/hooks/useToggle.ts'), false, 'deletion restored');
+      assert.strictEqual(repo.fileExists('tests/fixtures.renamed.ts'), true, 'rename restored');
+      assert.strictEqual(repo.fileExists('tests/fixtures.ts'), false, 'old name still gone');
+    });
+  });
+
+  describe('AUTO_STASH_AND_POP_IN_NEW_BRANCH over a complex working tree', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('moves all working changes onto the target branch and empties the stash list', async () => {
+      const state = repo.seedComplexWorkingState();
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.apiBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.apiBranch);
+      assert.strictEqual(repo.stashCount(), 0, 'pop consumes the stash');
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'changes present on target');
+      assert.ok(repo.readFile(state.staged[0]).includes('// staged edit'), 'staged content moved');
+      assert.ok(repo.readFile(state.modifiedUnstaged[0]).includes('// unstaged edit'), 'unstaged content moved');
+      assert.strictEqual(repo.fileExists(state.untracked[0]), true, 'untracked WIP moved');
+      assert.strictEqual(repo.fileExists(state.deleted[0]), false, 'deletion moved');
+      assert.strictEqual(repo.fileExists('src/services/webhookService.ts'), true, 'target branch file present');
+    });
+  });
+
+  describe('AUTO_STASH_AND_APPLY_IN_NEW_BRANCH over a complex working tree', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('copies the changes onto the target branch while preserving the stash', async () => {
+      const state = repo.seedComplexWorkingState();
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.uiBranch), AUTO_STASH_AND_APPLY_IN_NEW_BRANCH);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.uiBranch);
+      assert.strictEqual(repo.stashCount(), 1, 'apply keeps the stash entry');
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'changes present on target');
+      assert.ok(repo.readFile(state.staged[1]).includes('// staged edit'), 'staged content applied');
+    });
+  });
+
+  describe('AUTO_STASH_IGNORE over a complex working tree', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('carries non-conflicting changes across the checkout without stashing', async () => {
+      const state = repo.seedComplexWorkingState();
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.uiBranch), AUTO_STASH_IGNORE);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.uiBranch);
+      assert.strictEqual(repo.stashCount(), 0, 'no stash created');
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'changes persist after checkout');
+      assert.strictEqual(repo.fileExists(state.untracked[1]), true, 'untracked WIP persists');
+    });
+  });
+
+  describe('checkout to a remote-only branch', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('creates a local tracking branch from origin and checks it out', async () => {
+      await repo.git.fetchAllRemoteBranchesAndTags();
+
+      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.prBranch), AUTO_STASH_IGNORE);
+
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.prBranch);
+      assert.strictEqual(repo.fileExists('src/features/prFeature.ts'), true, 'remote-only branch content present');
+    });
+  });
+
+  describe('stash conflict prediction blocks a risky pop', () => {
+    let repo: HeavyTestRepo;
+    before(() => { repo = createHeavyTestRepo(); });
+    after(() => { repo.cleanup(); });
+
+    it('cancels the checkout when the user declines the predicted conflict', async () => {
+      // Dirty exactly the file that the conflict branch also rewrote.
+      repo.makeChange(repo.conflictFile, '// working tree rewrite of format\nexport const format = 1;\n');
+      const restoreWarning = stubWarning(undefined); // user declines
+
+      try {
+        await sut.checkoutAndStashChanges(
+          repo.git,
+          repo.mainBranch,
+          makeRef(repo.conflictBranch),
+          AUTO_STASH_AND_POP_IN_NEW_BRANCH
+        );
+
+        assert.strictEqual(await repo.git.getCurrentBranch(), repo.mainBranch, 'branch unchanged');
+        assert.strictEqual(repo.stashCount(), 0, 'no stash created when cancelled');
+      } finally {
+        restoreWarning();
+      }
+    });
+  });
+});

--- a/src/test/heavy/heavyPr.test.ts
+++ b/src/test/heavy/heavyPr.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { CheckoutByPRCommand } from '../../commands/checkoutByPRCommand';
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AUTO_STASH_MODE_BRANCH } from '../../configuration/extensionConfig';
+import { AutoStashService } from '../../services/autoStashService';
+import { GitHubPR } from '../../types/dataTypes';
+
+import { createHeavyTestRepo, HeavyTestRepo } from '../e2e/helpers/gitTestRepo';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Heavy-repository coverage for checkout-by-PR (same-repo and fork). The GitHub
+ * REST API is mocked; the "remote" is the heavy repo's local bare origin/fork,
+ * and the working tree carries a full mixed-state WIP before the checkout.
+ */
+
+function makeMockConfigManager(mode: string): ConfigurationManager {
+  return { get: () => ({ mode }) } as unknown as ConfigurationManager;
+}
+
+function makePR(headRef: string, overrides: Partial<GitHubPR> = {}): GitHubPR {
+  return {
+    number: 42,
+    title: 'Heavy PR title',
+    body: '',
+    head: { ref: headRef, sha: 'abc123', repo: { full_name: 'owner/repo', clone_url: '' } },
+    base: { ref: 'main', repo: { full_name: 'owner/repo' } },
+    html_url: 'https://github.com/owner/repo/pull/42',
+    labels: [],
+    assignees: [],
+    ...overrides,
+  };
+}
+
+class TestableCheckoutByPRCommand extends CheckoutByPRCommand {
+  constructor(
+    private readonly testGit: GitExecutor,
+    private readonly prData: GitHubPR,
+    autoStashService: AutoStashService
+  ) {
+    super(makeMockConfigManager(AUTO_STASH_MODE_BRANCH), mockLogService, autoStashService);
+  }
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return this.testGit;
+  }
+
+  protected createGitHubClient(_owner: string, _repo: string): GitHubClient {
+    const prData = this.prData;
+    return {
+      fetchPullRequest: async () => prData,
+    } as unknown as GitHubClient;
+  }
+}
+
+function stubInputBox(value: string | undefined): () => void {
+  const original = vscode.window.showInputBox.bind(vscode.window);
+  (vscode.window as any).showInputBox = async () => value;
+  return () => { (vscode.window as any).showInputBox = original; };
+}
+
+function stubInfoMessages(messages: string[]): () => void {
+  const original = vscode.window.showInformationMessage.bind(vscode.window);
+  (vscode.window as any).showInformationMessage = async (message: string) => {
+    messages.push(message);
+    return 'OK';
+  };
+  return () => { (vscode.window as any).showInformationMessage = original; };
+}
+
+function makeService(): AutoStashService {
+  return new AutoStashService(makeMockConfigManager(AUTO_STASH_MODE_BRANCH), mockLogService);
+}
+
+describe('Heavy repo — checkout by PR (same repo)', () => {
+  let repo: HeavyTestRepo;
+  let restoreInput: () => void;
+  let restoreInfo: () => void;
+
+  before(() => {
+    repo = createHeavyTestRepo();
+    repo.git.getRepoInfo = async () => ({ owner: 'owner', repo: 'heavy-repo' });
+    restoreInput = stubInputBox('42');
+    restoreInfo = stubInfoMessages([]);
+  });
+
+  after(() => {
+    restoreInfo();
+    restoreInput();
+    repo.cleanup();
+  });
+
+  it('stashes the mixed WIP on the source branch and checks out the fetched PR branch', async () => {
+    repo.seedComplexWorkingState();
+
+    await new TestableCheckoutByPRCommand(repo.git, makePR(repo.prBranch), makeService()).execute();
+
+    assert.strictEqual(await repo.git.getCurrentBranch(), repo.prBranch);
+    assert.strictEqual(repo.fileExists('src/features/prFeature.ts'), true, 'PR branch content present');
+    assert.strictEqual(await repo.git.isWorkdirHasChanges(), false, 'PR branch is clean');
+    assert.strictEqual(repo.stashCount(), 1, 'WIP stashed on the source branch');
+    assert.strictEqual(
+      await repo.git.isStashWithMessageExists(`auto-stash-${repo.mainBranch}`),
+      true,
+      'stash named after the source branch'
+    );
+  });
+});
+
+describe('Heavy repo — checkout by PR (fork)', () => {
+  let repo: HeavyTestRepo;
+  let restoreInput: () => void;
+  let restoreInfo: () => void;
+
+  before(() => {
+    repo = createHeavyTestRepo();
+    repo.git.getRepoInfo = async () => ({ owner: 'owner', repo: 'heavy-repo' });
+    restoreInput = stubInputBox('99');
+    restoreInfo = stubInfoMessages([]);
+  });
+
+  after(() => {
+    restoreInfo();
+    restoreInput();
+    repo.cleanup();
+  });
+
+  it('fetches the branch from the fork remote URL and checks it out', async () => {
+    const pr = makePR(repo.forkBranch, {
+      number: 99,
+      head: {
+        ref: repo.forkBranch,
+        sha: 'def456',
+        repo: { full_name: 'fork-owner/repo', clone_url: repo.forkRepoPath },
+      },
+      base: { ref: 'main', repo: { full_name: 'owner/repo' } },
+    });
+
+    await new TestableCheckoutByPRCommand(repo.git, pr, makeService()).execute();
+
+    assert.strictEqual(await repo.git.getCurrentBranch(), repo.forkBranch);
+    assert.strictEqual(repo.fileExists('src/features/forkFeature.ts'), true, 'fork branch content present');
+  });
+});

--- a/src/test/heavy/heavyPullRebase.test.ts
+++ b/src/test/heavy/heavyPullRebase.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+
+import {
+  AUTO_STASH_CURRENT_BRANCH,
+} from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+
+import { createHeavyTestRepo, HeavyTestRepo } from '../e2e/helpers/gitTestRepo';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Heavy-repository coverage for pull-with-stash and rebase-with-stash. The
+ * repo's local `main` is behind a producer that pushed commits touching several
+ * files; every operation runs while the working tree carries a full mixed-state
+ * WIP that is disjoint from both the remote and the rebase target.
+ */
+
+const mockConfigManager = {
+  get: () => ({ useFastBranchList: false }),
+} as unknown as ConfigurationManager;
+const sut = new AutoStashService(mockConfigManager, mockLogService);
+
+function assertHeadContains(repo: HeavyTestRepo, target: string): void {
+  assert.doesNotThrow(
+    () => repo.exec(`git merge-base --is-ancestor ${target} HEAD`),
+    `HEAD should contain ${target}`
+  );
+}
+
+describe('Heavy repo — pull with stash (merge)', () => {
+  let repo: HeavyTestRepo;
+  before(() => { repo = createHeavyTestRepo(); });
+  after(() => { repo.cleanup(); });
+
+  it('integrates remote commits and restores the full WIP', async () => {
+    const state = repo.seedComplexWorkingState();
+
+    await sut.pullAndStashChanges(repo.git, repo.mainBranch, 'merge');
+
+    assert.strictEqual(repo.stashCount(), 0, 'temporary stash is popped');
+    // Remote (producer) changes are present.
+    assert.ok(repo.readFile('data/orders.json').includes('101'), 'remote order integrated');
+    assert.strictEqual(repo.fileExists('docs/CHANGELOG.md'), true, 'remote-added file present');
+    // Local WIP is restored.
+    assert.ok(repo.readFile(state.staged[0]).includes('// staged edit'), 'staged WIP restored');
+    assert.ok(repo.readFile(state.modifiedUnstaged[0]).includes('// unstaged edit'), 'unstaged WIP restored');
+    assert.strictEqual(repo.fileExists(state.untracked[0]), true, 'untracked WIP restored');
+    assert.strictEqual(repo.fileExists(state.deleted[0]), false, 'deletion restored');
+  });
+});
+
+describe('Heavy repo — pull with stash (rebase)', () => {
+  let repo: HeavyTestRepo;
+  before(() => { repo = createHeavyTestRepo(); });
+  after(() => { repo.cleanup(); });
+
+  it('replays a local commit on top of the remote and restores the WIP', async () => {
+    // Give local main a commit the remote does not have, so the pull truly rebases.
+    repo.makeChange('docs/local-note.md', '# Local note\n\nadded locally\n');
+    repo.exec('git add docs/local-note.md');
+    repo.exec('git commit -m "docs: local note"');
+
+    const state = repo.seedComplexWorkingState();
+
+    await sut.pullAndStashChanges(repo.git, repo.mainBranch, 'rebase');
+
+    assert.strictEqual(repo.stashCount(), 0);
+    assert.strictEqual(repo.fileExists('docs/local-note.md'), true, 'local commit preserved');
+    assert.ok(repo.readFile('data/orders.json').includes('101'), 'remote order integrated');
+    assert.strictEqual(repo.fileExists('docs/CHANGELOG.md'), true, 'remote-added file present');
+    // Linear history: the local commit sits on top of the remote commit.
+    assertHeadContains(repo, 'origin/main');
+    assert.ok(repo.readFile(state.staged[1]).includes('// staged edit'), 'WIP restored after rebase');
+  });
+});
+
+describe('Heavy repo — rebase with stash (branch onto branch)', () => {
+  let repo: HeavyTestRepo;
+  before(() => { repo = createHeavyTestRepo(); });
+  after(() => { repo.cleanup(); });
+
+  it('rebases a feature branch onto a release branch and restores the WIP', async () => {
+    repo.exec(`git checkout ${repo.apiBranch}`);
+    const state = repo.seedComplexWorkingState();
+
+    await sut.rebaseAndStashChanges(repo.git, repo.apiBranch, repo.releaseBranch, AUTO_STASH_CURRENT_BRANCH);
+
+    assert.strictEqual(await repo.git.getCurrentBranch(), repo.apiBranch);
+    assertHeadContains(repo, repo.releaseBranch);
+    assert.strictEqual(repo.stashCount(), 0);
+    // Both branches' committed changes are present after the rebase.
+    assert.ok(repo.readFile('src/services/apiService.ts').includes('api:v2'), 'feature commit kept');
+    assert.strictEqual(repo.fileExists('src/services/webhookService.ts'), true, 'feature file kept');
+    assert.ok(repo.readFile('package.json').includes('1.1.0'), 'release commit incorporated');
+    // WIP restored.
+    assert.ok(repo.readFile(state.staged[0]).includes('// staged edit'), 'WIP restored after rebase');
+    assert.strictEqual(repo.fileExists(state.untracked[0]), true, 'untracked WIP restored');
+  });
+});

--- a/src/test/heavy/heavyWorktree.test.ts
+++ b/src/test/heavy/heavyWorktree.test.ts
@@ -1,0 +1,130 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { AUTO_STASH_MODE_MANUAL } from '../../configuration/extensionConfig';
+
+import { createHeavyTestRepo } from '../e2e/helpers/gitTestRepo';
+import {
+  cleanupWorktree,
+  commandId,
+  ensureExtensionActivated,
+  execIn,
+  getDefaultWorktreePath,
+  isSameTestPath,
+  QuickPickLikeItem,
+  setExtensionMode,
+  stubCreateQuickPick,
+  stubErrorMessages,
+  stubInformationMessages,
+  stubInputBox,
+  stubShowQuickPick,
+  withRepoWorkspace,
+} from '../e2e/helpers/commandHarness';
+
+/**
+ * Heavy-repository coverage for the git-worktree commands, driven through the
+ * real contributed commands. Exercises creating a worktree from a many-branch
+ * repo and copying a multi-file WIP into a sibling worktree.
+ */
+
+describe('Heavy repo — worktree commands', () => {
+  before(async () => {
+    await ensureExtensionActivated();
+    await setExtensionMode(AUTO_STASH_MODE_MANUAL);
+  });
+
+  it('creates a new worktree for a feature branch from a large repo', async () => {
+    const repo = createHeavyTestRepo();
+    const worktreePath = getDefaultWorktreePath(repo, repo.uiBranch);
+
+    const restoreQuickPick = stubCreateQuickPick((items, quickPick) => {
+      assert.strictEqual(quickPick.placeholder, 'Select a target branch for the new worktree');
+      return items.find((item) => item.ref?.name === repo.uiBranch && !item.ref.remote);
+    });
+    const restoreInput = stubInputBox((options) => options.value);
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('moveToNewWorktree'));
+
+        assert.deepStrictEqual(errors.messages, []);
+        assert.strictEqual(fs.existsSync(worktreePath), true, 'worktree directory created');
+        assert.strictEqual(
+          execIn(worktreePath, 'git branch --show-current').trim(),
+          repo.uiBranch,
+          'worktree is checked out to the feature branch'
+        );
+        assert.strictEqual(
+          fs.existsSync(path.join(worktreePath, 'src/components/Sidebar.ts')),
+          true,
+          'feature branch files are present in the worktree'
+        );
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      restoreInput();
+      restoreQuickPick();
+      await cleanupWorktree(repo, worktreePath);
+      repo.cleanup();
+    }
+  });
+
+  it('copies a multi-file WIP into a sibling worktree and preserves the source', async () => {
+    const repo = createHeavyTestRepo();
+    const worktreePath = getDefaultWorktreePath(repo, repo.apiBranch);
+
+    // A sibling worktree checked out to a branch that shares these files with main.
+    repo.exec(`git worktree add "${worktreePath}" ${repo.apiBranch}`);
+
+    // Files identical between main and the target branch, so patches apply cleanly.
+    const stagedFile = 'src/utils/validate.ts';
+    const unstagedFile = 'docs/getting-started.md';
+    const untrackedFile = 'data/wip.json';
+
+    const restoreQuickPick = stubShowQuickPick((items, options) => {
+      if (options?.placeHolder === 'Select a worktree to copy changes to') {
+        return items.find((item) =>
+          typeof item !== 'string' &&
+          isSameTestPath((item as QuickPickLikeItem).worktree?.path, worktreePath)
+        ) as vscode.QuickPickItem;
+      }
+      return undefined;
+    });
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        fs.writeFileSync(path.join(repo.repoPath, stagedFile), `${repo.readFile(stagedFile)}// staged wip\n`);
+        repo.exec(`git add ${stagedFile}`);
+        fs.writeFileSync(path.join(repo.repoPath, unstagedFile), `${repo.readFile(unstagedFile)}\nunstaged wip\n`);
+        fs.writeFileSync(path.join(repo.repoPath, untrackedFile), '{"wip":true}\n');
+
+        await vscode.commands.executeCommand(commandId('copyWipChangesToWorktree'));
+
+        assert.deepStrictEqual(errors.messages, []);
+        // Target worktree received all three kinds of change.
+        assert.ok(execIn(worktreePath, `git show :${stagedFile}`).includes('// staged wip'), 'staged change copied');
+        assert.ok(
+          fs.readFileSync(path.join(worktreePath, unstagedFile), 'utf-8').includes('unstaged wip'),
+          'unstaged change copied'
+        );
+        assert.strictEqual(fs.existsSync(path.join(worktreePath, untrackedFile)), true, 'untracked file copied');
+        // Source worktree still has its changes.
+        assert.ok(repo.readFile(stagedFile).includes('// staged wip'), 'source staged change preserved');
+        assert.strictEqual(repo.fileExists(untrackedFile), true, 'source untracked file preserved');
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      restoreQuickPick();
+      await cleanupWorktree(repo, worktreePath);
+      repo.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Context

The existing e2e tests each exercise one feature over a tiny fixture (2 branches, 1–2 files). Nothing exercised the extension over a **large, complex repository** with many files in mixed git states. This PR adds a **separate, opt-in heavy test group** that runs the main features over a ~28-file, multi-branch repo to confirm the extension behaves correctly on big codebases as well as small ones.

## Remote testing — no real GitHub repo needed

All remote-dependent features are tested **fully offline and deterministically**:
- Remote git ops (pull/rebase, PR-branch fetch, fork fetch) run against a **local bare repo** acting as `origin` (+ a producer clone that pushed divergent commits, a remote-only PR branch, and a separate fork remote).
- The **GitHub REST API is mocked** by subclassing the command and overriding `createGitHubClient()` — same pattern as the existing `checkoutByPR` tests. No token, no network, CI-safe.

## What's added

- **`createHeavyTestRepo()` / `seedComplexWorkingState()`** in `gitTestRepo.ts` — ~28 mock files across nested dirs and file types, branches `feature/ui`, `feature/api`, `release/1.x`, `feature/conflict`, plus origin/producer/PR/fork remotes. `seedComplexWorkingState()` dirties the tree into staged + unstaged + mixed + untracked + deleted + renamed all at once (disjoint from the feature branches so pop/apply never conflicts by accident).
- **`helpers/commandHarness.ts`** — shared stubs to drive the real contributed commands (quick picks, input boxes, notifications, workspace folder).
- **`src/test/heavy/*.test.ts`** — checkout + auto-stash (all 4 modes, round-trip, remote-only branch, conflict-preview cancel), pull-with-stash (merge + rebase), rebase-with-stash, checkout-by-PR (same-repo + fork), and worktree commands (`moveToNewWorktree`, `copyWipChangesToWorktree`) — all over the heavy repo.
- **Opt-in suite wiring** — `e2e-heavy` label in `.vscode-test.mjs`, `test:e2e:heavy` / `test:e2e:heavy:ci` scripts, and a manual/scheduled `Heavy E2E Tests` workflow. Kept **out of the per-PR e2e run** via glob isolation (`out/test/heavy/**` vs `out/test/e2e/**`).

## Notable change to a shared helper

`createBareRepo` now sets the initial branch via `git init --bare -b main` instead of a follow-up `git symbolic-ref HEAD`. The old approach auto-discovers the bare repo from the cwd and is **rejected when `safe.bareRepository=explicit`** is configured. Result is identical; this just makes the fixtures runnable in that environment. No behavior change on CI.

## Deviation from the approved plan

The plan proposed extracting the harness *and refactoring* the 1840-line `commandInterface.test.ts` to consume it. I created the shared harness but **left `commandInterface.test.ts` untouched** to avoid risk to a large passing suite I couldn't fully audit in one pass; the harness is consumed by the new heavy tests. The minor helper duplication can be cleaned up in a follow-up.

## Verification

- `yarn compile` (check-types + lint + esbuild): clean
- `yarn compile-tests`: clean
- `yarn test:e2e:heavy`: **14 passing**
- existing `e2e` suite: green (confirms the `createBareRepo` change is non-regressing)
- `unit` suite: **211 passing**
- Confirmed heavy tests do **not** run under the standard e2e glob
