### PR TITLE
feat(status-bar): add all worktree commands and Open Settings to quick actions menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ In fast-paced development environments, switching between Git branches is freque
 | Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `Git Smart Checkout: Init Jira` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
 | Store the Jira API token securely in VS Code Secret Storage | `Git Smart Checkout: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
 | Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
-| Open a quick-actions menu of common commands from the status bar item | `Git Smart Checkout: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
+| Open a quick-actions menu of common commands (checkout, pull/rebase, all worktree commands, clone PR, open settings) from the status bar item | `Git Smart Checkout: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
+| Open this extension's settings | `Git Smart Checkout: Open Settings` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
 
 ## Extension Settings
 

--- a/docs/status-bar-quick-actions.md
+++ b/docs/status-bar-quick-actions.md
@@ -18,7 +18,17 @@ into a hub for the extension. You can also open it from the command palette.
 | Update branch | Pull (Rebase With Stash) | `Git Smart Checkout: Pull (Rebase With Stash)` |
 | Update branch | Rebase (With Stash) | `Git Smart Checkout: Rebase ... (With Stash)` |
 | Worktree | Move to new worktree | `Git Smart Checkout: Move to new worktree` |
+| Worktree | PR review in worktree… | `Git Smart Checkout: PR Review in Worktree` |
+| Worktree | Open worktree dev terminal… | `Git Smart Checkout: Open Worktree Dev Terminal...` |
+| Worktree changes | Copy staged changes to worktree… | `Git Smart Checkout: Copy staged changes to worktree...` |
+| Worktree changes | Copy WIP changes to worktree… | `Git Smart Checkout: Copy WIP changes to worktree...` |
+| Worktree changes | Copy WIP from worktree… | `Git Smart Checkout: Copy WIP from Worktree` |
+| Worktree changes | Move WIP from worktree… | `Git Smart Checkout: Move WIP from Worktree` |
+| Remove worktrees | Remove worktree… | `Git Smart Checkout: Remove Worktree...` |
+| Remove worktrees | Remove multiple worktrees… | `Git Smart Checkout: Remove Multiple Worktrees...` |
+| Remove worktrees | Remove PR review worktree… | `Git Smart Checkout: Remove PR review in Worktree` |
 | GitHub | Clone pull request… | `Git Smart Checkout: Clone pull request...` |
+| Settings | Open settings | `Git Smart Checkout: Open Settings` (opens VS Code Settings filtered to this extension) |
 
 Selecting an action runs the underlying command, so each step behaves exactly as
 it does from the command palette. Dismissing the menu (for example with `Esc`)

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.openSettings",
+        "title": "Open Settings",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.clonePullRequest",
         "title": "Clone pull request...",
         "category": "GSC",

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -33,6 +33,7 @@ export enum AnalyticsEvent {
   JiraInitialized = 'jira_initialized',
   AutoStashManaged = 'auto_stash_managed',
   StatusBarMenuOpened = 'status_bar_menu_opened',
+  SettingsOpened = 'settings_opened',
 }
 
 let client: PostHog | null = null;

--- a/src/commands/openSettingsCommand/index.ts
+++ b/src/commands/openSettingsCommand/index.ts
@@ -1,0 +1,18 @@
+import { commands } from 'vscode';
+
+import { AnalyticsEvent, capture } from '../../analytics/analytics';
+import { EXTENSION_ID } from '../../const';
+import { LoggingService } from '../../logging/loggingService';
+import { BaseCommand } from '../command';
+
+export class OpenSettingsCommand extends BaseCommand {
+  constructor(logService: LoggingService) {
+    super(logService);
+  }
+
+  async execute(): Promise<void> {
+    capture(AnalyticsEvent.SettingsOpened);
+
+    await commands.executeCommand('workbench.action.openSettings', `@ext:${EXTENSION_ID}`);
+  }
+}

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,2 @@
 export const EXTENSION_NAME = 'git-smart-checkout';
+export const EXTENSION_ID = `vradchuk.${EXTENSION_NAME}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { CommandManager } from './commands/commandManager';
 import { PullRebaseWithStashCommand, PullWithStashCommand } from './commands/pullWithStashCommand';
 import { SwitchModeCommand } from './commands/switchModeCommand';
 import { StatusBarMenuCommand } from './commands/statusBarMenuCommand';
+import { OpenSettingsCommand } from './commands/openSettingsCommand';
 import { VscodeGitProvider } from './common/git/vscodeGitProvider';
 import { ConfigurationManager } from './configuration/configurationManager';
 import { EXTENSION_NAME } from './const';
@@ -120,6 +121,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   const statusBarMenuCommand = new StatusBarMenuCommand(statusBarManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.showStatusBarMenu`, statusBarMenuCommand);
+
+  const openSettingsCommand = new OpenSettingsCommand(logService);
+  commandManager.registerCommand(`${EXTENSION_NAME}.openSettings`, openSettingsCommand);
 
   commandManager.registerCommand(`${EXTENSION_NAME}.checkoutTo`, checkoutToCommand);
 

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -136,8 +136,39 @@ export class StatusBarManager implements Disposable {
       { label: '$(git-merge) Rebase (With Stash)', commandId: command('rebaseWithStash') },
       { label: 'Worktree', kind: QuickPickItemKind.Separator },
       { label: '$(list-tree) Move to new worktree', commandId: command('moveToNewWorktree') },
+      { label: '$(eye) PR review in worktree…', commandId: command('prReviewInWorktree') },
+      {
+        label: '$(terminal) Open worktree dev terminal…',
+        commandId: command('openWorktreeDevTerminal'),
+      },
+      { label: 'Worktree changes', kind: QuickPickItemKind.Separator },
+      {
+        label: '$(diff-added) Copy staged changes to worktree…',
+        commandId: command('copyStagedChangesToWorktree'),
+      },
+      {
+        label: '$(copy) Copy WIP changes to worktree…',
+        commandId: command('copyWipChangesToWorktree'),
+      },
+      {
+        label: '$(arrow-left) Copy WIP from worktree…',
+        commandId: command('copyWipChangesFromWorktree'),
+      },
+      {
+        label: '$(arrow-right) Move WIP from worktree…',
+        commandId: command('moveWipChangesFromWorktree'),
+      },
+      { label: 'Remove worktrees', kind: QuickPickItemKind.Separator },
+      { label: '$(trash) Remove worktree…', commandId: command('removeWorktree') },
+      { label: '$(trash) Remove multiple worktrees…', commandId: command('removeMultipleWorktrees') },
+      {
+        label: '$(trash) Remove PR review worktree…',
+        commandId: command('removePRReviewInWorktree'),
+      },
       { label: 'GitHub', kind: QuickPickItemKind.Separator },
       { label: '$(repo-clone) Clone pull request…', commandId: command('clonePullRequest') },
+      { label: 'Settings', kind: QuickPickItemKind.Separator },
+      { label: '$(settings-gear) Open settings', commandId: command('openSettings') },
     ];
 
     const selection = await window.showQuickPick(items, {

--- a/src/test/e2e/statusBarMenu.test.ts
+++ b/src/test/e2e/statusBarMenu.test.ts
@@ -23,7 +23,17 @@ const EXPECTED_ACTIONS = [
   'pullRebaseWithStash',
   'rebaseWithStash',
   'moveToNewWorktree',
+  'prReviewInWorktree',
+  'openWorktreeDevTerminal',
+  'copyStagedChangesToWorktree',
+  'copyWipChangesToWorktree',
+  'copyWipChangesFromWorktree',
+  'moveWipChangesFromWorktree',
+  'removeWorktree',
+  'removeMultipleWorktrees',
+  'removePRReviewInWorktree',
   'clonePullRequest',
+  'openSettings',
 ];
 
 function delay(ms = 0): Promise<void> {
@@ -84,6 +94,11 @@ describe('status bar quick actions menu', () => {
   it('contributes the quick actions command', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes(commandId('showStatusBarMenu')));
+  });
+
+  it('contributes the open settings command', async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes(commandId('openSettings')));
   });
 
   it('lists the expected actions grouped by separators', async () => {

--- a/src/test/unit/openSettingsCommand.test.ts
+++ b/src/test/unit/openSettingsCommand.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { OpenSettingsCommand } from '../../commands/openSettingsCommand';
+import { EXTENSION_ID } from '../../const';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('OpenSettingsCommand', () => {
+  it('opens VS Code settings filtered to the extension', async () => {
+    const calls: Array<{ command: string; args: unknown[] }> = [];
+    const original = vscode.commands.executeCommand.bind(vscode.commands);
+
+    (vscode.commands as any).executeCommand = async (command: string, ...args: unknown[]) => {
+      calls.push({ command, args });
+      return undefined;
+    };
+
+    try {
+      const command = new OpenSettingsCommand(mockLogService);
+      await command.execute();
+
+      assert.deepStrictEqual(calls, [
+        { command: 'workbench.action.openSettings', args: [`@ext:${EXTENSION_ID}`] },
+      ]);
+    } finally {
+      (vscode.commands as any).executeCommand = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Builds on the status-bar quick-actions menu from #108. The menu previously exposed only one of the extension's ten worktree commands and had no shortcut to the extension's settings. This makes it a complete hub for worktree work.

### 1. All worktree commands in the menu
The menu now includes every worktree command, grouped under dedicated separators for readability:
- **Worktree** — Move to new worktree, PR review in worktree…, Open worktree dev terminal…
- **Worktree changes** — Copy staged changes to worktree…, Copy WIP changes to worktree…, Copy WIP from worktree…, Move WIP from worktree…
- **Remove worktrees** — Remove worktree…, Remove multiple worktrees…, Remove PR review worktree…

### 2. Open Settings
New reusable `git-smart-checkout.openSettings` command (also available from the Command Palette) that opens VS Code Settings filtered to this extension (`@ext:vradchuk.git-smart-checkout`), surfaced as an **Open settings** action in the menu.

### Note on the original request item #3
The request also asked for a new "Quick command…" to open the menu via keyboard. The existing `GSC: Quick Actions` command (`showStatusBarMenu`) is **already** in the Command Palette and already accepts a user-assigned hotkey, so a duplicate command was intentionally not added (confirmed with the requester). No default keybinding is contributed.

## Changes
- `statusBarManager.ts` — expanded the quick-actions `items` array
- `commands/openSettingsCommand/` — new command class
- `extension.ts`, `package.json`, `const.ts`, `analytics.ts` — register command, `EXTENSION_ID` constant, `SettingsOpened` event
- Tests: extended `statusBarMenu.test.ts` expectations + new `openSettingsCommand.test.ts` unit test
- Docs: `docs/status-bar-quick-actions.md`, `README.md`

## Testing
- `yarn compile` — types + lint clean
- `yarn test` (unit) — 343 passing
- e2e-ci — passes with the documented local `safe.bareRepository=all` override; the only failures without it are the pre-existing tag-push fixtures unrelated to this change