### PR TITLE
feat: add "Remove Multiple Worktrees..." command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In fast-paced development environments, switching between Git branches is freque
 | Rebase the current branch onto another ref while preserving local changes | `Git Smart Checkout: Rebase ... (With Stash)` | [Rebase with stash](docs/rebase-with-stash.md) |
 | Copy staged or WIP changes between existing worktrees | `Git Smart Checkout: Copy staged changes to worktree ...`, `Git Smart Checkout: Copy WIP changes to worktree ...`, `Git Smart Checkout: Copy WIP from Worktree`, `Git Smart Checkout: Move WIP from Worktree` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
 | Open a terminal in a selected worktree's directory | `Git Smart Checkout: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
+| Remove several Git worktrees at once with a single confirmation | `Git Smart Checkout: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
 | Create a new PR from selected commits in another GitHub PR | `Git Smart Checkout: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
@@ -78,6 +79,7 @@ This extension collects anonymous usage events to help improve the extension.
 - Whether the working directory had uncommitted changes (boolean)
 - Whether copy/move worktree commands copied staged/WIP changes, whether the target had local changes, included untracked files, and how many untracked files were copied
 - Whether PR review worktree removal stashed changes before removal
+- Number of worktrees removed in a bulk removal and whether their changes were stashed or reset
 - Commit count for PR clone operations (number only)
 - Whether a PR was created as a draft (boolean)
 - Whether a tag template was used (boolean)

--- a/docs/remove-multiple-worktrees.md
+++ b/docs/remove-multiple-worktrees.md
@@ -1,0 +1,55 @@
+# Remove Multiple Worktrees
+
+Command: `Git Smart Checkout: Remove Multiple Worktrees...`
+
+Use this command to clean up several Git worktrees at once. When you accumulate
+many linked worktrees (one per feature branch, PR review, etc.), removing them
+one-by-one is tedious — this command lets you check the ones you no longer need
+and remove them all in a single action.
+
+For removing a single worktree, use `Git Smart Checkout: Remove Worktree...`
+instead.
+
+## When It Is Available
+
+The command appears in the Command Palette only when the repository has **at
+least two removable worktrees**. Removable worktrees are all linked worktrees
+except the main one, excluding bare and prunable entries. With zero or one
+removable worktree, the single `Remove Worktree...` command is sufficient, so
+this command stays hidden.
+
+## What It Does
+
+1. Determines the project in the current VS Code workspace (prompts you to pick
+   one when the workspace contains multiple projects).
+2. Lists the removable worktrees in a **multi-select picker**. Each entry shows
+   the branch name (or `Detached at <hash>` for a detached worktree) and the
+   worktree's filesystem path.
+3. After you check the worktrees you want and press Enter, asks for a single
+   confirmation, then removes every selected worktree in one pass.
+4. Closes any open workspace folders that point at the removed worktrees.
+
+## Selection and Confirmation
+
+- **Check the worktrees to remove**, then press Enter to confirm the selection.
+- **All selected worktrees are clean:** a single confirmation dialog lists the
+  worktrees and asks you to confirm before removing them all.
+- **One or more selected worktrees have uncommitted changes:** a single dialog
+  asks how to handle the changes for *all* dirty worktrees before removal:
+  - **Stash Changes and Remove All** — stashes each dirty worktree's changes
+    (including untracked files) using an auto-stash named after its branch, then
+    removes every selected worktree.
+  - **Reset Changes and Remove All** — discards each dirty worktree's changes
+    (`git reset --hard` + `git clean -fd`), then removes every selected worktree.
+  - **Cancel** — aborts without changing anything.
+
+The chosen policy is applied to every dirty worktree, so you are prompted only
+once no matter how many worktrees have changes. Clean worktrees are removed as-is.
+
+## Notes
+
+- Worktrees are detected with `git worktree list`, so the picker always reflects
+  the worktrees Git knows about for the selected repository.
+- The main worktree, along with bare and prunable worktrees, cannot be selected.
+- Removal is best-effort per worktree: if one worktree fails to remove, the
+  others still complete and the failures are reported afterwards.

--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.removeMultipleWorktrees",
+        "title": "Remove Multiple Worktrees...",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.openWorktreeDevTerminal",
         "title": "Open Worktree Dev Terminal...",
         "category": "GSC"
@@ -249,6 +254,10 @@
         },
         {
           "command": "git-smart-checkout.removeWorktree"
+        },
+        {
+          "command": "git-smart-checkout.removeMultipleWorktrees",
+          "when": "git-smart-checkout.hasMultipleRemovableWorktrees"
         },
         {
           "command": "git-smart-checkout.openWorktreeDevTerminal"

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -22,6 +22,7 @@ export enum AnalyticsEvent {
   PrReviewInWorktree = 'pr_review_in_worktree',
   PrReviewWorktreeRemoved = 'pr_review_worktree_removed',
   WorktreeRemoved = 'worktree_removed',
+  MultipleWorktreesRemoved = 'multiple_worktrees_removed',
   CopyStagedChangesToWorktree = 'copy_staged_changes_to_worktree',
   CopyWipChangesToWorktree = 'copy_wip_changes_to_worktree',
   CopyWipChangesFromWorktree = 'copy_wip_changes_from_worktree',

--- a/src/commands/removeMultipleWorktreesCommand/index.ts
+++ b/src/commands/removeMultipleWorktreesCommand/index.ts
@@ -1,0 +1,211 @@
+import * as vscode from 'vscode';
+
+import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitWorktree } from '../../common/git/types';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { LoggingService } from '../../logging/loggingService';
+import { refreshRemoveMultipleWorktreesVisibility } from '../utils/worktreeCommandVisibility';
+import {
+  getRemovableWorktrees,
+  getWorktreeDetail,
+  getWorktreeLabel,
+  getWorktreeStashName,
+  removeWorkspaceFoldersForPath,
+} from '../utils/worktreeRemoval';
+import { BaseCommand } from '../command';
+
+const ACTION_REMOVE_ALL = 'Remove All Worktrees';
+const ACTION_STASH_ALL_AND_REMOVE = 'Stash Changes and Remove All';
+const ACTION_RESET_ALL_AND_REMOVE = 'Reset Changes and Remove All';
+const ACTION_CANCEL = 'Cancel';
+
+type DirtyAction = 'clean' | 'stash' | 'reset';
+type WorktreeQuickPickItem = vscode.QuickPickItem & { worktree: IGitWorktree };
+type FailedRemoval = { worktree: IGitWorktree; error: string };
+
+export class RemoveMultipleWorktreesCommand extends BaseCommand {
+  constructor(
+    logService: LoggingService,
+    private vscodeGitProvider?: VscodeGitProvider
+  ) {
+    super(logService);
+  }
+
+  async execute(): Promise<void> {
+    try {
+      const git = await this.getGitExecutor(this.vscodeGitProvider, 'Remove Multiple Worktrees');
+      const removable = getRemovableWorktrees(await git.worktreeListDetailed());
+
+      if (removable.length < 2) {
+        await vscode.window.showInformationMessage(
+          'Need at least two removable Git worktrees to remove multiple at once.',
+          'OK'
+        );
+        return;
+      }
+
+      const selected = await this.selectWorktrees(removable);
+      if (!selected || selected.length === 0) {
+        return;
+      }
+
+      const dirtyPaths = await this.findDirtyWorktreePaths(selected);
+      const dirtyAction = await this.confirmRemoval(selected, dirtyPaths);
+      if (!dirtyAction) {
+        return;
+      }
+
+      const { removed, failed } = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Git Smart Checkout: Remove Multiple Worktrees',
+          cancellable: false,
+        },
+        async (progress) => this.removeWorktrees(git, selected, dirtyPaths, dirtyAction, progress)
+      );
+
+      for (const worktree of removed) {
+        await removeWorkspaceFoldersForPath(worktree.path);
+      }
+
+      capture(AnalyticsEvent.MultipleWorktreesRemoved, {
+        count: removed.length,
+        had_dirty: dirtyPaths.size > 0,
+        dirty_action: dirtyAction,
+      });
+
+      await refreshRemoveMultipleWorktreesVisibility(this.logService, this.vscodeGitProvider);
+
+      await this.reportResult(removed, failed);
+    } catch (error) {
+      captureException(error);
+      const message = error instanceof Error ? error.message : String(error);
+      message && (await vscode.window.showErrorMessage(message, 'OK'));
+    }
+  }
+
+  private async selectWorktrees(worktrees: IGitWorktree[]): Promise<IGitWorktree[] | undefined> {
+    const items: WorktreeQuickPickItem[] = worktrees.map((worktree) => ({
+      label: getWorktreeLabel(worktree),
+      description: worktree.path,
+      detail: getWorktreeDetail(worktree),
+      worktree,
+    }));
+
+    const picked = await vscode.window.showQuickPick(items, {
+      title: 'Remove Multiple Worktrees',
+      placeHolder: 'Check the worktrees to remove',
+      canPickMany: true,
+    });
+
+    return picked?.map((item) => item.worktree);
+  }
+
+  private async findDirtyWorktreePaths(worktrees: IGitWorktree[]): Promise<Set<string>> {
+    const dirty = new Set<string>();
+
+    for (const worktree of worktrees) {
+      const worktreeGit = new GitExecutor(worktree.path, this.logService, this.vscodeGitProvider);
+      if (await worktreeGit.isWorkdirHasChanges()) {
+        dirty.add(worktree.path);
+      }
+    }
+
+    return dirty;
+  }
+
+  private async confirmRemoval(
+    selected: IGitWorktree[],
+    dirtyPaths: Set<string>
+  ): Promise<DirtyAction | undefined> {
+    const detail = this.formatWorktreeList(selected);
+
+    if (dirtyPaths.size === 0) {
+      const choice = await vscode.window.showWarningMessage(
+        `Remove ${selected.length} worktrees?`,
+        { modal: true, detail },
+        ACTION_REMOVE_ALL,
+        ACTION_CANCEL
+      );
+
+      return choice === ACTION_REMOVE_ALL ? 'clean' : undefined;
+    }
+
+    const choice = await vscode.window.showWarningMessage(
+      `${selected.length} worktrees selected, ${dirtyPaths.size} with uncommitted changes. ` +
+        'What would you like to do with the changes before removing all?',
+      { modal: true, detail },
+      ACTION_STASH_ALL_AND_REMOVE,
+      ACTION_RESET_ALL_AND_REMOVE,
+      ACTION_CANCEL
+    );
+
+    if (choice === ACTION_STASH_ALL_AND_REMOVE) {
+      return 'stash';
+    }
+
+    if (choice === ACTION_RESET_ALL_AND_REMOVE) {
+      return 'reset';
+    }
+
+    return undefined;
+  }
+
+  private async removeWorktrees(
+    git: GitExecutor,
+    selected: IGitWorktree[],
+    dirtyPaths: Set<string>,
+    dirtyAction: DirtyAction,
+    progress: vscode.Progress<{ message?: string }>
+  ): Promise<{ removed: IGitWorktree[]; failed: FailedRemoval[] }> {
+    const removed: IGitWorktree[] = [];
+    const failed: FailedRemoval[] = [];
+
+    for (const [index, worktree] of selected.entries()) {
+      const label = getWorktreeLabel(worktree);
+      progress.report({ message: `Removing ${label} (${index + 1}/${selected.length})...` });
+
+      try {
+        if (dirtyPaths.has(worktree.path) && dirtyAction !== 'clean') {
+          const worktreeGit = new GitExecutor(worktree.path, this.logService, this.vscodeGitProvider);
+          if (dirtyAction === 'stash') {
+            await worktreeGit.createStash(getWorktreeStashName(worktree));
+          } else {
+            await worktreeGit.discardAllWorktreeChanges();
+          }
+        }
+
+        await git.worktreeRemove(worktree.path, false);
+        removed.push(worktree);
+      } catch (error) {
+        failed.push({ worktree, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+
+    return { removed, failed };
+  }
+
+  private async reportResult(removed: IGitWorktree[], failed: FailedRemoval[]): Promise<void> {
+    if (removed.length > 0) {
+      await vscode.window.showInformationMessage(
+        `Removed ${removed.length} worktree${removed.length === 1 ? '' : 's'}.`,
+        'OK'
+      );
+    }
+
+    if (failed.length > 0) {
+      const detail = failed
+        .map(({ worktree, error }) => `${getWorktreeLabel(worktree)}: ${error}`)
+        .join('\n');
+      await vscode.window.showErrorMessage(
+        `Failed to remove ${failed.length} worktree${failed.length === 1 ? '' : 's'}:\n${detail}`,
+        'OK'
+      );
+    }
+  }
+
+  private formatWorktreeList(worktrees: IGitWorktree[]): string {
+    return worktrees.map((worktree) => `• ${getWorktreeLabel(worktree)} (${worktree.path})`).join('\n');
+  }
+}

--- a/src/commands/removeWorktreeCommand/index.ts
+++ b/src/commands/removeWorktreeCommand/index.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { AnalyticsEvent, capture, captureException } from '../../analytics/analytics';
@@ -6,8 +5,13 @@ import { GitExecutor } from '../../common/git/gitExecutor';
 import { IGitWorktree } from '../../common/git/types';
 import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
 import { LoggingService } from '../../logging/loggingService';
-import { getStashMessage } from '../utils/getStashMessage';
-import { getWorktreeBranchName, removeWorkspaceFoldersForPath } from '../utils/worktreeRemoval';
+import {
+  getRemovableWorktrees,
+  getWorktreeDetail,
+  getWorktreeLabel,
+  getWorktreeStashName,
+  removeWorkspaceFoldersForPath,
+} from '../utils/worktreeRemoval';
 import { BaseCommand } from '../command';
 
 const ACTION_REMOVE_WORKTREE = 'Remove Worktree';
@@ -62,9 +66,7 @@ export class RemoveWorktreeCommand extends BaseCommand {
 
   private async selectWorktree(git: GitExecutor): Promise<IGitWorktree | undefined> {
     const worktrees = await git.worktreeListDetailed();
-    const removableWorktrees = worktrees
-      .slice(1)
-      .filter((worktree) => !worktree.bare && !worktree.prunable);
+    const removableWorktrees = getRemovableWorktrees(worktrees);
 
     if (removableWorktrees.length === 0) {
       await vscode.window.showInformationMessage('No removable Git worktrees found.', 'OK');
@@ -72,9 +74,9 @@ export class RemoveWorktreeCommand extends BaseCommand {
     }
 
     const items: WorktreeQuickPickItem[] = removableWorktrees.map((worktree) => ({
-      label: this.getWorktreeLabel(worktree),
+      label: getWorktreeLabel(worktree),
       description: worktree.path,
-      detail: this.getWorktreeDetail(worktree),
+      detail: getWorktreeDetail(worktree),
       worktree,
     }));
 
@@ -109,7 +111,7 @@ export class RemoveWorktreeCommand extends BaseCommand {
       dirtyAction = action;
       if (action === 'stash') {
         progress.report({ message: 'Stashing changes...' });
-        await worktreeGit.createStash(this.getStashName(worktree));
+        await worktreeGit.createStash(getWorktreeStashName(worktree));
       } else {
         progress.report({ message: 'Resetting changes...' });
         await worktreeGit.discardAllWorktreeChanges();
@@ -125,7 +127,7 @@ export class RemoveWorktreeCommand extends BaseCommand {
 
   private async confirmCleanRemoval(worktree: IGitWorktree): Promise<boolean> {
     const choice = await vscode.window.showWarningMessage(
-      `Remove worktree "${this.getWorktreeLabel(worktree)}" at ${worktree.path}?`,
+      `Remove worktree "${getWorktreeLabel(worktree)}" at ${worktree.path}?`,
       { modal: true },
       ACTION_REMOVE_WORKTREE,
       ACTION_CANCEL
@@ -136,7 +138,7 @@ export class RemoveWorktreeCommand extends BaseCommand {
 
   private async confirmDirtyRemoval(worktree: IGitWorktree): Promise<Exclude<DirtyAction, 'clean'> | undefined> {
     const choice = await vscode.window.showWarningMessage(
-      `Worktree "${this.getWorktreeLabel(worktree)}" has uncommitted changes. What would you like to do before removing it?`,
+      `Worktree "${getWorktreeLabel(worktree)}" has uncommitted changes. What would you like to do before removing it?`,
       { modal: true },
       ACTION_STASH_AND_REMOVE,
       ACTION_RESET_AND_REMOVE,
@@ -152,42 +154,5 @@ export class RemoveWorktreeCommand extends BaseCommand {
     }
 
     return undefined;
-  }
-
-  private getWorktreeLabel(worktree: IGitWorktree): string {
-    const branchName = this.getWorktreeBranchName(worktree);
-
-    if (branchName) {
-      return branchName;
-    }
-
-    if (worktree.detached) {
-      return `Detached at ${this.getShortHead(worktree)}`;
-    }
-
-    return path.basename(worktree.path);
-  }
-
-  private getWorktreeDetail(worktree: IGitWorktree): string {
-    if (worktree.detached) {
-      return `Detached HEAD ${this.getShortHead(worktree)}`;
-    }
-
-    return worktree.head ? `HEAD ${this.getShortHead(worktree)}` : '';
-  }
-
-  private getStashName(worktree: IGitWorktree): string {
-    return getStashMessage(
-      this.getWorktreeBranchName(worktree) ??
-        `detached-${worktree.head ? this.getShortHead(worktree) : path.basename(worktree.path)}`
-    );
-  }
-
-  private getWorktreeBranchName(worktree: IGitWorktree): string | undefined {
-    return getWorktreeBranchName(worktree.branch);
-  }
-
-  private getShortHead(worktree: IGitWorktree): string {
-    return worktree.head?.slice(0, 7) ?? 'unknown';
   }
 }

--- a/src/commands/utils/worktreeCommandVisibility.ts
+++ b/src/commands/utils/worktreeCommandVisibility.ts
@@ -1,0 +1,42 @@
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { getWorkspaceFoldersFormatted } from '../../common/vscode';
+import { LoggingService } from '../../logging/loggingService';
+import { setContextHasMultipleRemovableWorktrees } from '../../utils/setContext';
+import { getRemovableWorktrees } from './worktreeRemoval';
+
+/**
+ * Recomputes the `git-smart-checkout.hasMultipleRemovableWorktrees` context key
+ * that gates the "Remove Multiple Worktrees..." command in the Command Palette.
+ *
+ * The check runs across every workspace folder without prompting (so it cannot
+ * use {@link getGitExecutor}, which pops a repository picker on multi-folder
+ * workspaces). The command is shown when any folder has at least two removable
+ * worktrees. This is best-effort: the command re-validates at execution time.
+ */
+export async function refreshRemoveMultipleWorktreesVisibility(
+  logService: LoggingService,
+  vscodeGitProvider?: VscodeGitProvider
+): Promise<void> {
+  try {
+    const folders = getWorkspaceFoldersFormatted() ?? [];
+
+    for (const folder of folders) {
+      const git = new GitExecutor(folder.path, logService, vscodeGitProvider);
+      const worktrees = await git.worktreeListDetailed(true);
+
+      if (getRemovableWorktrees(worktrees).length >= 2) {
+        await setContextHasMultipleRemovableWorktrees(true);
+        return;
+      }
+    }
+
+    await setContextHasMultipleRemovableWorktrees(false);
+  } catch (error) {
+    logService.warn(
+      `[Remove Multiple Worktrees] Failed to refresh command visibility: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/src/commands/utils/worktreeRemoval.ts
+++ b/src/commands/utils/worktreeRemoval.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { IGitWorktree } from '../../common/git/types';
+import { getStashMessage } from './getStashMessage';
+
 export async function removeWorkspaceFoldersForPath(removedPath: string): Promise<void> {
   const folders = vscode.workspace.workspaceFolders ?? [];
   const indexesToRemove = folders
@@ -40,4 +43,45 @@ export function normalizePathForComparison(targetPath: string): string {
 
 export function getWorktreeBranchName(branchRef: string | undefined): string | undefined {
   return branchRef?.replace(/^refs\/heads\//, '');
+}
+
+/**
+ * Worktrees a user is allowed to remove: every linked worktree except the main
+ * one (always the first entry), excluding bare and prunable entries.
+ */
+export function getRemovableWorktrees(worktrees: IGitWorktree[]): IGitWorktree[] {
+  return worktrees.slice(1).filter((worktree) => !worktree.bare && !worktree.prunable);
+}
+
+export function getWorktreeShortHead(worktree: IGitWorktree): string {
+  return worktree.head?.slice(0, 7) ?? 'unknown';
+}
+
+export function getWorktreeLabel(worktree: IGitWorktree): string {
+  const branchName = getWorktreeBranchName(worktree.branch);
+
+  if (branchName) {
+    return branchName;
+  }
+
+  if (worktree.detached) {
+    return `Detached at ${getWorktreeShortHead(worktree)}`;
+  }
+
+  return path.basename(worktree.path);
+}
+
+export function getWorktreeDetail(worktree: IGitWorktree): string {
+  if (worktree.detached) {
+    return `Detached HEAD ${getWorktreeShortHead(worktree)}`;
+  }
+
+  return worktree.head ? `HEAD ${getWorktreeShortHead(worktree)}` : '';
+}
+
+export function getWorktreeStashName(worktree: IGitWorktree): string {
+  return getStashMessage(
+    getWorktreeBranchName(worktree.branch) ??
+      `detached-${worktree.head ? getWorktreeShortHead(worktree) : path.basename(worktree.path)}`
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ import { MoveToNewWorktreeCommand } from './commands/moveToNewWorktreeCommand';
 import { OpenWorktreeDevTerminalCommand } from './commands/openWorktreeDevTerminalCommand';
 import { RemovePRReviewInWorktreeCommand } from './commands/removePRReviewInWorktreeCommand';
 import { RemoveWorktreeCommand } from './commands/removeWorktreeCommand';
+import { RemoveMultipleWorktreesCommand } from './commands/removeMultipleWorktreesCommand';
+import { refreshRemoveMultipleWorktreesVisibility } from './commands/utils/worktreeCommandVisibility';
 import { RebaseWithStashCommand } from './commands/rebaseWithStashCommand';
 import { PRReviewWorktreeStore } from './services/prReviewWorktreeStore';
 import { RefDetailsCache } from './services/refDetailsCache';
@@ -176,6 +178,12 @@ export function activate(context: vscode.ExtensionContext) {
   const removeWorktreeCommand = new RemoveWorktreeCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.removeWorktree`, removeWorktreeCommand);
 
+  const removeMultipleWorktreesCommand = new RemoveMultipleWorktreesCommand(logService, vscodeGitProvider);
+  commandManager.registerCommand(
+    `${EXTENSION_NAME}.removeMultipleWorktrees`,
+    removeMultipleWorktreesCommand
+  );
+
   const openWorktreeDevTerminalCommand = new OpenWorktreeDevTerminalCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.openWorktreeDevTerminal`, openWorktreeDevTerminalCommand);
 
@@ -293,6 +301,19 @@ export function activate(context: vscode.ExtensionContext) {
   // Register all commands with VS Code
   commandManager.registerAll(context);
 
+  // Gate the "Remove Multiple Worktrees..." command on having >= 2 removable
+  // worktrees. Recompute on activation and whenever the window regains focus or
+  // the workspace folders change (covers worktrees added/removed externally).
+  void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
+  const windowStateListener = vscode.window.onDidChangeWindowState((state) => {
+    if (state.focused) {
+      void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
+    }
+  });
+  const workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
+  });
+
   // Listen for configuration changes
   const configChangeListener = vscode.workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration(EXTENSION_NAME)) {
@@ -308,6 +329,8 @@ export function activate(context: vscode.ExtensionContext) {
   // Add to context subscriptions
   context.subscriptions.push(
     configChangeListener,
+    windowStateListener,
+    workspaceFoldersListener,
     telemetryChangeListener,
     statusBarManager,
     logService,

--- a/src/test/e2e/commandInterface.test.ts
+++ b/src/test/e2e/commandInterface.test.ts
@@ -195,6 +195,31 @@ function stubShowQuickPick(
   };
 }
 
+function stubShowQuickPickMany(
+  pick: (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options: vscode.QuickPickOptions | undefined
+  ) => vscode.QuickPickItem | vscode.QuickPickItem[] | undefined
+): { calls: number; restore: () => void } {
+  const original = vscode.window.showQuickPick.bind(vscode.window);
+  const state = {
+    calls: 0,
+    restore() {
+      (vscode.window as any).showQuickPick = original;
+    },
+  };
+
+  (vscode.window as any).showQuickPick = async (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options?: vscode.QuickPickOptions
+  ) => {
+    state.calls += 1;
+    return pick(items, options);
+  };
+
+  return state;
+}
+
 function stubInputBox(
   ...answers: Array<string | ((options: vscode.InputBoxOptions) => string | undefined)>
 ): () => void {
@@ -1627,6 +1652,295 @@ describe('VS Code command interface', () => {
           delete (vscode.workspace as any).workspaceFolders;
         }
         await cleanupWorktree(repo, worktreePath);
+        repo.cleanup();
+      }
+    });
+  });
+
+  describe('removeMultipleWorktrees', () => {
+    function addWorktree(repo: TestRepo, branch: string, createFrom?: string): string {
+      if (createFrom) {
+        repo.exec(`git branch ${branch} ${createFrom}`);
+      }
+      const worktreePath = getDefaultWorktreePath(repo, branch);
+      repo.exec(`git worktree add "${worktreePath}" ${branch}`);
+      return worktreePath;
+    }
+
+    function pickWorktrees(...labels: string[]) {
+      return stubShowQuickPickMany((items, options) => {
+        if (options?.placeHolder !== 'Check the worktrees to remove') {
+          return undefined;
+        }
+        assert.strictEqual(options?.canPickMany, true, 'picker should allow multiple selection');
+        return items.filter(
+          (item): item is QuickPickLikeItem =>
+            typeof item !== 'string' && labels.includes(item.label)
+        );
+      });
+    }
+
+    it('lists removable worktrees and excludes the main worktree', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+      let labels: string[] = [];
+
+      const quickPick = stubShowQuickPickMany((items, options) => {
+        if (options?.placeHolder === 'Check the worktrees to remove') {
+          labels = items
+            .filter((item): item is QuickPickLikeItem => typeof item !== 'string')
+            .map((item) => item.label);
+        }
+        return undefined;
+      });
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.ok(!labels.includes(repo.mainBranch), 'main worktree should be hidden');
+          assert.ok(labels.includes(repo.featureBranch), 'feature worktree should be listed');
+          assert.ok(labels.includes('bugfix'), 'bugfix worktree should be listed');
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(fs.existsSync(featurePath), true);
+          assert.strictEqual(fs.existsSync(bugfixPath), true);
+        });
+      } finally {
+        errors.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
+        repo.cleanup();
+      }
+    });
+
+    it('removes multiple selected clean worktrees in one action', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+
+      const quickPick = pickWorktrees(repo.featureBranch, 'bugfix');
+      const warnings = stubWarningMessages((_message, items) => {
+        assert.deepStrictEqual(items, ['Remove All Worktrees', 'Cancel']);
+        return 'Remove All Worktrees';
+      });
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(warnings.messages.length, 1);
+          assert.strictEqual(fs.existsSync(featurePath), false);
+          assert.strictEqual(fs.existsSync(bugfixPath), false);
+        });
+      } finally {
+        errors.restore();
+        info.restore();
+        warnings.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
+        repo.cleanup();
+      }
+    });
+
+    it('stashes every dirty worktree before removing them all', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+      fs.writeFileSync(path.join(featurePath, 'file1.txt'), 'dirty feature\n');
+      fs.writeFileSync(path.join(bugfixPath, 'file1.txt'), 'dirty bugfix\n');
+
+      const quickPick = pickWorktrees(repo.featureBranch, 'bugfix');
+      const warnings = stubWarningMessages((_message, items) => {
+        assert.deepStrictEqual(items, [
+          'Stash Changes and Remove All',
+          'Reset Changes and Remove All',
+          'Cancel',
+        ]);
+        return 'Stash Changes and Remove All';
+      });
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(fs.existsSync(featurePath), false);
+          assert.strictEqual(fs.existsSync(bugfixPath), false);
+          assert.strictEqual(repo.stashCount(), 2);
+        });
+      } finally {
+        errors.restore();
+        info.restore();
+        warnings.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
+        repo.cleanup();
+      }
+    });
+
+    it('resets every dirty worktree before removing them all', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+      fs.writeFileSync(path.join(featurePath, 'file1.txt'), 'dirty feature\n');
+      fs.writeFileSync(path.join(bugfixPath, 'notes.txt'), 'untracked bugfix\n');
+
+      const quickPick = pickWorktrees(repo.featureBranch, 'bugfix');
+      const warnings = stubWarningMessages((_message, _items) => 'Reset Changes and Remove All');
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(fs.existsSync(featurePath), false);
+          assert.strictEqual(fs.existsSync(bugfixPath), false);
+          assert.strictEqual(repo.stashCount(), 0);
+        });
+      } finally {
+        errors.restore();
+        info.restore();
+        warnings.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
+        repo.cleanup();
+      }
+    });
+
+    it('cancels removal without changing any worktree', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+
+      const quickPick = pickWorktrees(repo.featureBranch, 'bugfix');
+      const warnings = stubWarningMessages((_message, _items) => 'Cancel');
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(fs.existsSync(featurePath), true);
+          assert.strictEqual(fs.existsSync(bugfixPath), true);
+          assert.ok(!info.messages.some((message) => message.startsWith('Removed')));
+        });
+      } finally {
+        errors.restore();
+        info.restore();
+        warnings.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
+        repo.cleanup();
+      }
+    });
+
+    it('does not prompt and informs when fewer than two worktrees are removable', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+
+      const quickPick = stubShowQuickPickMany(() => undefined);
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await withRepoWorkspace(repo, async () => {
+          await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+          assert.strictEqual(quickPick.calls, 0, 'picker should not be shown');
+          assert.ok(
+            info.messages.some((message) => message.includes('at least two removable')),
+            'should explain that two worktrees are required'
+          );
+          assert.deepStrictEqual(errors.messages, []);
+          assert.strictEqual(fs.existsSync(featurePath), true);
+        });
+      } finally {
+        errors.restore();
+        info.restore();
+        quickPick.restore();
+        await cleanupWorktree(repo, featurePath);
+        repo.cleanup();
+      }
+    });
+
+    it('removes matching open workspace folders for every removed worktree', async () => {
+      const repo = createTestRepo();
+      const featurePath = addWorktree(repo, repo.featureBranch);
+      const bugfixPath = addWorktree(repo, 'bugfix', repo.mainBranch);
+      const originalFolders = Object.getOwnPropertyDescriptor(vscode.workspace, 'workspaceFolders');
+      const originalUpdateWorkspaceFolders = vscode.workspace.updateWorkspaceFolders.bind(vscode.workspace);
+      let folders = [
+        { uri: vscode.Uri.file(repo.repoPath), name: path.basename(repo.repoPath), index: 0 },
+        { uri: vscode.Uri.file(featurePath), name: path.basename(featurePath), index: 1 },
+        { uri: vscode.Uri.file(bugfixPath), name: path.basename(bugfixPath), index: 2 },
+      ] as vscode.WorkspaceFolder[];
+
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        configurable: true,
+        get: () => folders,
+      });
+
+      (vscode.workspace as any).updateWorkspaceFolders = (start: number, deleteCount: number) => {
+        folders.splice(start, deleteCount);
+        folders = folders.map((folder, index) => ({ ...folder, index }));
+        return true;
+      };
+
+      const quickPick = stubShowQuickPickMany((items, options) => {
+        if (options?.placeHolder === 'Choose a repository') {
+          return items.find(
+            (item): item is QuickPickLikeItem =>
+              typeof item !== 'string' && item.label === path.basename(repo.repoPath)
+          );
+        }
+        if (options?.placeHolder === 'Check the worktrees to remove') {
+          return items.filter(
+            (item): item is QuickPickLikeItem =>
+              typeof item !== 'string' && [repo.featureBranch, 'bugfix'].includes(item.label)
+          );
+        }
+        return undefined;
+      });
+      const warnings = stubWarningMessages((_message, _items) => 'Remove All Worktrees');
+      const info = stubInformationMessages((_message, _items) => 'OK');
+      const errors = stubErrorMessages();
+
+      try {
+        await vscode.commands.executeCommand(commandId('removeMultipleWorktrees'));
+
+        assert.deepStrictEqual(errors.messages, []);
+        assert.strictEqual(fs.existsSync(featurePath), false);
+        assert.strictEqual(fs.existsSync(bugfixPath), false);
+        assert.deepStrictEqual(folders.map((folder) => folder.uri.fsPath), [repo.repoPath]);
+      } finally {
+        errors.restore();
+        info.restore();
+        warnings.restore();
+        quickPick.restore();
+        (vscode.workspace as any).updateWorkspaceFolders = originalUpdateWorkspaceFolders;
+        if (originalFolders) {
+          Object.defineProperty(vscode.workspace, 'workspaceFolders', originalFolders);
+        } else {
+          delete (vscode.workspace as any).workspaceFolders;
+        }
+        await cleanupWorktree(repo, featurePath);
+        await cleanupWorktree(repo, bugfixPath);
         repo.cleanup();
       }
     });

--- a/src/test/unit/worktreeRemoval.test.ts
+++ b/src/test/unit/worktreeRemoval.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+
+import { IGitWorktree } from '../../common/git/types';
+import {
+  getRemovableWorktrees,
+  getWorktreeDetail,
+  getWorktreeLabel,
+} from '../../commands/utils/worktreeRemoval';
+
+describe('getRemovableWorktrees', () => {
+  it('excludes the main worktree and keeps linked worktrees', () => {
+    const worktrees: IGitWorktree[] = [
+      { path: '/repo', head: 'abc1234', branch: 'refs/heads/main' },
+      { path: '/repo-feature', head: 'def4567', branch: 'refs/heads/feature/foo' },
+      { path: '/repo-bugfix', head: '7890abc', branch: 'refs/heads/bugfix/bar' },
+    ];
+
+    const removable = getRemovableWorktrees(worktrees);
+
+    assert.deepStrictEqual(
+      removable.map((worktree) => worktree.path),
+      ['/repo-feature', '/repo-bugfix']
+    );
+  });
+
+  it('excludes bare and prunable worktrees', () => {
+    const worktrees: IGitWorktree[] = [
+      { path: '/repo', head: 'abc1234', branch: 'refs/heads/main' },
+      { path: '/repo-bare', bare: true },
+      { path: '/repo-stale', head: 'def4567', branch: 'refs/heads/stale', prunable: true },
+      { path: '/repo-feature', head: '7890abc', branch: 'refs/heads/feature/foo' },
+    ];
+
+    const removable = getRemovableWorktrees(worktrees);
+
+    assert.deepStrictEqual(
+      removable.map((worktree) => worktree.path),
+      ['/repo-feature']
+    );
+  });
+
+  it('returns an empty list when only the main worktree exists', () => {
+    const worktrees: IGitWorktree[] = [
+      { path: '/repo', head: 'abc1234', branch: 'refs/heads/main' },
+    ];
+
+    assert.deepStrictEqual(getRemovableWorktrees(worktrees), []);
+  });
+});
+
+describe('getWorktreeLabel / getWorktreeDetail', () => {
+  it('labels branch worktrees with the branch name', () => {
+    assert.strictEqual(
+      getWorktreeLabel({ path: '/repo-feature', head: 'def4567', branch: 'refs/heads/feature/foo' }),
+      'feature/foo'
+    );
+  });
+
+  it('labels detached worktrees with the short head', () => {
+    const worktree: IGitWorktree = { path: '/repo-detached', head: '7890abcdef', detached: true };
+    assert.strictEqual(getWorktreeLabel(worktree), 'Detached at 7890abc');
+    assert.strictEqual(getWorktreeDetail(worktree), 'Detached HEAD 7890abc');
+  });
+});

--- a/src/utils/setContext.ts
+++ b/src/utils/setContext.ts
@@ -24,3 +24,7 @@ export const setContextIsCherryPickConflict = async (value: boolean) => {
 export const setContextCanCreateBranchFromTemplate = async (value: boolean) => {
   await setContextKey(`${EXTENSION_NAME}.canCreateBranchFromTemplate`, value);
 };
+
+export const setContextHasMultipleRemovableWorktrees = async (value: boolean) => {
+  await setContextKey(`${EXTENSION_NAME}.hasMultipleRemovableWorktrees`, value);
+};


### PR DESCRIPTION
## Summary

Adds a **Remove Multiple Worktrees...** command (`GSC: Remove Multiple Worktrees...`) for bulk-removing linked Git worktrees. The user checks the worktrees to remove in a multi-select picker and removes them all in one action — complementing the existing single `Remove Worktree...` command.

## Behavior

- **Multi-select picker** (`canPickMany`) listing every removable worktree (linked worktrees, excluding the main/bare/prunable entries).
- **Visibility:** the command appears in the Command Palette only when there are **≥ 2 removable worktrees**, gated by a new `git-smart-checkout.hasMultipleRemovableWorktrees` context key. The key is refreshed on activation, window focus, and workspace-folder changes; the command also re-validates at execution time.
- **Dirty handling — one global prompt:** if any selected worktree has uncommitted changes, a single dialog asks *Stash all* / *Reset all* / *Cancel*, and the chosen policy is applied to every dirty worktree before removing all selected ones in one pass.
- Closes any open workspace folders pointing at removed worktrees; removal is best-effort per worktree and failures are reported afterwards.

## Implementation notes

- Extracted shared worktree helpers (`getRemovableWorktrees`, `getWorktreeLabel`/`Detail`/`StashName`) into `src/commands/utils/worktreeRemoval.ts` and reused them from the existing `RemoveWorktreeCommand` (no behavior change there).
- New `multiple_worktrees_removed` analytics event (count + dirty action).

## Tests & docs

- **Unit:** `getRemovableWorktrees` / label helpers.
- **E2E:** listing & main exclusion, bulk clean removal, stash-all, reset-all, cancel, the `< 2` guard, and workspace-folder cleanup.
- All tests green locally: unit (295 passing) and e2e (`e2e-ci`, 150 passing).
- Docs: new `docs/remove-multiple-worktrees.md`; README feature-table row + telemetry note.