### PR TITLE
feat(status-bar): quick-actions menu hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In fast-paced development environments, switching between Git branches is freque
 | Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
 | Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
+| Open a quick-actions menu of common commands from the status bar item | `Git Smart Checkout: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
 
 ## Extension Settings
 
@@ -74,6 +75,7 @@ This extension collects anonymous usage events to help improve the extension.
 
 - Extension activation
 - Command usage (checkout, pull, rebase, tag creation, PR clone)
+- Opening the status bar quick-actions menu
 - Stash mode used during checkout and rebase commands
 - Whether the working directory had uncommitted changes (boolean)
 - Whether copy/move worktree commands copied staged/WIP changes, whether the target had local changes, included untracked files, and how many untracked files were copied

--- a/docs/status-bar-quick-actions.md
+++ b/docs/status-bar-quick-actions.md
@@ -1,0 +1,35 @@
+# Status Bar Quick Actions
+
+Command: `Git Smart Checkout: Quick Actions`
+
+Clicking the extension status bar item opens a quick-pick menu that gathers the
+most common Git Smart Checkout commands in one place, turning the status item
+into a hub for the extension. You can also open it from the command palette.
+
+## Actions
+
+| Group | Action | Runs |
+| --- | --- | --- |
+| Stash mode | Switch stash mode | `Git Smart Checkout: Switch Mode` (the current mode is shown in the description) |
+| Checkout | Checkout to… | `Git Smart Checkout: Checkout to ... (With Stash)` |
+| Checkout | Checkout previous branch | `Git Smart Checkout: Checkout previous branch (With Stash)` |
+| Checkout | Checkout by PR number… | `Git Smart Checkout: Checkout by PR number... (With Stash)` |
+| Update branch | Pull (With Stash) | `Git Smart Checkout: Pull (With Stash)` |
+| Update branch | Pull (Rebase With Stash) | `Git Smart Checkout: Pull (Rebase With Stash)` |
+| Update branch | Rebase (With Stash) | `Git Smart Checkout: Rebase ... (With Stash)` |
+| Worktree | Move to new worktree | `Git Smart Checkout: Move to new worktree` |
+| GitHub | Clone pull request… | `Git Smart Checkout: Clone pull request...` |
+
+Selecting an action runs the underlying command, so each step behaves exactly as
+it does from the command palette. Dismissing the menu (for example with `Esc`)
+does nothing.
+
+## Status Bar
+
+The status bar item shows the current stash mode and opens this menu on click.
+Switching the stash mode is available as the first action. Hide the status bar
+item with:
+
+```json
+"git-smart-checkout.showStatusBar": false
+```

--- a/docs/switch-mode.md
+++ b/docs/switch-mode.md
@@ -2,7 +2,7 @@
 
 Command: `Git Smart Checkout: Switch Mode`
 
-Use this command, or click the extension status bar item, to change the default stash mode used by checkout-style commands.
+Use this command to change the default stash mode used by checkout-style commands. It is also the first action in the status bar [quick-actions menu](status-bar-quick-actions.md).
 
 ## What It Controls
 
@@ -26,9 +26,9 @@ For rebase, `autoStashAndPop` and `autoStashAndApply` are treated as "Auto stash
 
 ## Status Bar
 
-The status bar item shows the current mode and opens the same mode picker. Manual mode uses
-the normal status bar background, while automatic modes use the warning background to remain
-visually distinct. Hide the item with:
+The status bar item shows the current mode and opens the [quick-actions menu](status-bar-quick-actions.md),
+where "Switch stash mode" is the first action. Manual mode uses the normal status bar background,
+while automatic modes use the warning background to remain visually distinct. Hide the item with:
 
 ```json
 "git-smart-checkout.showStatusBar": false

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.showStatusBarMenu",
+        "title": "Quick Actions",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.clonePullRequest",
         "title": "Clone pull request...",
         "category": "GSC",

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -28,6 +28,7 @@ export enum AnalyticsEvent {
   MoveWipChangesFromWorktree = 'move_wip_changes_from_worktree',
   WorktreeDevTerminalOpened = 'worktree_dev_terminal_opened',
   CopyBranchName = 'copy_branch_name',
+  StatusBarMenuOpened = 'status_bar_menu_opened',
 }
 
 let client: PostHog | null = null;

--- a/src/commands/statusBarMenuCommand/index.ts
+++ b/src/commands/statusBarMenuCommand/index.ts
@@ -1,0 +1,17 @@
+import { LoggingService } from '../../logging/loggingService';
+import { StatusBarManager } from '../../statusBar/statusBarManager';
+import { BaseCommand } from '../command';
+
+export class StatusBarMenuCommand extends BaseCommand {
+  private statusBarManager: StatusBarManager;
+
+  constructor(statusBarManager: StatusBarManager, logService: LoggingService) {
+    super(logService);
+
+    this.statusBarManager = statusBarManager;
+  }
+
+  async execute(): Promise<void> {
+    await this.statusBarManager.showQuickActionsMenu();
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { CopyBranchNameCommand } from './commands/copyBranchNameCommand';
 import { CommandManager } from './commands/commandManager';
 import { PullRebaseWithStashCommand, PullWithStashCommand } from './commands/pullWithStashCommand';
 import { SwitchModeCommand } from './commands/switchModeCommand';
+import { StatusBarMenuCommand } from './commands/statusBarMenuCommand';
 import { VscodeGitProvider } from './common/git/vscodeGitProvider';
 import { ConfigurationManager } from './configuration/configurationManager';
 import { EXTENSION_NAME } from './const';
@@ -111,6 +112,9 @@ export function activate(context: vscode.ExtensionContext) {
   const pullRebaseWithStashCommand = new PullRebaseWithStashCommand(logService, autoStashService);
 
   commandManager.registerCommand(`${EXTENSION_NAME}.switchMode`, switchModeCommand);
+
+  const statusBarMenuCommand = new StatusBarMenuCommand(statusBarManager, logService);
+  commandManager.registerCommand(`${EXTENSION_NAME}.showStatusBarMenu`, statusBarMenuCommand);
 
   commandManager.registerCommand(`${EXTENSION_NAME}.checkoutTo`, checkoutToCommand);
 

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -2,6 +2,7 @@ import {
   commands,
   Disposable,
   QuickPickItem,
+  QuickPickItemKind,
   StatusBarAlignment,
   StatusBarItem,
   ThemeColor,
@@ -17,6 +18,10 @@ import {
   TAutoStashModeConfig,
 } from '../configuration/extensionConfig';
 import { AnalyticsEvent, capture } from '../analytics/analytics';
+
+interface QuickActionItem extends QuickPickItem {
+  commandId?: string;
+}
 
 export function getStatusBarBackgroundColor(
   mode: TAutoStashModeConfig
@@ -37,7 +42,7 @@ export class StatusBarManager implements Disposable {
 
     this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
 
-    this.statusBarItem.command = `${EXTENSION_NAME}.switchMode`;
+    this.statusBarItem.command = `${EXTENSION_NAME}.showStatusBarMenu`;
     this.updateStatusBar();
   }
 
@@ -47,7 +52,7 @@ export class StatusBarManager implements Disposable {
     const modeDetails = AUTO_STASH_MODES_DETAILS[config.mode as TAutoStashModeConfig];
 
     this.statusBarItem.text = `${modeDetails.icon} ${modeDetails.briefLabel}`;
-    this.statusBarItem.tooltip = `${EXTENSION_NAME}\nCurrent mode: ${modeDetails.label}\nClick to switch modes`;
+    this.statusBarItem.tooltip = `${EXTENSION_NAME}\nCurrent mode: ${modeDetails.label}\nClick to open quick actions`;
 
     this.statusBarItem.backgroundColor = getStatusBarBackgroundColor(config.mode);
 
@@ -105,6 +110,47 @@ export class StatusBarManager implements Disposable {
       //     }
       //   });
     }
+  }
+
+  public async showQuickActionsMenu(): Promise<void> {
+    capture(AnalyticsEvent.StatusBarMenuOpened);
+
+    const config = this.configManager.get();
+    const modeDetails = AUTO_STASH_MODES_DETAILS[config.mode as TAutoStashModeConfig];
+    const command = (name: string) => `${EXTENSION_NAME}.${name}`;
+
+    const items: QuickActionItem[] = [
+      { label: 'Stash mode', kind: QuickPickItemKind.Separator },
+      {
+        label: '$(gear) Switch stash mode',
+        description: `Current: ${modeDetails.briefLabel}`,
+        commandId: command('switchMode'),
+      },
+      { label: 'Checkout', kind: QuickPickItemKind.Separator },
+      { label: '$(arrow-swap) Checkout to…', commandId: command('checkoutTo') },
+      { label: '$(history) Checkout previous branch', commandId: command('checkoutPrevious') },
+      { label: '$(git-pull-request) Checkout by PR number…', commandId: command('checkoutByPR') },
+      { label: 'Update branch', kind: QuickPickItemKind.Separator },
+      { label: '$(repo-pull) Pull (With Stash)', commandId: command('pullWithStash') },
+      { label: '$(repo-pull) Pull (Rebase With Stash)', commandId: command('pullRebaseWithStash') },
+      { label: '$(git-merge) Rebase (With Stash)', commandId: command('rebaseWithStash') },
+      { label: 'Worktree', kind: QuickPickItemKind.Separator },
+      { label: '$(list-tree) Move to new worktree', commandId: command('moveToNewWorktree') },
+      { label: 'GitHub', kind: QuickPickItemKind.Separator },
+      { label: '$(repo-clone) Clone pull request…', commandId: command('clonePullRequest') },
+    ];
+
+    const selection = await window.showQuickPick(items, {
+      title: 'Git Smart Checkout',
+      placeHolder: 'Select an action',
+    });
+
+    if (!selection?.commandId) {
+      return;
+    }
+
+    this.loggingService.info(`Status bar quick action: ${selection.commandId}`);
+    await commands.executeCommand(selection.commandId);
   }
 
   public show(): void {

--- a/src/test/e2e/statusBarMenu.test.ts
+++ b/src/test/e2e/statusBarMenu.test.ts
@@ -1,0 +1,172 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import {
+  AUTO_STASH_MODE_BRANCH,
+  AUTO_STASH_MODE_MANUAL,
+  AUTO_STASH_MODES_DETAILS,
+} from '../../configuration/extensionConfig';
+import { EXTENSION_NAME } from '../../const';
+
+type MenuItem = vscode.QuickPickItem & { commandId?: string };
+
+const commandId = (name: string) => `${EXTENSION_NAME}.${name}`;
+
+const MENU_PLACEHOLDER = 'Select an action';
+
+const EXPECTED_ACTIONS = [
+  'switchMode',
+  'checkoutTo',
+  'checkoutPrevious',
+  'checkoutByPR',
+  'pullWithStash',
+  'pullRebaseWithStash',
+  'rebaseWithStash',
+  'moveToNewWorktree',
+  'clonePullRequest',
+];
+
+function delay(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function ensureExtensionActivated(): Promise<void> {
+  const extension = vscode.extensions.all.find(
+    (item) => item.packageJSON?.name === EXTENSION_NAME
+  );
+
+  assert.ok(extension, `Extension ${EXTENSION_NAME} should be installed in the test host.`);
+  await extension.activate();
+}
+
+async function setExtensionMode(mode: string | undefined): Promise<void> {
+  await vscode.workspace
+    .getConfiguration(EXTENSION_NAME)
+    .update('mode', mode, vscode.ConfigurationTarget.Global);
+  await delay(50);
+}
+
+function getMode(): string | undefined {
+  return vscode.workspace.getConfiguration(EXTENSION_NAME).get<string>('mode');
+}
+
+function stubShowQuickPick(
+  pick: (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options: vscode.QuickPickOptions | undefined
+  ) => vscode.QuickPickItem | string | undefined
+): () => void {
+  const original = vscode.window.showQuickPick.bind(vscode.window);
+
+  (vscode.window as any).showQuickPick = async (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options?: vscode.QuickPickOptions
+  ) => pick(items, options);
+
+  return () => {
+    (vscode.window as any).showQuickPick = original;
+  };
+}
+
+describe('status bar quick actions menu', () => {
+  before(async () => {
+    await ensureExtensionActivated();
+  });
+
+  beforeEach(async () => {
+    await setExtensionMode(AUTO_STASH_MODE_MANUAL);
+  });
+
+  afterEach(async () => {
+    await setExtensionMode(AUTO_STASH_MODE_MANUAL);
+  });
+
+  it('contributes the quick actions command', async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes(commandId('showStatusBarMenu')));
+  });
+
+  it('lists the expected actions grouped by separators', async () => {
+    let inspected = false;
+    const restore = stubShowQuickPick((items, options) => {
+      if (options?.placeHolder !== MENU_PLACEHOLDER) {
+        return undefined;
+      }
+
+      inspected = true;
+      const menuItems = items as readonly MenuItem[];
+
+      const actionCommands = menuItems
+        .filter((item) => typeof item !== 'string' && item.commandId)
+        .map((item) => item.commandId);
+
+      for (const name of EXPECTED_ACTIONS) {
+        assert.ok(
+          actionCommands.includes(commandId(name)),
+          `menu should include the ${name} action`
+        );
+      }
+
+      const separators = menuItems.filter(
+        (item) =>
+          typeof item !== 'string' && item.kind === vscode.QuickPickItemKind.Separator
+      );
+      assert.ok(separators.length >= 4, 'menu should group actions with separators');
+
+      const switchModeItem = menuItems.find(
+        (item) => item.commandId === commandId('switchMode')
+      );
+      assert.ok(
+        switchModeItem?.description?.includes(
+          AUTO_STASH_MODES_DETAILS[AUTO_STASH_MODE_MANUAL].briefLabel
+        ),
+        'switch mode action should show the current mode in its description'
+      );
+
+      // Dismiss the menu without selecting anything.
+      return undefined;
+    });
+
+    try {
+      await vscode.commands.executeCommand(commandId('showStatusBarMenu'));
+
+      assert.strictEqual(inspected, true);
+      // Dismissing the menu must be a no-op.
+      assert.strictEqual(getMode(), AUTO_STASH_MODE_MANUAL);
+    } finally {
+      restore();
+    }
+  });
+
+  it('runs the selected action (switch stash mode)', async () => {
+    const targetLabel = AUTO_STASH_MODES_DETAILS[AUTO_STASH_MODE_BRANCH].label;
+    let openedMenu = false;
+    let openedModePicker = false;
+
+    const restore = stubShowQuickPick((items, options) => {
+      const menuItems = items as readonly MenuItem[];
+
+      if (options?.placeHolder === MENU_PLACEHOLDER) {
+        openedMenu = true;
+        return menuItems.find((item) => item.commandId === commandId('switchMode'));
+      }
+
+      // The switchMode command opens its own mode picker.
+      openedModePicker = true;
+      return menuItems.find(
+        (item) => typeof item !== 'string' && item.label.includes(targetLabel)
+      );
+    });
+
+    try {
+      await vscode.commands.executeCommand(commandId('showStatusBarMenu'));
+      await delay(100);
+
+      assert.strictEqual(openedMenu, true, 'the quick actions menu should be shown');
+      assert.strictEqual(openedModePicker, true, 'selecting switch mode should open the mode picker');
+      assert.strictEqual(getMode(), AUTO_STASH_MODE_BRANCH);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements **point 9** from the *Improvements and new feature ideas* list in the code review: turn the status bar item into a hub for the extension.

Previously, clicking the status bar item only opened the stash-mode picker. It now opens a grouped quick-pick menu of the most common Git Smart Checkout commands. Switching the stash mode is still the first action (and shows the current mode in its description), so existing muscle memory keeps working.

### Menu contents

| Group | Action |
| --- | --- |
| Stash mode | Switch stash mode (shows current mode) |
| Checkout | Checkout to…, Checkout previous branch, Checkout by PR number… |
| Update branch | Pull (With Stash), Pull (Rebase With Stash), Rebase (With Stash) |
| Worktree | Move to new worktree |
| GitHub | Clone pull request… |

Each entry simply dispatches the existing command, so behavior is identical to running it from the command palette.

## Changes

- `StatusBarManager.showQuickActionsMenu()` builds and shows the grouped menu and dispatches the chosen command.
- New thin `StatusBarMenuCommand` registered as `git-smart-checkout.showStatusBarMenu`; the status bar item now points at it (tooltip updated to "Click to open quick actions").
- New `Quick Actions` command contribution in `package.json`.
- New `status_bar_menu_opened` analytics event (documented in the README telemetry section).
- Docs: new `docs/status-bar-quick-actions.md`, plus README Features row and `switch-mode.md` updates.

## Testing

- `yarn compile` (type-check + lint) ✓
- `yarn test:unit` — 290 passing ✓
- `yarn test:e2e` — full suite passing ✓ (new `statusBarMenu.test.ts` covers command contribution, menu contents/separators, current-mode description, and action dispatch via switch-mode)