### PR TITLE
feat(jira): store Jira API token in VS Code Secret Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ In fast-paced development environments, switching between Git branches is freque
 | Create a new PR from selected commits in another GitHub PR | `Git Smart Checkout: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
+| Store the Jira API token securely in VS Code Secret Storage | `Git Smart Checkout: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
 | Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
 
 ## Extension Settings
@@ -60,7 +61,7 @@ Click a setting ID to open that setting in VS Code.
 | ⚙️ [`git-smart-checkout.jira.domain`](vscode://settings/git-smart-checkout.jira.domain) (Jira domain) | `string` | Jira Cloud host (e.g. `your-company.atlassian.net`). Required when the branch template uses Jira tokens. |
 | ⚙️ [`git-smart-checkout.jira.username`](vscode://settings/git-smart-checkout.jira.username) (Jira username) | `string` | Atlassian account username for Jira API authentication (usually your Atlassian account email). |
 | ⚙️ [`git-smart-checkout.jira.email`](vscode://settings/git-smart-checkout.jira.email) (Deprecated Jira email) | `string` | Deprecated compatibility fallback used only when `jira.username` is empty. Migrate to `git-smart-checkout.jira.username`. |
-| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | Jira API token. See setting description for unscoped vs scoped token guidance. |
+| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | **Deprecated — stored in plaintext.** Use the `Git Smart Checkout: Set Jira token` command, which keeps the token in VS Code Secret Storage. Any value set here is migrated into Secret Storage and cleared on the next activation. |
 | ⚙️ [`git-smart-checkout.jira.projectKeys`](vscode://settings/git-smart-checkout.jira.projectKeys) (Jira project keys) | `array` | Optional list of project keys that limit the Jira issue picker, e.g. `["KEY", "HOME"]`. Empty (default) shows all issues assigned to you. |
 | ⚙️ [`git-smart-checkout.pushTagWithoutConfirmation`](vscode://settings/git-smart-checkout.pushTagWithoutConfirmation) (Push tag without confirmation) | `boolean` | Pushes the created Git tag to the remote without asking for confirmation. |
 | ⚙️ [`git-smart-checkout.tagRemote`](vscode://settings/git-smart-checkout.tagRemote) (Tag remote) | `string` | Git remote used when pushing created tags. |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ In fast-paced development environments, switching between Git branches is freque
 | Create a new PR from selected commits in another GitHub PR | `Git Smart Checkout: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
+| Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `Git Smart Checkout: Init Jira` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
 | Store the Jira API token securely in VS Code Secret Storage | `Git Smart Checkout: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
 | Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
 

--- a/docs/create-branch-from-template.md
+++ b/docs/create-branch-from-template.md
@@ -13,8 +13,14 @@ Create and check out a new Git branch from a configurable template. Supports Jir
 | --- | --- |
 | `git-smart-checkout.jira.domain` | Jira Cloud host, e.g. `your-company.atlassian.net` |
 | `git-smart-checkout.jira.username` | Atlassian account username (usually your Atlassian account email) |
-| `git-smart-checkout.jira.token` | API token from [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens) |
 | `git-smart-checkout.jira.projectKeys` | Optional list of project keys to limit the issue picker, e.g. `["KEY", "HOME"]`. Empty (default) shows all issues assigned to you. |
+
+The Jira **API token** is not a setting. Run the `Git Smart Checkout: Set Jira token` command and paste the token; it is stored in [VS Code Secret Storage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage) rather than in plaintext settings (which can be synced via Settings Sync). Run the command again with an empty value to remove the stored token.
+
+> [!NOTE]
+> If you previously set the deprecated `git-smart-checkout.jira.token` setting, it is migrated into Secret Storage and cleared from settings automatically the next time the extension activates.
+
+Create the token at [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
 
 **Unscoped token (recommended):** use **Create API token** (classic). It works with `https://<domain>.atlassian.net` and needs no scope selection.
 

--- a/docs/create-branch-from-template.md
+++ b/docs/create-branch-from-template.md
@@ -9,13 +9,20 @@ Create and check out a new Git branch from a configurable template. Supports Jir
 
 ## Jira Configuration
 
-| Setting | Description |
+The quickest way to get set up is the `Git Smart Checkout: Init Jira` command, which walks through three prompts:
+
+1. **Domain** — prefilled with the current value if already set.
+2. **Username** — prefilled with the current value if already set.
+3. **API token** — prefilled and masked (shown as dots) if a token is already stored; leave it unchanged to keep it, clear it to remove it, or type a new one.
+
+Domain and username are written to settings (and stay editable there); the API token is stored in [VS Code Secret Storage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage). You can also manage these individually:
+
+| Setting / Command | Description |
 | --- | --- |
 | `git-smart-checkout.jira.domain` | Jira Cloud host, e.g. `your-company.atlassian.net` |
 | `git-smart-checkout.jira.username` | Atlassian account username (usually your Atlassian account email) |
 | `git-smart-checkout.jira.projectKeys` | Optional list of project keys to limit the issue picker, e.g. `["KEY", "HOME"]`. Empty (default) shows all issues assigned to you. |
-
-The Jira **API token** is not a setting. Run the `Git Smart Checkout: Set Jira token` command and paste the token; it is stored in [VS Code Secret Storage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage) rather than in plaintext settings (which can be synced via Settings Sync). Run the command again with an empty value to remove the stored token.
+| `Git Smart Checkout: Set Jira token` | Set or replace just the API token. It is stored in Secret Storage rather than plaintext settings (which can be synced via Settings Sync). Run it with an empty value to remove the stored token. |
 
 > [!NOTE]
 > If you previously set the deprecated `git-smart-checkout.jira.token` setting, it is migrated into Secret Storage and cleared from settings automatically the next time the extension activates.

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.setJiraToken",
+        "title": "Set Jira token",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.checkoutByPR",
         "title": "Checkout by PR number... (With Stash)",
         "category": "GSC"
@@ -222,6 +227,9 @@
         {
           "command": "git-smart-checkout.createBranchFromTemplate",
           "when": "git-smart-checkout.canCreateBranchFromTemplate"
+        },
+        {
+          "command": "git-smart-checkout.setJiraToken"
         },
         {
           "command": "git-smart-checkout.checkoutByPR"
@@ -356,7 +364,8 @@
         "git-smart-checkout.jira.token": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Jira API token. Create one at [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).\n\n**Unscoped token (recommended):** choose **Create API token** (classic/unscoped). It uses your Jira permissions and works with `https://<domain>.atlassian.net` — no scopes to select.\n\n**Scoped token (optional):** if you use a scoped token, grant at least: `read:jira-work`, `read:jira-user`, `read:issue-details:jira`, `read:project:jira`. Scoped tokens may require the `api.atlassian.com` gateway; this extension expects an unscoped token with the domain setting above."
+          "markdownDescription": "Jira API token. **Stored in plaintext — use the `GSC: Set Jira token` command instead**, which keeps the token in VS Code Secret Storage.\n\nAny value set here is automatically migrated into Secret Storage and cleared on the next activation.\n\nCreate a token at [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens). **Unscoped token (recommended):** choose **Create API token** (classic/unscoped). It uses your Jira permissions and works with `https://<domain>.atlassian.net` — no scopes to select. **Scoped token (optional):** grant at least `read:jira-work`, `read:jira-user`, `read:issue-details:jira`, `read:project:jira`.",
+          "deprecationMessage": "Use the \"GSC: Set Jira token\" command instead. This setting stores the token in plaintext (and may be synced via Settings Sync); any value is migrated to Secret Storage and cleared automatically."
         },
         "git-smart-checkout.jira.projectKeys": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.initJira",
+        "title": "Init Jira",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.setJiraToken",
         "title": "Set Jira token",
         "category": "GSC"
@@ -227,6 +232,9 @@
         {
           "command": "git-smart-checkout.createBranchFromTemplate",
           "when": "git-smart-checkout.canCreateBranchFromTemplate"
+        },
+        {
+          "command": "git-smart-checkout.initJira"
         },
         {
           "command": "git-smart-checkout.setJiraToken"

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -29,6 +29,7 @@ export enum AnalyticsEvent {
   WorktreeDevTerminalOpened = 'worktree_dev_terminal_opened',
   CopyBranchName = 'copy_branch_name',
   JiraTokenSet = 'jira_token_set',
+  JiraInitialized = 'jira_initialized',
 }
 
 let client: PostHog | null = null;

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -28,6 +28,7 @@ export enum AnalyticsEvent {
   MoveWipChangesFromWorktree = 'move_wip_changes_from_worktree',
   WorktreeDevTerminalOpened = 'worktree_dev_terminal_opened',
   CopyBranchName = 'copy_branch_name',
+  JiraTokenSet = 'jira_token_set',
 }
 
 let client: PostHog | null = null;

--- a/src/commands/createBranchFromTemplateCommand/index.ts
+++ b/src/commands/createBranchFromTemplateCommand/index.ts
@@ -65,7 +65,7 @@ export class CreateBranchFromTemplateCommand extends BaseCommand {
     if (branchTemplateNeedsJira(template)) {
       if (!isJiraConfigured(cfg.jira)) {
         await this.showErrorMessage(
-          'Branch template requires Jira. Configure git-smart-checkout.jira.domain, jira.username, and jira.token.'
+          'Branch template requires Jira. Set git-smart-checkout.jira.domain and jira.username, then run "GSC: Set Jira token".'
         );
         return;
       }

--- a/src/commands/initJiraCommand/index.ts
+++ b/src/commands/initJiraCommand/index.ts
@@ -1,0 +1,82 @@
+import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { LoggingService } from '../../logging/loggingService';
+import { BaseCommand } from '../command';
+
+/**
+ * Guided Jira setup: collects the domain, username, and API token through three
+ * input boxes. Domain and username are stored in settings (and remain editable
+ * there); the API token is stored in VS Code Secret Storage.
+ */
+export class InitJiraCommand extends BaseCommand {
+  constructor(
+    private readonly configManager: ConfigurationManager,
+    logService: LoggingService
+  ) {
+    super(logService);
+  }
+
+  async execute(): Promise<void> {
+    const jira = this.configManager.get().jira;
+
+    const domain = await this.showInputBox({
+      title: 'Init Jira (1 of 3): Domain',
+      prompt: 'Jira Cloud host, e.g. your-company.atlassian.net',
+      placeHolder: 'your-company.atlassian.net',
+      value: jira.domain,
+      ignoreFocusOut: true,
+    });
+    if (domain === undefined) {
+      return;
+    }
+
+    const username = await this.showInputBox({
+      title: 'Init Jira (2 of 3): Username',
+      prompt: 'Atlassian account username (usually your account email)',
+      placeHolder: 'you@example.com',
+      value: jira.username,
+      ignoreFocusOut: true,
+    });
+    if (username === undefined) {
+      return;
+    }
+
+    const token = await this.showInputBox({
+      title: 'Init Jira (3 of 3): API token',
+      prompt: jira.token
+        ? 'API token (hidden). Leave unchanged to keep it, clear it to remove, or type a new token.'
+        : 'API token, stored securely in VS Code Secret Storage.',
+      placeHolder: 'Paste your Atlassian API token',
+      value: jira.token,
+      password: true,
+      ignoreFocusOut: true,
+    });
+    if (token === undefined) {
+      return;
+    }
+
+    try {
+      await this.configManager.updateJiraDomain(domain.trim());
+      await this.configManager.updateJiraUsername(username.trim());
+      await this.configManager.setJiraToken(token);
+    } catch (e) {
+      captureException(e);
+      this.logService.error('[Jira] Failed to save Jira credentials', e);
+      await this.showErrorMessage(
+        'Failed to save Jira credentials. See the output channel for details.'
+      );
+      return;
+    }
+
+    capture(AnalyticsEvent.JiraInitialized, {
+      has_domain: domain.trim() !== '',
+      has_username: username.trim() !== '',
+      has_token: token.trim() !== '',
+    });
+
+    this.logService.info(
+      '[Jira] Credentials saved (domain and username in settings, token in Secret Storage)'
+    );
+    await this.showInformationMessage('Jira credentials saved.');
+  }
+}

--- a/src/commands/setJiraTokenCommand/index.ts
+++ b/src/commands/setJiraTokenCommand/index.ts
@@ -1,0 +1,57 @@
+import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { LoggingService } from '../../logging/loggingService';
+import { BaseCommand } from '../command';
+
+export class SetJiraTokenCommand extends BaseCommand {
+  constructor(
+    private readonly configManager: ConfigurationManager,
+    logService: LoggingService
+  ) {
+    super(logService);
+  }
+
+  async execute(): Promise<void> {
+    const hasToken = this.configManager.hasJiraToken();
+
+    const input = await this.showInputBox({
+      title: 'Set Jira API token',
+      prompt: hasToken
+        ? 'Enter a new Jira API token, or leave empty to remove the stored token.'
+        : 'Enter your Jira API token. It is stored securely in VS Code Secret Storage.',
+      placeHolder: hasToken
+        ? 'A token is already stored — typing replaces it'
+        : 'Paste your Atlassian API token',
+      password: true,
+      ignoreFocusOut: true,
+    });
+
+    if (input === undefined) {
+      // The user dismissed the input box.
+      return;
+    }
+
+    const token = input.trim();
+
+    try {
+      await this.configManager.setJiraToken(token);
+    } catch (e) {
+      captureException(e);
+      this.logService.error('[Jira] Failed to update the Jira token in Secret Storage', e);
+      await this.showErrorMessage(
+        'Failed to update the Jira API token. See the output channel for details.'
+      );
+      return;
+    }
+
+    capture(AnalyticsEvent.JiraTokenSet, { cleared: token === '' });
+
+    if (token === '') {
+      this.logService.info('[Jira] Token removed from Secret Storage');
+      await this.showInformationMessage('Jira API token removed from Secret Storage.');
+    } else {
+      this.logService.info('[Jira] Token saved to Secret Storage');
+      await this.showInformationMessage('Jira API token saved to Secret Storage.');
+    }
+  }
+}

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -127,6 +127,18 @@ export class ConfigurationManager {
     await config.update('showStatusBar', enabled, ConfigurationTarget.Global);
   }
 
+  /** Persist the Jira Cloud host in settings (empty clears it). */
+  public async updateJiraDomain(domain: string): Promise<void> {
+    const config = workspace.getConfiguration(EXTENSION_NAME);
+    await config.update('jira.domain', domain === '' ? undefined : domain, ConfigurationTarget.Global);
+  }
+
+  /** Persist the Jira account username in settings (empty clears it). */
+  public async updateJiraUsername(username: string): Promise<void> {
+    const config = workspace.getConfiguration(EXTENSION_NAME);
+    await config.update('jira.username', username === '' ? undefined : username, ConfigurationTarget.Global);
+  }
+
   // Preferred refs helpers
   public getPreferredRefs(repoId: string): PreferredRefsRepo {
     return getRepoPrefs(this.config.preferredRefs, repoId);

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -1,7 +1,8 @@
-import { ConfigurationTarget, workspace } from 'vscode';
+import { ConfigurationTarget, Disposable, SecretStorage, workspace } from 'vscode';
 import { AUTO_STASH_MODE_MANUAL, ExtensionConfig, PreferredRefsMap, PreferredRefsRepo } from './extensionConfig';
 import { EXTENSION_NAME } from '../const';
 import { IGitRef } from '../common/git/types';
+import { JIRA_TOKEN_SECRET_KEY, migrateJiraTokenSetting } from './jiraTokenStore';
 import {
   cleanupMissingRefs,
   getRepoPrefs,
@@ -12,8 +13,55 @@ import {
 
 export class ConfigurationManager {
   private config: ExtensionConfig;
+  /** Jira API token cached from Secret Storage; never read from settings. */
+  private jiraToken = '';
 
-  constructor() {
+  constructor(private readonly secrets: SecretStorage) {
+    this.config = this.readConfig();
+  }
+
+  /**
+   * Migrate any legacy plaintext token into Secret Storage, load the stored
+   * token into the in-memory config, and keep it in sync with external changes.
+   * Call once during activation.
+   *
+   * @param onChange invoked after the cached token is refreshed from an
+   *   external secret change (e.g. another window), so dependent UI such as
+   *   command visibility can re-evaluate.
+   * @returns a disposable for the secret-change subscription.
+   */
+  public async initJiraToken(onChange?: () => void): Promise<Disposable> {
+    await migrateJiraTokenSetting(this.secrets);
+    await this.refreshJiraToken();
+
+    return this.secrets.onDidChange(async (event) => {
+      if (event.key === JIRA_TOKEN_SECRET_KEY) {
+        await this.refreshJiraToken();
+        onChange?.();
+      }
+    });
+  }
+
+  /** Store (or, when empty, remove) the Jira API token in Secret Storage. */
+  public async setJiraToken(token: string): Promise<void> {
+    const trimmed = token.trim();
+    if (trimmed === '') {
+      await this.secrets.delete(JIRA_TOKEN_SECRET_KEY);
+    } else {
+      await this.secrets.store(JIRA_TOKEN_SECRET_KEY, trimmed);
+    }
+    // Refresh eagerly so callers see the new value immediately; the onDidChange
+    // listener will also fire and is idempotent.
+    await this.refreshJiraToken();
+  }
+
+  /** Whether a non-empty Jira API token is currently stored. */
+  public hasJiraToken(): boolean {
+    return this.jiraToken.trim() !== '';
+  }
+
+  private async refreshJiraToken(): Promise<void> {
+    this.jiraToken = (await this.secrets.get(JIRA_TOKEN_SECRET_KEY)) ?? '';
     this.config = this.readConfig();
   }
 
@@ -54,7 +102,8 @@ export class ConfigurationManager {
     return {
       domain: vscodeConfig.get('jira.domain', ''),
       username,
-      token: vscodeConfig.get('jira.token', ''),
+      // The token lives in Secret Storage, not settings. See initJiraToken.
+      token: this.jiraToken,
       projectKeys: vscodeConfig.get<string[]>('jira.projectKeys', []),
     };
   }

--- a/src/configuration/jiraTokenStore.ts
+++ b/src/configuration/jiraTokenStore.ts
@@ -1,0 +1,80 @@
+import { ConfigurationTarget, workspace } from 'vscode';
+import { EXTENSION_NAME } from '../const';
+
+/**
+ * Key under which the Jira API token is stored in VS Code Secret Storage
+ * (`context.secrets`). Namespaced to avoid clashing with other extensions.
+ */
+export const JIRA_TOKEN_SECRET_KEY = 'git-smart-checkout.jira.token';
+
+/** Settings section (relative to {@link EXTENSION_NAME}) of the legacy plaintext token. */
+const LEGACY_TOKEN_SETTING = 'jira.token';
+
+/** Minimal slice of `vscode.SecretStorage` needed for migration. */
+export interface JiraSecretWriter {
+  get(key: string): Thenable<string | undefined>;
+  store(key: string, value: string): Thenable<void>;
+  delete(key: string): Thenable<void>;
+}
+
+/** Minimal slice of `vscode.WorkspaceConfiguration` needed for migration. */
+export interface LegacyTokenConfig {
+  inspect<T>(section: string):
+    | { globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T }
+    | undefined;
+  update(section: string, value: undefined, target: ConfigurationTarget): Thenable<void>;
+}
+
+/**
+ * One-time migration of a plaintext `git-smart-checkout.jira.token` setting into
+ * Secret Storage. The legacy value is stored as a secret (unless a secret is
+ * already present, which always wins) and the plaintext setting is cleared from
+ * every scope that defines it so it is no longer persisted or synced.
+ *
+ * Safe to call on every activation: when the setting is absent it is a no-op.
+ *
+ * @returns `true` when a non-empty legacy value was found and migrated.
+ */
+export async function migrateJiraTokenSetting(
+  secrets: JiraSecretWriter,
+  config: LegacyTokenConfig = workspace.getConfiguration(EXTENSION_NAME)
+): Promise<boolean> {
+  const inspected = config.inspect<string>(LEGACY_TOKEN_SETTING);
+  if (!inspected) {
+    return false;
+  }
+
+  const candidate =
+    inspected.globalValue ?? inspected.workspaceValue ?? inspected.workspaceFolderValue;
+  const legacyValue = typeof candidate === 'string' ? candidate.trim() : '';
+
+  let migrated = false;
+  if (legacyValue !== '') {
+    // A secret set explicitly via the command always wins; only seed the secret
+    // from the legacy setting when no secret exists yet.
+    const existing = await secrets.get(JIRA_TOKEN_SECRET_KEY);
+    if (!existing) {
+      await secrets.store(JIRA_TOKEN_SECRET_KEY, legacyValue);
+    }
+    migrated = true;
+  }
+
+  // Clear the plaintext setting wherever it is defined so it stops being
+  // persisted (and synced via Settings Sync).
+  await clearScope(config, inspected.globalValue, ConfigurationTarget.Global);
+  await clearScope(config, inspected.workspaceValue, ConfigurationTarget.Workspace);
+  await clearScope(config, inspected.workspaceFolderValue, ConfigurationTarget.WorkspaceFolder);
+
+  return migrated;
+}
+
+async function clearScope(
+  config: LegacyTokenConfig,
+  value: string | undefined,
+  target: ConfigurationTarget
+): Promise<void> {
+  if (value === undefined) {
+    return;
+  }
+  await config.update(LEGACY_TOKEN_SETTING, undefined, target);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import {
   MoveWipChangesFromWorktreeCommand,
 } from './commands/copyChangesFromWorktreeCommand';
 import { CreateBranchFromTemplateCommand } from './commands/createBranchFromTemplateCommand';
+import { SetJiraTokenCommand } from './commands/setJiraTokenCommand';
 import { CreateTagFromTemplateCommand } from './commands/createTagFromTemplateCommand';
 import { canShowCreateBranchFromTemplateCommand } from './services/branchTemplateAvailability';
 import { setContextCanCreateBranchFromTemplate } from './utils/setContext';
@@ -64,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const commandManager = new CommandManager();
 
-  const configManager = new ConfigurationManager();
+  const configManager = new ConfigurationManager(context.secrets);
 
   const updateTelemetryState = () =>
     setAnalyticsEnabled(vscode.env.isTelemetryEnabled && configManager.get().telemetry.enabled);
@@ -151,6 +152,9 @@ export function activate(context: vscode.ExtensionContext) {
     createBranchFromTemplateCommand
   );
 
+  const setJiraTokenCommand = new SetJiraTokenCommand(configManager, logService);
+  commandManager.registerCommand(`${EXTENSION_NAME}.setJiraToken`, setJiraTokenCommand);
+
   const refreshBranchTemplateCommandVisibility = () => {
     logService.info('[Create Branch] Re-evaluating command visibility after configuration change');
     void canShowCreateBranchFromTemplateCommand(configManager.get(), logService).then(
@@ -163,6 +167,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   void setContextCanCreateBranchFromTemplate(false);
   refreshBranchTemplateCommandVisibility();
+
+  // Migrate any legacy plaintext Jira token into Secret Storage, then load it
+  // and keep command visibility in sync with external token changes.
+  void configManager.initJiraToken(refreshBranchTemplateCommandVisibility).then(
+    (subscription) => {
+      context.subscriptions.push(subscription);
+      refreshBranchTemplateCommandVisibility();
+    },
+    (error) => logService.error('[Jira] Failed to initialize Jira token storage', error)
+  );
 
   const moveToNewWorktreeCommand = new MoveToNewWorktreeCommand(
     configManager,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import {
 } from './commands/copyChangesFromWorktreeCommand';
 import { CreateBranchFromTemplateCommand } from './commands/createBranchFromTemplateCommand';
 import { SetJiraTokenCommand } from './commands/setJiraTokenCommand';
+import { InitJiraCommand } from './commands/initJiraCommand';
 import { CreateTagFromTemplateCommand } from './commands/createTagFromTemplateCommand';
 import { canShowCreateBranchFromTemplateCommand } from './services/branchTemplateAvailability';
 import { setContextCanCreateBranchFromTemplate } from './utils/setContext';
@@ -154,6 +155,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   const setJiraTokenCommand = new SetJiraTokenCommand(configManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.setJiraToken`, setJiraTokenCommand);
+
+  const initJiraCommand = new InitJiraCommand(configManager, logService);
+  commandManager.registerCommand(`${EXTENSION_NAME}.initJira`, initJiraCommand);
 
   const refreshBranchTemplateCommandVisibility = () => {
     logService.info('[Create Branch] Re-evaluating command visibility after configuration change');

--- a/src/test/unit/configurationManager.test.ts
+++ b/src/test/unit/configurationManager.test.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 
 import { ConfigurationManager } from '../../configuration/configurationManager';
 import { EXTENSION_NAME } from '../../const';
+import { JIRA_TOKEN_SECRET_KEY } from '../../configuration/jiraTokenStore';
+import { FakeSecretStorage } from './helpers/fakeSecretStorage';
 
 describe('ConfigurationManager', () => {
   const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
@@ -10,18 +12,81 @@ describe('ConfigurationManager', () => {
   afterEach(async () => {
     await config.update('jira.username', undefined, vscode.ConfigurationTarget.Global);
     await config.update('jira.email', undefined, vscode.ConfigurationTarget.Global);
+    await config.update('jira.token', undefined, vscode.ConfigurationTarget.Global);
   });
 
   it('uses deprecated jira.email only when jira.username is empty', async () => {
     await config.update('jira.username', '', vscode.ConfigurationTarget.Global);
     await config.update('jira.email', 'legacy@example.com', vscode.ConfigurationTarget.Global);
 
-    const manager = new ConfigurationManager();
+    const manager = new ConfigurationManager(new FakeSecretStorage());
     assert.strictEqual(manager.get().jira.username, 'legacy@example.com');
 
     await config.update('jira.username', 'current@example.com', vscode.ConfigurationTarget.Global);
     manager.reload();
 
     assert.strictEqual(manager.get().jira.username, 'current@example.com');
+  });
+
+  describe('Jira token in Secret Storage', () => {
+    it('starts empty and reports no token', () => {
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      assert.strictEqual(manager.get().jira.token, '');
+      assert.strictEqual(manager.hasJiraToken(), false);
+    });
+
+    it('stores a token and exposes it through config', async () => {
+      const secrets = new FakeSecretStorage();
+      const manager = new ConfigurationManager(secrets);
+
+      await manager.setJiraToken('my-token');
+
+      assert.strictEqual(manager.get().jira.token, 'my-token');
+      assert.strictEqual(manager.hasJiraToken(), true);
+      assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'my-token');
+    });
+
+    it('trims the token before storing', async () => {
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+
+      await manager.setJiraToken('  spaced-token  ');
+
+      assert.strictEqual(manager.get().jira.token, 'spaced-token');
+    });
+
+    it('removes the token when set to an empty value', async () => {
+      const secrets = new FakeSecretStorage();
+      const manager = new ConfigurationManager(secrets);
+
+      await manager.setJiraToken('to-remove');
+      await manager.setJiraToken('   ');
+
+      assert.strictEqual(manager.get().jira.token, '');
+      assert.strictEqual(manager.hasJiraToken(), false);
+      assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    });
+
+    it('loads an existing secret and tracks external changes via initJiraToken', async () => {
+      const secrets = new FakeSecretStorage();
+      secrets.seed(JIRA_TOKEN_SECRET_KEY, 'preexisting');
+      const manager = new ConfigurationManager(secrets);
+
+      let changeCount = 0;
+      const subscription = await manager.initJiraToken(() => {
+        changeCount += 1;
+      });
+
+      assert.strictEqual(manager.get().jira.token, 'preexisting');
+
+      // Simulate a change from another window writing directly to the store.
+      await secrets.store(JIRA_TOKEN_SECRET_KEY, 'updated-elsewhere');
+      // The onDidChange handler refreshes asynchronously; let it settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.strictEqual(manager.get().jira.token, 'updated-elsewhere');
+      assert.ok(changeCount >= 1, 'onChange callback should fire on external changes');
+
+      subscription.dispose();
+    });
   });
 });

--- a/src/test/unit/helpers/fakeSecretStorage.ts
+++ b/src/test/unit/helpers/fakeSecretStorage.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+
+/**
+ * In-memory implementation of `vscode.SecretStorage` for unit tests. Fires
+ * `onDidChange` on store/delete just like the real Secret Storage.
+ */
+export class FakeSecretStorage implements vscode.SecretStorage {
+  private readonly store_ = new Map<string, string>();
+  private readonly emitter = new vscode.EventEmitter<vscode.SecretStorageChangeEvent>();
+
+  readonly onDidChange = this.emitter.event;
+
+  async get(key: string): Promise<string | undefined> {
+    return this.store_.get(key);
+  }
+
+  async store(key: string, value: string): Promise<void> {
+    this.store_.set(key, value);
+    this.emitter.fire({ key });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store_.delete(key);
+    this.emitter.fire({ key });
+  }
+
+  /** Test-only: seed a value without firing change events. */
+  seed(key: string, value: string): void {
+    this.store_.set(key, value);
+  }
+}

--- a/src/test/unit/initJiraCommand.test.ts
+++ b/src/test/unit/initJiraCommand.test.ts
@@ -1,0 +1,138 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { InitJiraCommand } from '../../commands/initJiraCommand';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { JIRA_TOKEN_SECRET_KEY } from '../../configuration/jiraTokenStore';
+import { EXTENSION_NAME } from '../../const';
+import { FakeSecretStorage } from './helpers/fakeSecretStorage';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/** InitJiraCommand with scripted input-box responses and captured prompts. */
+class ScriptedInitJiraCommand extends InitJiraCommand {
+  readonly seenInputBoxes: vscode.InputBoxOptions[] = [];
+  readonly infoMessages: string[] = [];
+  readonly errorMessages: string[] = [];
+
+  constructor(
+    configManager: ConfigurationManager,
+    private readonly responses: Array<string | undefined>
+  ) {
+    super(configManager, mockLogService);
+  }
+
+  protected async showInputBox(options: vscode.InputBoxOptions): Promise<string | undefined> {
+    this.seenInputBoxes.push(options);
+    return this.responses.shift();
+  }
+
+  protected async showInformationMessage(message: string, ..._items: string[]): Promise<string | undefined> {
+    this.infoMessages.push(message);
+    return undefined;
+  }
+
+  protected async showErrorMessage(message: string, ..._items: string[]): Promise<string | undefined> {
+    this.errorMessages.push(message);
+    return undefined;
+  }
+}
+
+describe('InitJiraCommand', () => {
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+
+  afterEach(async () => {
+    await config.update('jira.domain', undefined, vscode.ConfigurationTarget.Global);
+    await config.update('jira.username', undefined, vscode.ConfigurationTarget.Global);
+    await config.update('jira.email', undefined, vscode.ConfigurationTarget.Global);
+    await config.update('jira.token', undefined, vscode.ConfigurationTarget.Global);
+  });
+
+  it('stores domain/username in settings and the token in Secret Storage', async () => {
+    const secrets = new FakeSecretStorage();
+    const manager = new ConfigurationManager(secrets);
+    const command = new ScriptedInitJiraCommand(manager, [
+      'team.atlassian.net',
+      'me@example.com',
+      'api-token-123',
+    ]);
+
+    await command.execute();
+
+    assert.strictEqual(manager.get().jira.domain, 'team.atlassian.net');
+    assert.strictEqual(manager.get().jira.username, 'me@example.com');
+    assert.strictEqual(manager.get().jira.token, 'api-token-123');
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'api-token-123');
+    assert.deepStrictEqual(command.infoMessages, ['Jira credentials saved.']);
+  });
+
+  it('prefills existing values and renders the token masked', async () => {
+    const secrets = new FakeSecretStorage();
+    const manager = new ConfigurationManager(secrets);
+
+    await manager.setJiraToken('existing-token');
+    await config.update('jira.domain', 'old.atlassian.net', vscode.ConfigurationTarget.Global);
+    await config.update('jira.username', 'old@example.com', vscode.ConfigurationTarget.Global);
+    manager.reload();
+
+    const command = new ScriptedInitJiraCommand(manager, [
+      'old.atlassian.net',
+      'old@example.com',
+      'existing-token',
+    ]);
+
+    await command.execute();
+
+    const [domainBox, usernameBox, tokenBox] = command.seenInputBoxes;
+    assert.strictEqual(domainBox.value, 'old.atlassian.net');
+    assert.strictEqual(usernameBox.value, 'old@example.com');
+    assert.strictEqual(tokenBox.value, 'existing-token');
+    assert.strictEqual(tokenBox.password, true);
+  });
+
+  it('trims values and removes the token when the token step is cleared', async () => {
+    const secrets = new FakeSecretStorage();
+    const manager = new ConfigurationManager(secrets);
+    await manager.setJiraToken('to-remove');
+
+    const command = new ScriptedInitJiraCommand(manager, [
+      '  spaced.atlassian.net  ',
+      '  user@example.com  ',
+      '   ',
+    ]);
+
+    await command.execute();
+
+    assert.strictEqual(manager.get().jira.domain, 'spaced.atlassian.net');
+    assert.strictEqual(manager.get().jira.username, 'user@example.com');
+    assert.strictEqual(manager.get().jira.token, '');
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+  });
+
+  it('persists nothing when cancelled at the first step', async () => {
+    const secrets = new FakeSecretStorage();
+    const manager = new ConfigurationManager(secrets);
+    const command = new ScriptedInitJiraCommand(manager, [undefined]);
+
+    await command.execute();
+
+    assert.strictEqual(command.seenInputBoxes.length, 1);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    assert.deepStrictEqual(command.infoMessages, []);
+  });
+
+  it('persists nothing when cancelled at the token step', async () => {
+    const secrets = new FakeSecretStorage();
+    const manager = new ConfigurationManager(secrets);
+    const command = new ScriptedInitJiraCommand(manager, [
+      'team.atlassian.net',
+      'me@example.com',
+      undefined,
+    ]);
+
+    await command.execute();
+
+    assert.strictEqual(command.seenInputBoxes.length, 3);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    assert.deepStrictEqual(command.infoMessages, []);
+  });
+});

--- a/src/test/unit/jiraTokenStore.test.ts
+++ b/src/test/unit/jiraTokenStore.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+import { ConfigurationTarget } from 'vscode';
+
+import {
+  JIRA_TOKEN_SECRET_KEY,
+  LegacyTokenConfig,
+  migrateJiraTokenSetting,
+} from '../../configuration/jiraTokenStore';
+import { FakeSecretStorage } from './helpers/fakeSecretStorage';
+
+interface InspectResult {
+  globalValue?: string;
+  workspaceValue?: string;
+  workspaceFolderValue?: string;
+}
+
+/** Fake `vscode.WorkspaceConfiguration` slice that records `update` calls. */
+class FakeLegacyConfig implements LegacyTokenConfig {
+  readonly cleared: ConfigurationTarget[] = [];
+
+  constructor(private readonly inspectResult: InspectResult | undefined) {}
+
+  inspect<T>(_section: string) {
+    return this.inspectResult as
+      | { globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T }
+      | undefined;
+  }
+
+  async update(_section: string, value: undefined, target: ConfigurationTarget): Promise<void> {
+    assert.strictEqual(value, undefined, 'migration must only clear the setting');
+    this.cleared.push(target);
+  }
+}
+
+describe('migrateJiraTokenSetting', () => {
+  it('is a no-op when the setting was never declared', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig(undefined);
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, false);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    assert.deepStrictEqual(config.cleared, []);
+  });
+
+  it('does nothing when no scope holds a value', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({});
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, false);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    assert.deepStrictEqual(config.cleared, []);
+  });
+
+  it('moves a global plaintext token into Secret Storage and clears the setting', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({ globalValue: 'super-secret' });
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, true);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'super-secret');
+    assert.deepStrictEqual(config.cleared, [ConfigurationTarget.Global]);
+  });
+
+  it('trims whitespace around the migrated value', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({ globalValue: '  padded-token  ' });
+
+    await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'padded-token');
+  });
+
+  it('clears the workspace scope when the value lives there', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({ workspaceValue: 'ws-token' });
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, true);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'ws-token');
+    assert.deepStrictEqual(config.cleared, [ConfigurationTarget.Workspace]);
+  });
+
+  it('clears every scope that defines the setting', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({
+      globalValue: 'g',
+      workspaceValue: 'w',
+      workspaceFolderValue: 'wf',
+    });
+
+    await migrateJiraTokenSetting(secrets, config);
+
+    assert.deepStrictEqual(config.cleared, [
+      ConfigurationTarget.Global,
+      ConfigurationTarget.Workspace,
+      ConfigurationTarget.WorkspaceFolder,
+    ]);
+    // Global value wins as the seed.
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'g');
+  });
+
+  it('never overwrites a token already stored in Secret Storage', async () => {
+    const secrets = new FakeSecretStorage();
+    secrets.seed(JIRA_TOKEN_SECRET_KEY, 'existing-secret');
+    const config = new FakeLegacyConfig({ globalValue: 'stale-plaintext' });
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, true);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), 'existing-secret');
+    // The stray plaintext is still cleared from settings.
+    assert.deepStrictEqual(config.cleared, [ConfigurationTarget.Global]);
+  });
+
+  it('clears an empty plaintext value without storing a secret', async () => {
+    const secrets = new FakeSecretStorage();
+    const config = new FakeLegacyConfig({ globalValue: '   ' });
+
+    const migrated = await migrateJiraTokenSetting(secrets, config);
+
+    assert.strictEqual(migrated, false);
+    assert.strictEqual(await secrets.get(JIRA_TOKEN_SECRET_KEY), undefined);
+    assert.deepStrictEqual(config.cleared, [ConfigurationTarget.Global]);
+  });
+});


### PR DESCRIPTION
Implements point 4: stop storing the Jira API token in plaintext settings and move it to VS Code Secret Storage.

## Problem
`git-smart-checkout.jira.token` was stored as a plaintext setting and could be synced through Settings Sync, exposing the credential.

## Changes
- **New command `GSC: Set Jira token`** — prompts with a masked input box and stores the token in `context.secrets`. Submitting an empty value removes the stored token.
- **`ConfigurationManager`** now takes `SecretStorage`, caches the token from Secret Storage (never from settings), and exposes `setJiraToken`, `hasJiraToken`, and `initJiraToken`. `config.jira.token` is sourced from the cache.
- **One-time migration** (`migrateJiraTokenSetting`): on activation, any legacy plaintext value is seeded into Secret Storage (an existing secret always wins) and the setting is cleared from every scope. Safe no-op when unset.
- **`package.json`**: the `jira.token` setting is deprecated (with a `deprecationMessage`) and the new command is registered/added to the command palette.
- External secret changes (e.g. another window) refresh the cache and re-evaluate the *Create Branch from Template* command visibility.

## Tests
- `jiraTokenStore.test.ts` — migration across scopes, trimming, empty values, and "existing secret wins".
- `configurationManager.test.ts` — store/clear/trim token, initial load, and external-change tracking via `initJiraToken` (with an in-memory `FakeSecretStorage`).
- Full unit suite: **303 passing**. Type-check, lint, and production build all green.

## Docs
- README: added the command to the features table and marked the `jira.token` setting deprecated.
- `docs/create-branch-from-template.md`: documents setting the token via the command + the automatic migration.