### PR TITLE
feat(pr-clone): pre-fill description from PR template with markdown preview

### DIFF
--- a/docs/github-pr-clone.md
+++ b/docs/github-pr-clone.md
@@ -21,7 +21,7 @@ The GitHub PR Clone feature creates a new pull request by cherry-picking selecte
 2. Select the GitHub pull request you want to clone from.
 3. Choose the target branch where your new PR should be merged.
 4. Choose the feature branch name for your new PR.
-5. Add a description for the new PR.
+5. Review the pre-filled description for the new PR (see [Description editor and templates](#description-editor-and-templates)).
 6. Select the commits to cherry-pick.
 7. Let the extension create the branch, cherry-pick commits, and create the new PR or draft PR.
 
@@ -35,6 +35,16 @@ During the cherry-pick process, the extension stashes uncommitted workspace chan
 In a multi-root workspace, the command asks which repository to use each time it runs. Switching repositories refreshes the repository shown in the PR Clone view and all subsequent PR data and Git operations use the newly selected repository.
 
 The new PR also copies labels and assignees from the original PR. These metadata updates are best effort: if GitHub rejects one of them, the new PR is still created and the failure is logged.
+
+## Description editor and templates
+
+The description field is pre-filled so you rarely start from scratch:
+
+- The first line is always a back-reference link to the source PR (`[Cloned from PR #N](...)`).
+- The body of the original pull request is used as the description.
+- When the source PR has an **empty** body, the extension falls back to the repository's pull request template, if it has one. The following locations are checked, and the first match wins: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`, `PULL_REQUEST_TEMPLATE.md`, `pull_request_template.md`, `docs/PULL_REQUEST_TEMPLATE.md`, and `docs/pull_request_template.md`.
+
+Use the **Edit / Preview** toggle above the field to switch between editing the raw Markdown and a rendered Markdown preview, so you can check formatting (headings, lists, task lists, links, code, and quotes) before creating the PR. The description stays fully editable regardless of how it was pre-filled.
 
 ## Conflict Handling
 

--- a/src/common/api/ghClient.ts
+++ b/src/common/api/ghClient.ts
@@ -4,6 +4,46 @@ import { authentication } from 'vscode';
 import { EXTENSION_NAME } from '../../const';
 import { GitHubCommit, GitHubCommitFile, GitHubLabel, GitHubPR, GitHubUser } from '../../types/dataTypes';
 
+/**
+ * Locations GitHub recognizes for a single pull request template, in priority
+ * order. The first non-empty match wins.
+ * @see https://docs.github.com/articles/creating-a-pull-request-template-for-your-repository
+ */
+export const PR_TEMPLATE_CANDIDATE_PATHS = [
+  '.github/PULL_REQUEST_TEMPLATE.md',
+  '.github/pull_request_template.md',
+  'PULL_REQUEST_TEMPLATE.md',
+  'pull_request_template.md',
+  'docs/PULL_REQUEST_TEMPLATE.md',
+  'docs/pull_request_template.md',
+];
+
+interface GitHubContentsResponse {
+  content?: string;
+  encoding?: string;
+}
+
+/**
+ * Decode a GitHub "get repository content" response into UTF-8 text. Returns
+ * undefined when the payload is not a base64-encoded file (e.g. a directory
+ * listing comes back as an array, or the encoding is unexpected).
+ */
+export const decodeGitHubFileContent = (
+  response: GitHubContentsResponse | undefined | null
+): string | undefined => {
+  if (!response || typeof response.content !== 'string') {
+    return undefined;
+  }
+  if (response.encoding && response.encoding !== 'base64') {
+    return undefined;
+  }
+  try {
+    return Buffer.from(response.content, 'base64').toString('utf-8');
+  } catch {
+    return undefined;
+  }
+};
+
 export class GitHubClient {
   private static readonly BASE_URL = 'https://api.github.com';
   private static readonly USER_AGENT = `${EXTENSION_NAME}-vscode-extension`;
@@ -287,5 +327,35 @@ export class GitHubClient {
   public async fetchLabels(): Promise<GitHubLabel[]> {
     const endpoint = `/repos/${this.owner}/${this.repo}/labels`;
     return this.makePaginatedRequest<GitHubLabel>(endpoint);
+  }
+
+  /**
+   * Fetch the repository's pull request template, if one exists.
+   *
+   * Probes the locations GitHub recognizes for a single template and returns
+   * the first non-empty match (in priority order). Missing templates surface as
+   * 404s, which are expected and swallowed; this method returns undefined when
+   * no template is found.
+   */
+  public async fetchPullRequestTemplate(): Promise<string | undefined> {
+    const responses = await Promise.allSettled(
+      PR_TEMPLATE_CANDIDATE_PATHS.map((path) =>
+        this.makeRequest<GitHubContentsResponse>(
+          `/repos/${this.owner}/${this.repo}/contents/${encodeURI(path)}`
+        )
+      )
+    );
+
+    for (const result of responses) {
+      if (result.status !== 'fulfilled') {
+        continue;
+      }
+      const decoded = decodeGitHubFileContent(result.value);
+      if (decoded && decoded.trim().length > 0) {
+        return decoded;
+      }
+    }
+
+    return undefined;
   }
 }

--- a/src/test/unit/buildCloneDescription.test.ts
+++ b/src/test/unit/buildCloneDescription.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+
+import { buildCloneDescription } from '../../webview/utils/buildCloneDescription';
+
+const pr = {
+  number: 42,
+  html_url: 'https://github.com/owner/repo/pull/42',
+};
+
+const header = '[Cloned from PR #42](https://github.com/owner/repo/pull/42)';
+
+describe('buildCloneDescription', () => {
+  it('uses the original PR body when present', () => {
+    const result = buildCloneDescription(
+      { ...pr, body: 'Original body\n\nwith details' },
+      '## Template\n- [ ] item'
+    );
+
+    assert.strictEqual(result, `${header}\n\nOriginal body\n\nwith details`);
+  });
+
+  it('falls back to the template when the body is empty', () => {
+    const template = '## Summary\n\n- [ ] Tests added';
+    const result = buildCloneDescription({ ...pr, body: '' }, template);
+
+    assert.strictEqual(result, `${header}\n\n${template}`);
+  });
+
+  it('treats a whitespace-only body as empty and uses the template', () => {
+    const template = 'Checklist';
+    const result = buildCloneDescription({ ...pr, body: '   \n  \t' }, template);
+
+    assert.strictEqual(result, `${header}\n\n${template}`);
+  });
+
+  it('falls back to an empty description when neither body nor template exist', () => {
+    const result = buildCloneDescription({ ...pr, body: '' });
+
+    assert.strictEqual(result, `${header}\n\n`);
+  });
+
+  it('handles a null/undefined body', () => {
+    const result = buildCloneDescription({ ...pr, body: null }, 'Template body');
+
+    assert.strictEqual(result, `${header}\n\nTemplate body`);
+  });
+
+  it('always keeps the back-reference link on the first line', () => {
+    const result = buildCloneDescription({ ...pr, body: 'anything' });
+
+    assert.ok(result.startsWith(header));
+  });
+});

--- a/src/test/unit/githubTemplate.test.ts
+++ b/src/test/unit/githubTemplate.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+
+import {
+  PR_TEMPLATE_CANDIDATE_PATHS,
+  decodeGitHubFileContent,
+} from '../../common/api/ghClient';
+
+const toBase64 = (value: string): string => Buffer.from(value, 'utf-8').toString('base64');
+
+describe('decodeGitHubFileContent', () => {
+  it('decodes base64 file content into UTF-8 text', () => {
+    const text = '## Pull request template\n\n- [ ] Tests added';
+    const decoded = decodeGitHubFileContent({ content: toBase64(text), encoding: 'base64' });
+
+    assert.strictEqual(decoded, text);
+  });
+
+  it('tolerates the newline-wrapped base64 GitHub returns', () => {
+    const text = 'line one\nline two';
+    const wrapped = toBase64(text).replace(/(.{4})/g, '$1\n');
+    const decoded = decodeGitHubFileContent({ content: wrapped, encoding: 'base64' });
+
+    assert.strictEqual(decoded, text);
+  });
+
+  it('defaults to base64 when no encoding is provided', () => {
+    const decoded = decodeGitHubFileContent({ content: toBase64('hello') });
+
+    assert.strictEqual(decoded, 'hello');
+  });
+
+  it('returns undefined for unexpected encodings', () => {
+    const decoded = decodeGitHubFileContent({ content: 'whatever', encoding: 'utf-8' });
+
+    assert.strictEqual(decoded, undefined);
+  });
+
+  it('returns undefined when there is no content (e.g. a directory listing)', () => {
+    assert.strictEqual(decodeGitHubFileContent({}), undefined);
+    assert.strictEqual(decodeGitHubFileContent(undefined), undefined);
+    assert.strictEqual(decodeGitHubFileContent(null), undefined);
+  });
+});
+
+describe('PR_TEMPLATE_CANDIDATE_PATHS', () => {
+  it('probes the canonical template locations in priority order', () => {
+    assert.strictEqual(PR_TEMPLATE_CANDIDATE_PATHS[0], '.github/PULL_REQUEST_TEMPLATE.md');
+    assert.ok(PR_TEMPLATE_CANDIDATE_PATHS.includes('PULL_REQUEST_TEMPLATE.md'));
+    assert.ok(PR_TEMPLATE_CANDIDATE_PATHS.includes('docs/PULL_REQUEST_TEMPLATE.md'));
+  });
+
+  it('covers lowercase variants', () => {
+    assert.ok(PR_TEMPLATE_CANDIDATE_PATHS.includes('.github/pull_request_template.md'));
+  });
+});

--- a/src/test/unit/renderMarkdown.test.ts
+++ b/src/test/unit/renderMarkdown.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert';
+
+import { renderMarkdown } from '../../webview/utils/renderMarkdown';
+
+describe('renderMarkdown', () => {
+  it('returns an empty string for empty input', () => {
+    assert.strictEqual(renderMarkdown(''), '');
+  });
+
+  it('renders headings at the right level', () => {
+    assert.strictEqual(renderMarkdown('# Title'), '<h1>Title</h1>');
+    assert.strictEqual(renderMarkdown('### Sub'), '<h3>Sub</h3>');
+  });
+
+  it('wraps plain text in a paragraph', () => {
+    assert.strictEqual(renderMarkdown('hello world'), '<p>hello world</p>');
+  });
+
+  it('renders bold, italic, strikethrough and inline code', () => {
+    assert.strictEqual(renderMarkdown('**bold**'), '<p><strong>bold</strong></p>');
+    assert.strictEqual(renderMarkdown('*italic*'), '<p><em>italic</em></p>');
+    assert.strictEqual(renderMarkdown('~~gone~~'), '<p><del>gone</del></p>');
+    assert.strictEqual(renderMarkdown('`code`'), '<p><code>code</code></p>');
+  });
+
+  it('escapes HTML so embedded markup cannot execute', () => {
+    const html = renderMarkdown('<script>alert(1)</script>');
+    assert.ok(!html.includes('<script>'), 'raw <script> must not appear');
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+
+  it('does not reinterpret characters inside inline code', () => {
+    const html = renderMarkdown('`a_b_c` and _real_');
+    assert.ok(html.includes('<code>a_b_c</code>'), 'underscores in code stay literal');
+    assert.ok(html.includes('<em>real</em>'), 'emphasis still works outside code');
+  });
+
+  it('renders safe links and rejects dangerous schemes', () => {
+    const safe = renderMarkdown('[text](https://example.com)');
+    assert.ok(safe.includes('<a href="https://example.com"'));
+    assert.ok(safe.includes('rel="noopener noreferrer"'));
+
+    const dangerous = renderMarkdown('[x](javascript:alert(1))');
+    assert.ok(!dangerous.includes('<a '), 'javascript: links must not become anchors');
+  });
+
+  it('keeps underscores inside link URLs intact', () => {
+    const html = renderMarkdown('[t](https://example.com/a_b_c)');
+    assert.ok(html.includes('href="https://example.com/a_b_c"'));
+    assert.ok(!html.includes('<em>'), 'URL underscores must not turn into emphasis');
+  });
+
+  it('renders unordered lists', () => {
+    assert.strictEqual(renderMarkdown('- one\n- two'), '<ul><li>one</li><li>two</li></ul>');
+  });
+
+  it('renders task list checkboxes', () => {
+    const html = renderMarkdown('- [ ] todo\n- [x] done');
+    assert.ok(html.includes('type="checkbox" disabled />'), 'unchecked box rendered');
+    assert.ok(html.includes('type="checkbox" disabled checked />'), 'checked box rendered');
+    assert.ok(html.includes('todo'));
+    assert.ok(html.includes('done'));
+  });
+
+  it('renders ordered lists', () => {
+    assert.strictEqual(renderMarkdown('1. a\n2. b'), '<ol><li>a</li><li>b</li></ol>');
+  });
+
+  it('renders fenced code blocks without inline formatting', () => {
+    const html = renderMarkdown('```\nconst a = **b**;\n```');
+    assert.ok(html.startsWith('<pre><code>'));
+    assert.ok(html.includes('const a = **b**;'), 'code content kept literal');
+    assert.ok(!html.includes('<strong>'));
+  });
+
+  it('renders blockquotes', () => {
+    const html = renderMarkdown('> quoted');
+    assert.ok(html.includes('<blockquote>'));
+    assert.ok(html.includes('quoted'));
+  });
+
+  it('renders horizontal rules', () => {
+    assert.strictEqual(renderMarkdown('---'), '<hr />');
+  });
+});

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -209,7 +209,17 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
       const branches = await this.getBranches(git);
 
-      this.updateWebviewWithPRData(prData, detailedCommits, branches);
+      // Best-effort: pre-fill the description from the repo's PR template when
+      // the source PR has no body. A missing template (or fetch failure) must
+      // not block the clone flow.
+      let prTemplate: string | undefined;
+      try {
+        prTemplate = await ghClient.fetchPullRequestTemplate();
+      } catch (templateError) {
+        this.loggingService.warn(`Failed to fetch PR template: ${templateError}`);
+      }
+
+      this.updateWebviewWithPRData(prData, detailedCommits, branches, prTemplate);
     } catch (error) {
       this.loggingService.error(`Failed to fetch PR: ${error}`);
       await postFetchPRError(this.webviewView?.webview, error);
@@ -243,7 +253,12 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     }
   }
 
-  private updateWebviewWithPRData(prData: GitHubPR, commits: GitHubCommit[], branches: string[]) {
+  private updateWebviewWithPRData(
+    prData: GitHubPR,
+    commits: GitHubCommit[],
+    branches: string[],
+    prTemplate?: string
+  ) {
     this.currentCommits = commits;
 
     if (!this.webviewView) {
@@ -272,6 +287,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       branches,
       defaultTargetBranch,
       prBranchPrefix,
+      prTemplate,
     });
 
     // Also update the commits webview

--- a/src/webview/Apps/PR/App/index.tsx
+++ b/src/webview/Apps/PR/App/index.tsx
@@ -98,7 +98,8 @@ export const App: React.FC = () => {
             commits: message.commits,
             branches: message.branches,
             defaultTargetBranch: message.defaultTargetBranch,
-            prBranchPrefix: message.prBranchPrefix
+            prBranchPrefix: message.prBranchPrefix,
+            prTemplate: message.prTemplate
           });
           break;
         case message.command === WebviewCommand.FETCH_PR_ERROR:
@@ -151,6 +152,7 @@ export const App: React.FC = () => {
         selectedTargetBranch={state.targetBranch}
         defaultTargetBranch={state.defaultTargetBranch}
         prBranchPrefix={state.prBranchPrefix}
+        prTemplate={state.prTemplate}
         isCloning={state.isCloning || false}
       />
     );

--- a/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
@@ -1,17 +1,20 @@
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+
 import { Button } from '@/components/Button';
 import { DropDownAction, DropDownButton } from '@/components/DropDownButton';
 import { Input } from '@/components/Input';
 import { Link } from '@/components/Link';
+import { MarkdownPreview } from '@/components/MarkdownPreview';
 import { Text } from '@/components/Text';
 import { Textarea } from '@/components/Textarea';
 import { useLogger } from '@/hooks';
-import { GitHubCommit, GitHubPR } from '@/types/dataTypes';
-import React, { useEffect, useState } from 'react';
-
+import { useSendMessage } from '@/hooks/useSendMessage';
 import { WebviewCommand } from '@/types/commands';
+import { GitHubCommit, GitHubPR } from '@/types/dataTypes';
+import { buildCloneDescription } from '@/utils/buildCloneDescription';
 
 import styles from './module.css';
-import { useSendMessage } from '@/hooks/useSendMessage';
 
 interface PrCloneFormProps {
   prData: GitHubPR;
@@ -22,6 +25,7 @@ interface PrCloneFormProps {
   selectedTargetBranch?: string;
   defaultTargetBranch?: string;
   prBranchPrefix?: string;
+  prTemplate?: string;
   isCloning: boolean;
 }
 
@@ -34,8 +38,9 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
   selectedTargetBranch,
   defaultTargetBranch,
   prBranchPrefix,
+  prTemplate,
   isCloning,
-  
+
 }) => {
   const [targetBranch, setTargetBranch] = useState(() => {
     // Use defaultTargetBranch from settings if provided and not empty, otherwise fallback
@@ -55,15 +60,10 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
 
   const prefix = createPrefix(prBranchPrefix);
   const [featureBranch, setFeatureBranch] = useState(`${prefix}${prData.head.ref}_clone`);
-  const [description, setDescription] = useState(() => {
-    const result = [
-      `[Cloned from PR #${prData.number}](${prData.html_url})`,
-      "",
-      prData.body || ''
-    ]
-
-    return result.join("\n");
-  });
+  const [description, setDescription] = useState(() =>
+    buildCloneDescription(prData, prTemplate)
+  );
+  const [isPreview, setIsPreview] = useState(false);
   const [selectedCommits, setSelectedCommits] = useState<string[]>([]);
 
   const logger = useLogger(false);
@@ -202,14 +202,44 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
 
       <div className={styles.form}>
 
+        <div className={styles.descriptionHeader}>
+          <Text.Label className={styles.branchLabel}>DESCRIPTION</Text.Label>
+          <div className={styles.viewToggle} role="tablist" aria-label="Description view mode">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={!isPreview}
+              className={classNames(styles.toggleButton, { [styles.toggleButtonActive]: !isPreview })}
+              onClick={() => setIsPreview(false)}
+              disabled={isCloning}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isPreview}
+              className={classNames(styles.toggleButton, { [styles.toggleButtonActive]: isPreview })}
+              onClick={() => setIsPreview(true)}
+              disabled={isCloning}
+            >
+              Preview
+            </button>
+          </div>
+        </div>
+
         <div className={styles.inputField}>
-          <Textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Description"
-            rows={10}
-            disabled={isCloning}
-          />
+          {isPreview ? (
+            <MarkdownPreview markdown={description} />
+          ) : (
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description"
+              rows={10}
+              disabled={isCloning}
+            />
+          )}
         </div>
 
 

--- a/src/webview/Apps/PR/pages/PrCloneForm/module.css
+++ b/src/webview/Apps/PR/pages/PrCloneForm/module.css
@@ -51,6 +51,50 @@
   height: 100%;
 }
 
+.descriptionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.viewToggle {
+  display: inline-flex;
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.toggleButton {
+  appearance: none;
+  border: none;
+  padding: 2px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--vscode-foreground);
+  background-color: transparent;
+  font-family: var(--vscode-font-family);
+
+  &:not(:last-child) {
+    border-right: 1px solid var(--vscode-dropdown-border);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+  }
+}
+
+.toggleButtonActive {
+  color: var(--vscode-button-foreground);
+  background-color: var(--vscode-button-background);
+}
+
 .inputField {
   display: flex;
   border-bottom: 1px solid var(--vscode-widget-border);

--- a/src/webview/components/MarkdownPreview/index.tsx
+++ b/src/webview/components/MarkdownPreview/index.tsx
@@ -1,0 +1,27 @@
+import classNames from 'classnames';
+import { FC } from 'react';
+
+import { renderMarkdown } from '@/utils/renderMarkdown';
+
+import styles from './module.css';
+
+interface MarkdownPreviewProps {
+  markdown: string;
+  className?: string;
+}
+
+export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown, className }) => {
+  const classes = classNames(styles.preview, className);
+
+  if (!markdown.trim()) {
+    return (
+      <div className={classes}>
+        <span className={styles.empty}>Nothing to preview</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes} dangerouslySetInnerHTML={{ __html: renderMarkdown(markdown) }} />
+  );
+};

--- a/src/webview/components/MarkdownPreview/module.css
+++ b/src/webview/components/MarkdownPreview/module.css
@@ -1,0 +1,122 @@
+.preview {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-input-background);
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 2px;
+  word-wrap: break-word;
+}
+
+.empty {
+  color: var(--vscode-input-placeholderForeground);
+  font-style: italic;
+}
+
+.preview :first-child {
+  margin-top: 0;
+}
+
+.preview :last-child {
+  margin-bottom: 0;
+}
+
+.preview h1,
+.preview h2,
+.preview h3,
+.preview h4,
+.preview h5,
+.preview h6 {
+  margin: 12px 0 6px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.preview h1 {
+  font-size: 1.4em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.preview h2 {
+  font-size: 1.25em;
+  padding-bottom: 3px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.preview h3 {
+  font-size: 1.1em;
+}
+
+.preview p {
+  margin: 0 0 10px;
+}
+
+.preview a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+}
+
+.preview a:hover {
+  text-decoration: underline;
+}
+
+.preview ul,
+.preview ol {
+  margin: 0 0 10px;
+  padding-left: 22px;
+}
+
+.preview li {
+  margin: 2px 0;
+}
+
+.preview li.task {
+  list-style: none;
+  margin-left: -18px;
+}
+
+.preview li.task input {
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.preview code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 0.92em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background-color: var(--vscode-textCodeBlock-background, rgba(127, 127, 127, 0.2));
+}
+
+.preview pre {
+  margin: 0 0 10px;
+  padding: 10px;
+  overflow-x: auto;
+  border-radius: 4px;
+  background-color: var(--vscode-textCodeBlock-background, rgba(127, 127, 127, 0.2));
+}
+
+.preview pre code {
+  padding: 0;
+  background: none;
+}
+
+.preview blockquote {
+  margin: 0 0 10px;
+  padding: 0 12px;
+  color: var(--vscode-descriptionForeground);
+  border-left: 3px solid var(--vscode-widget-border);
+}
+
+.preview hr {
+  height: 1px;
+  margin: 12px 0;
+  border: none;
+  background-color: var(--vscode-widget-border);
+}

--- a/src/webview/types/dataTypes.ts
+++ b/src/webview/types/dataTypes.ts
@@ -37,6 +37,7 @@ export interface AppState {
   targetBranch?: string;
   defaultTargetBranch?: string;
   prBranchPrefix?: string;
+  prTemplate?: string;
   isCloning?: boolean;
 }
 

--- a/src/webview/utils/buildCloneDescription.ts
+++ b/src/webview/utils/buildCloneDescription.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal shape of the source pull request needed to build a clone description.
+ * Declared structurally (rather than importing `GitHubPR`) so this helper stays
+ * dependency-free and can be unit-tested from the extension test harness.
+ */
+export interface ClonePrSource {
+  number: number;
+  html_url: string;
+  body?: string | null;
+}
+
+/**
+ * Build the description that pre-fills the PR Clone form.
+ *
+ * The original PR body is used whenever it has content. When the source PR has
+ * an empty body, the repository's pull request template (when one is available)
+ * is used as a fallback scaffold. A back-reference link to the source PR is
+ * always added on the first line.
+ */
+export const buildCloneDescription = (pr: ClonePrSource, template?: string): string => {
+  const header = `[Cloned from PR #${pr.number}](${pr.html_url})`;
+  const body = pr.body ?? '';
+  const hasBody = body.trim().length > 0;
+  const content = hasBody ? body : template ?? '';
+
+  return [header, '', content].join('\n');
+};

--- a/src/webview/utils/renderMarkdown.ts
+++ b/src/webview/utils/renderMarkdown.ts
@@ -1,0 +1,193 @@
+/**
+ * Minimal, dependency-free Markdown -> HTML renderer used for the PR description
+ * preview in the PR Clone webview.
+ *
+ * Safety: every piece of raw text is HTML-escaped *before* any markup is
+ * injected, and only a fixed whitelist of tags is produced. Link targets are
+ * scheme-validated, so a malicious `javascript:` URL in a PR body cannot be
+ * turned into a clickable link. This makes the output safe to assign through
+ * `dangerouslySetInnerHTML`.
+ *
+ * The goal is a faithful-enough preview (headings, emphasis, code, lists,
+ * task lists, block quotes, links, rules), not full CommonMark/GFM compliance.
+ */
+
+const PLACEHOLDER = '';
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+/**
+ * Return the URL when it uses a safe scheme (http/https/mailto), is an anchor
+ * or relative path, or carries no scheme at all. Returns `null` for anything
+ * else (e.g. `javascript:`/`data:`) so the caller can fall back to plain text.
+ */
+const sanitizeUrl = (url: string): string | null => {
+  const trimmed = url.trim();
+
+  if (/^(https?:\/\/|mailto:)/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^[#/]/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // No scheme at all -> treat as a relative link.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+};
+
+/**
+ * Apply inline formatting to a single line of already HTML-escaped text. Code
+ * spans and links are stashed behind placeholders before emphasis runs so that
+ * characters inside them (e.g. underscores in a URL) are never reinterpreted.
+ */
+const renderInline = (escaped: string): string => {
+  const tokens: string[] = [];
+  const stash = (html: string): string => {
+    tokens.push(html);
+    return `${PLACEHOLDER}${tokens.length - 1}${PLACEHOLDER}`;
+  };
+
+  let result = escaped.replace(/`([^`]+)`/g, (_match, code) => stash(`<code>${code}</code>`));
+
+  result = result.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, text, url) => {
+    const safe = sanitizeUrl(url);
+    if (!safe) {
+      return match;
+    }
+    return stash(`<a href="${safe}" target="_blank" rel="noopener noreferrer">${text}</a>`);
+  });
+
+  result = result
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+    .replace(/(^|[^A-Za-z0-9])_([^_]+)_(?=[^A-Za-z0-9]|$)/g, '$1<em>$2</em>')
+    .replace(/~~([^~]+)~~/g, '<del>$1</del>');
+
+  result = result.replace(new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, 'g'), (_match, index) =>
+    tokens[Number(index)]
+  );
+
+  return result;
+};
+
+const isBlank = (line: string): boolean => /^\s*$/.test(line);
+const isFence = (line: string): boolean => /^\s*```/.test(line);
+const isHeading = (line: string): boolean => /^#{1,6}\s+/.test(line);
+const isQuote = (line: string): boolean => /^\s*>\s?/.test(line);
+const isUnordered = (line: string): boolean => /^\s*[-*+]\s+/.test(line);
+const isOrdered = (line: string): boolean => /^\s*\d+[.)]\s+/.test(line);
+const isRule = (line: string): boolean => /^\s*([-*_])(\s*\1){2,}\s*$/.test(line);
+
+const isBlockStart = (line: string): boolean =>
+  isBlank(line) ||
+  isFence(line) ||
+  isHeading(line) ||
+  isQuote(line) ||
+  isUnordered(line) ||
+  isOrdered(line) ||
+  isRule(line);
+
+export const renderMarkdown = (markdown: string): string => {
+  const lines = (markdown ?? '').replace(/\r\n/g, '\n').split('\n');
+  const html: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (isFence(line)) {
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+        code.push(lines[i]);
+        i++;
+      }
+      i++; // skip the closing fence (if present)
+      html.push(`<pre><code>${escapeHtml(code.join('\n'))}</code></pre>`);
+      continue;
+    }
+
+    if (isBlank(line)) {
+      i++;
+      continue;
+    }
+
+    if (isRule(line)) {
+      html.push('<hr />');
+      i++;
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      const level = heading[1].length;
+      html.push(`<h${level}>${renderInline(escapeHtml(heading[2].trim()))}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    if (isQuote(line)) {
+      const quoted: string[] = [];
+      while (i < lines.length && isQuote(lines[i])) {
+        quoted.push(lines[i].replace(/^\s*>\s?/, ''));
+        i++;
+      }
+      html.push(`<blockquote>${renderMarkdown(quoted.join('\n'))}</blockquote>`);
+      continue;
+    }
+
+    if (isUnordered(line)) {
+      const items: string[] = [];
+      while (i < lines.length && isUnordered(lines[i])) {
+        const content = lines[i].replace(/^\s*[-*+]\s+/, '');
+        const task = content.match(/^\[([ xX])\]\s+(.*)$/);
+        if (task) {
+          const checked = task[1].toLowerCase() === 'x' ? ' checked' : '';
+          items.push(
+            `<li class="task"><input type="checkbox" disabled${checked} /> ${renderInline(
+              escapeHtml(task[2])
+            )}</li>`
+          );
+        } else {
+          items.push(`<li>${renderInline(escapeHtml(content))}</li>`);
+        }
+        i++;
+      }
+      html.push(`<ul>${items.join('')}</ul>`);
+      continue;
+    }
+
+    if (isOrdered(line)) {
+      const items: string[] = [];
+      while (i < lines.length && isOrdered(lines[i])) {
+        const content = lines[i].replace(/^\s*\d+[.)]\s+/, '');
+        items.push(`<li>${renderInline(escapeHtml(content))}</li>`);
+        i++;
+      }
+      html.push(`<ol>${items.join('')}</ol>`);
+      continue;
+    }
+
+    const paragraph: string[] = [];
+    while (i < lines.length && !isBlockStart(lines[i])) {
+      paragraph.push(lines[i]);
+      i++;
+    }
+    const rendered = paragraph.map((entry) => renderInline(escapeHtml(entry))).join('<br />');
+    html.push(`<p>${rendered}</p>`);
+  }
+
+  return html.join('\n');
+};


### PR DESCRIPTION
## Summary

Implements **point 8** from `FABLE_REVIEW.md` → *Improvements and new feature ideas*: **PR clone: draft description editor + template support**.

The PR Clone description field now:

- **Pre-fills from the original PR body** (existing behaviour, kept).
- **Falls back to the repository's pull request template** when the source PR has an empty body. `GitHubClient.fetchPullRequestTemplate()` probes the standard locations (`.github/PULL_REQUEST_TEMPLATE.md`, lowercase variants, repo root, and `docs/`) and decodes the GitHub contents API response. Template fetching is best-effort — a missing template or fetch failure never blocks the clone.
- **Has an Edit / Preview toggle** so you can review the rendered Markdown (headings, lists, task lists, links, code, quotes, rules) before creating the PR.

### Behaviour decision

The original PR body takes precedence; the template is only used as a fallback when the body is empty — the least noisy option for normal clones.

## Implementation notes

- `src/webview/utils/renderMarkdown.ts` — a small, **dependency-free** Markdown→HTML renderer. It HTML-escapes all text *before* injecting a fixed whitelist of tags and scheme-validates link targets, so it is safe to use with `dangerouslySetInnerHTML` (e.g. a `javascript:` URL in a PR body never becomes a clickable link).
- `src/webview/utils/buildCloneDescription.ts` — pure helper for the pre-fill logic (declared structurally so it is testable from the extension test harness).
- `MarkdownPreview` webview component + CSS module styled with VS Code theme variables.
- `prTemplate` flows extension → webview via the existing `SHOW_PR_DATA` message.

## Tests

New unit tests (all green; full suite **317 passing**):

- `renderMarkdown.test.ts` — formatting, HTML-escaping/XSS, safe vs dangerous links, underscores in URLs, task lists, code fences.
- `buildCloneDescription.test.ts` — body-first, template fallback, whitespace-only body, null body.
- `githubTemplate.test.ts` — base64 decoding (incl. newline-wrapped), encoding guards, candidate path priority.

Validated: `yarn check-types`, `yarn check-types-webview`, `yarn lint`, `yarn build-webview`, `yarn test:unit`.

## Docs

`docs/github-pr-clone.md` gains a *Description editor and templates* section and an updated How-It-Works step.