### PR TITLE
feat(status-bar): gate condition-dependent quick actions on repo state

### DIFF
--- a/docs/status-bar-quick-actions.md
+++ b/docs/status-bar-quick-actions.md
@@ -20,19 +20,38 @@ into a hub for the extension. You can also open it from the command palette.
 | Worktree | Move to new worktree | `Git Smart Checkout: Move to new worktree` |
 | Worktree | PR review in worktree… | `Git Smart Checkout: PR Review in Worktree` |
 | Worktree | Open worktree dev terminal… | `Git Smart Checkout: Open Worktree Dev Terminal...` |
-| Worktree changes | Copy staged changes to worktree… | `Git Smart Checkout: Copy staged changes to worktree...` |
-| Worktree changes | Copy WIP changes to worktree… | `Git Smart Checkout: Copy WIP changes to worktree...` |
-| Worktree changes | Copy WIP from worktree… | `Git Smart Checkout: Copy WIP from Worktree` |
-| Worktree changes | Move WIP from worktree… | `Git Smart Checkout: Move WIP from Worktree` |
-| Remove worktrees | Remove worktree… | `Git Smart Checkout: Remove Worktree...` |
-| Remove worktrees | Remove multiple worktrees… | `Git Smart Checkout: Remove Multiple Worktrees...` |
-| Remove worktrees | Remove PR review worktree… | `Git Smart Checkout: Remove PR review in Worktree` |
+| Worktree changes | Copy staged changes to worktree…¹ | `Git Smart Checkout: Copy staged changes to worktree...` |
+| Worktree changes | Copy WIP changes to worktree…¹ | `Git Smart Checkout: Copy WIP changes to worktree...` |
+| Worktree changes | Copy WIP from worktree…¹ | `Git Smart Checkout: Copy WIP from Worktree` |
+| Worktree changes | Move WIP from worktree…¹ | `Git Smart Checkout: Move WIP from Worktree` |
+| Remove worktrees | Remove worktree…¹ | `Git Smart Checkout: Remove Worktree...` |
+| Remove worktrees | Remove multiple worktrees…¹ | `Git Smart Checkout: Remove Multiple Worktrees...` |
+| Remove worktrees | Remove PR review worktree…¹ | `Git Smart Checkout: Remove PR review in Worktree` |
 | GitHub | Clone pull request… | `Git Smart Checkout: Clone pull request...` |
 | Settings | Open settings | `Git Smart Checkout: Open Settings` (opens VS Code Settings filtered to this extension) |
+
+¹ Shown only when the repository is in a state where the action can do
+something — see [Conditional actions](#conditional-actions). When none of a
+group's actions apply, the group separator is hidden too.
 
 Selecting an action runs the underlying command, so each step behaves exactly as
 it does from the command palette. Dismissing the menu (for example with `Esc`)
 does nothing.
+
+## Conditional actions
+
+These actions are gated on the repository state and only appear when their
+precondition is met (mirroring the guard inside each command):
+
+| Action | Shown when |
+| --- | --- |
+| Copy staged changes to worktree… | There are staged changes **and** another worktree to copy them into |
+| Copy WIP changes to worktree… | There are working-tree (WIP) changes **and** another worktree to copy them into |
+| Copy WIP from worktree… | At least one other worktree exists |
+| Move WIP from worktree… | At least one other worktree exists |
+| Remove worktree… | At least one removable worktree exists |
+| Remove multiple worktrees… | At least two removable worktrees exist |
+| Remove PR review worktree… | At least one tracked PR-review worktree still exists |
 
 ## Status Bar
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,14 @@ export function activate(context: vscode.ExtensionContext) {
   capture(AnalyticsEvent.ExtensionActivated);
 
   const logService = new LoggingService(configManager);
-  const statusBarManager = new StatusBarManager(configManager, logService);
+  const vscodeGitProvider = VscodeGitProvider.tryCreate(logService);
+  const prReviewWorktreeStore = new PRReviewWorktreeStore(context.globalState, logService);
+  const statusBarManager = new StatusBarManager(
+    configManager,
+    logService,
+    prReviewWorktreeStore,
+    vscodeGitProvider
+  );
   const prCloneService = new PrCloneService(context, logService, configManager);
   const prCloneWebViewProvider = new PrCloneWebViewProvider(
     context,
@@ -94,8 +101,6 @@ export function activate(context: vscode.ExtensionContext) {
     prCloneService
   );
   const autoStashService = new AutoStashService(configManager, logService);
-  const vscodeGitProvider = VscodeGitProvider.tryCreate(logService);
-  const prReviewWorktreeStore = new PRReviewWorktreeStore(context.globalState, logService);
   const refDetailsCache = new RefDetailsCache(context.globalState, logService);
 
   logService.info(`Extension "${EXTENSION_NAME}" is now active!`);

--- a/src/statusBar/quickActionsState.ts
+++ b/src/statusBar/quickActionsState.ts
@@ -1,0 +1,136 @@
+import { GitExecutor } from '../common/git/gitExecutor';
+import { IGitWorktree } from '../common/git/types';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { getWorkspaceFoldersFormatted } from '../common/vscode';
+import { getRemovableWorktrees, normalizePathForComparison } from '../commands/utils/worktreeRemoval';
+import { LoggingService } from '../logging/loggingService';
+import { PRReviewWorktreeStore } from '../services/prReviewWorktreeStore';
+
+/**
+ * Repository state used to decide which condition-dependent items appear in the
+ * status-bar quick actions menu. Every flag mirrors the early-exit guard inside
+ * the command it gates, so a shown item never immediately dead-ends in an
+ * informational dialog.
+ */
+export interface WorktreeQuickActionsState {
+  /** At least one removable (linked, non-bare, non-prunable) worktree exists. */
+  hasRemovableWorktree: boolean;
+  /** At least two removable worktrees exist. */
+  hasMultipleRemovableWorktrees: boolean;
+  /** At least one worktree other than the current one is selectable. */
+  hasOtherWorktree: boolean;
+  /** Staged changes exist and there is another worktree to copy them into. */
+  canCopyStagedToWorktree: boolean;
+  /** Working-tree (WIP) changes exist and there is another worktree to copy them into. */
+  canCopyWipToWorktree: boolean;
+  /** At least one tracked PR-review worktree still exists on disk. */
+  hasPRReviewWorktree: boolean;
+}
+
+const EMPTY_STATE: WorktreeQuickActionsState = {
+  hasRemovableWorktree: false,
+  hasMultipleRemovableWorktrees: false,
+  hasOtherWorktree: false,
+  canCopyStagedToWorktree: false,
+  canCopyWipToWorktree: false,
+  hasPRReviewWorktree: false,
+};
+
+function isSamePath(left: string, right: string): boolean {
+  return normalizePathForComparison(left) === normalizePathForComparison(right);
+}
+
+/**
+ * Worktrees other than the one rooted at {@link repositoryPath}, excluding bare
+ * and prunable entries. Matches the `selectableWorktrees` filter used by the
+ * copy/move-from-worktree commands.
+ */
+function getOtherWorktrees(worktrees: IGitWorktree[], repositoryPath: string): IGitWorktree[] {
+  return worktrees.filter(
+    (worktree) =>
+      !worktree.bare && !worktree.prunable && !isSamePath(worktree.path, repositoryPath)
+  );
+}
+
+async function gatherForFolder(
+  folderPath: string,
+  logService: LoggingService,
+  store: PRReviewWorktreeStore,
+  vscodeGitProvider?: VscodeGitProvider
+): Promise<WorktreeQuickActionsState> {
+  const git = new GitExecutor(folderPath, logService, vscodeGitProvider);
+  const worktrees = await git.worktreeListDetailed(true);
+
+  const removableCount = getRemovableWorktrees(worktrees).length;
+  const hasOtherWorktree = getOtherWorktrees(worktrees, git.repositoryPath).length > 0;
+
+  const hasStagedChanges = Boolean((await git.getStagedChangesPatch()).trim());
+  const hasWipChanges = await git.isWorkdirHasChanges();
+
+  const repoInfo = await git.getRepoInfo();
+  const identity = {
+    repoKey: PRReviewWorktreeStore.createRepoKey(repoInfo?.owner, repoInfo?.repo, git.repositoryPath),
+    repositoryPath: git.repositoryPath,
+  };
+  const records = await store.getForRepository(identity);
+  const hasPRReviewWorktree = records.some((record) =>
+    worktrees.some((worktree) => isSamePath(worktree.path, record.worktreePath))
+  );
+
+  return {
+    hasRemovableWorktree: removableCount >= 1,
+    hasMultipleRemovableWorktrees: removableCount >= 2,
+    hasOtherWorktree,
+    // Source changes and the target worktree must live in the SAME folder, so
+    // these are derived per-folder before the OR-combine below.
+    canCopyStagedToWorktree: hasStagedChanges && hasOtherWorktree,
+    canCopyWipToWorktree: hasWipChanges && hasOtherWorktree,
+    hasPRReviewWorktree,
+  };
+}
+
+/**
+ * Computes {@link WorktreeQuickActionsState} across every workspace folder
+ * without prompting (so it never uses `getGitExecutor`, which pops a repository
+ * picker on multi-folder workspaces). Each flag is OR-combined across folders.
+ *
+ * Best-effort: any failure degrades to an all-false state so the menu still
+ * opens with the always-available actions.
+ */
+export async function gatherWorktreeQuickActionsState(
+  logService: LoggingService,
+  store: PRReviewWorktreeStore,
+  vscodeGitProvider?: VscodeGitProvider
+): Promise<WorktreeQuickActionsState> {
+  try {
+    const folders = getWorkspaceFoldersFormatted() ?? [];
+    const state: WorktreeQuickActionsState = { ...EMPTY_STATE };
+
+    for (const folder of folders) {
+      try {
+        const folderState = await gatherForFolder(folder.path, logService, store, vscodeGitProvider);
+        state.hasRemovableWorktree ||= folderState.hasRemovableWorktree;
+        state.hasMultipleRemovableWorktrees ||= folderState.hasMultipleRemovableWorktrees;
+        state.hasOtherWorktree ||= folderState.hasOtherWorktree;
+        state.canCopyStagedToWorktree ||= folderState.canCopyStagedToWorktree;
+        state.canCopyWipToWorktree ||= folderState.canCopyWipToWorktree;
+        state.hasPRReviewWorktree ||= folderState.hasPRReviewWorktree;
+      } catch (error) {
+        logService.warn(
+          `[Quick Actions] Failed to gather worktree state for ${folder.path}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+
+    return state;
+  } catch (error) {
+    logService.warn(
+      `[Quick Actions] Failed to gather worktree state: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return { ...EMPTY_STATE };
+  }
+}

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -18,9 +18,17 @@ import {
   TAutoStashModeConfig,
 } from '../configuration/extensionConfig';
 import { AnalyticsEvent, capture } from '../analytics/analytics';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { PRReviewWorktreeStore } from '../services/prReviewWorktreeStore';
+import {
+  gatherWorktreeQuickActionsState,
+  WorktreeQuickActionsState,
+} from './quickActionsState';
 
 interface QuickActionItem extends QuickPickItem {
   commandId?: string;
+  /** Whether the item is shown; defaults to true when omitted. */
+  visible?: boolean;
 }
 
 export function getStatusBarBackgroundColor(
@@ -31,14 +39,125 @@ export function getStatusBarBackgroundColor(
     : new ThemeColor('statusBarItem.warningBackground');
 }
 
+/**
+ * Builds the full quick-actions item list. Condition-dependent items carry a
+ * `visible` flag derived from {@link WorktreeQuickActionsState}; everything else
+ * is always visible. Pure (no VS Code interaction) so it can be unit-tested.
+ */
+export function buildQuickActionItems(
+  modeBriefLabel: string,
+  state: WorktreeQuickActionsState
+): QuickActionItem[] {
+  const command = (name: string) => `${EXTENSION_NAME}.${name}`;
+
+  return [
+    { label: 'Stash mode', kind: QuickPickItemKind.Separator },
+    {
+      label: '$(gear) Switch stash mode',
+      description: `Current: ${modeBriefLabel}`,
+      commandId: command('switchMode'),
+    },
+    { label: 'Checkout', kind: QuickPickItemKind.Separator },
+    { label: '$(arrow-swap) Checkout to…', commandId: command('checkoutTo') },
+    { label: '$(history) Checkout previous branch', commandId: command('checkoutPrevious') },
+    { label: '$(git-pull-request) Checkout by PR number…', commandId: command('checkoutByPR') },
+    { label: 'Update branch', kind: QuickPickItemKind.Separator },
+    { label: '$(repo-pull) Pull (With Stash)', commandId: command('pullWithStash') },
+    { label: '$(repo-pull) Pull (Rebase With Stash)', commandId: command('pullRebaseWithStash') },
+    { label: '$(git-merge) Rebase (With Stash)', commandId: command('rebaseWithStash') },
+    { label: 'Worktree', kind: QuickPickItemKind.Separator },
+    { label: '$(list-tree) Move to new worktree', commandId: command('moveToNewWorktree') },
+    { label: '$(eye) PR review in worktree…', commandId: command('prReviewInWorktree') },
+    {
+      label: '$(terminal) Open worktree dev terminal…',
+      commandId: command('openWorktreeDevTerminal'),
+    },
+    { label: 'Worktree changes', kind: QuickPickItemKind.Separator },
+    {
+      label: '$(diff-added) Copy staged changes to worktree…',
+      commandId: command('copyStagedChangesToWorktree'),
+      visible: state.canCopyStagedToWorktree,
+    },
+    {
+      label: '$(copy) Copy WIP changes to worktree…',
+      commandId: command('copyWipChangesToWorktree'),
+      visible: state.canCopyWipToWorktree,
+    },
+    {
+      label: '$(arrow-left) Copy WIP from worktree…',
+      commandId: command('copyWipChangesFromWorktree'),
+      visible: state.hasOtherWorktree,
+    },
+    {
+      label: '$(arrow-right) Move WIP from worktree…',
+      commandId: command('moveWipChangesFromWorktree'),
+      visible: state.hasOtherWorktree,
+    },
+    { label: 'Remove worktrees', kind: QuickPickItemKind.Separator },
+    {
+      label: '$(trash) Remove worktree…',
+      commandId: command('removeWorktree'),
+      visible: state.hasRemovableWorktree,
+    },
+    {
+      label: '$(trash) Remove multiple worktrees…',
+      commandId: command('removeMultipleWorktrees'),
+      visible: state.hasMultipleRemovableWorktrees,
+    },
+    {
+      label: '$(trash) Remove PR review worktree…',
+      commandId: command('removePRReviewInWorktree'),
+      visible: state.hasPRReviewWorktree,
+    },
+    { label: 'GitHub', kind: QuickPickItemKind.Separator },
+    { label: '$(repo-clone) Clone pull request…', commandId: command('clonePullRequest') },
+    { label: 'Settings', kind: QuickPickItemKind.Separator },
+    { label: '$(settings-gear) Open settings', commandId: command('openSettings') },
+  ];
+}
+
+/**
+ * Drops items hidden via `visible === false`, then removes section separators
+ * that no longer head at least one action item (prevents orphaned headers such
+ * as "Worktree changes" or "Remove worktrees"). Pure and unit-testable.
+ */
+export function filterVisibleQuickActions(items: QuickActionItem[]): QuickActionItem[] {
+  const shown = items.filter((item) => item.visible !== false);
+
+  return shown.filter((item, index) => {
+    if (item.kind !== QuickPickItemKind.Separator) {
+      return true;
+    }
+
+    // Keep this separator only if an action item follows before the next separator.
+    for (let next = index + 1; next < shown.length; next++) {
+      if (shown[next].kind === QuickPickItemKind.Separator) {
+        return false;
+      }
+      return true;
+    }
+
+    return false;
+  });
+}
+
 export class StatusBarManager implements Disposable {
   private statusBarItem: StatusBarItem;
   private configManager: ConfigurationManager;
   private loggingService: LoggingService;
+  private prReviewWorktreeStore: PRReviewWorktreeStore;
+  private vscodeGitProvider?: VscodeGitProvider;
 
-  constructor(configManager: ConfigurationManager, loggingService: LoggingService) {
+  constructor(
+    configManager: ConfigurationManager,
+    loggingService: LoggingService,
+    prReviewWorktreeStore: PRReviewWorktreeStore,
+    vscodeGitProvider?: VscodeGitProvider
+  ) {
     this.configManager = configManager;
     this.loggingService = loggingService;
+    this.prReviewWorktreeStore = prReviewWorktreeStore;
+    this.vscodeGitProvider = vscodeGitProvider;
 
     this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
 
@@ -117,59 +236,15 @@ export class StatusBarManager implements Disposable {
 
     const config = this.configManager.get();
     const modeDetails = AUTO_STASH_MODES_DETAILS[config.mode as TAutoStashModeConfig];
-    const command = (name: string) => `${EXTENSION_NAME}.${name}`;
 
-    const items: QuickActionItem[] = [
-      { label: 'Stash mode', kind: QuickPickItemKind.Separator },
-      {
-        label: '$(gear) Switch stash mode',
-        description: `Current: ${modeDetails.briefLabel}`,
-        commandId: command('switchMode'),
-      },
-      { label: 'Checkout', kind: QuickPickItemKind.Separator },
-      { label: '$(arrow-swap) Checkout to…', commandId: command('checkoutTo') },
-      { label: '$(history) Checkout previous branch', commandId: command('checkoutPrevious') },
-      { label: '$(git-pull-request) Checkout by PR number…', commandId: command('checkoutByPR') },
-      { label: 'Update branch', kind: QuickPickItemKind.Separator },
-      { label: '$(repo-pull) Pull (With Stash)', commandId: command('pullWithStash') },
-      { label: '$(repo-pull) Pull (Rebase With Stash)', commandId: command('pullRebaseWithStash') },
-      { label: '$(git-merge) Rebase (With Stash)', commandId: command('rebaseWithStash') },
-      { label: 'Worktree', kind: QuickPickItemKind.Separator },
-      { label: '$(list-tree) Move to new worktree', commandId: command('moveToNewWorktree') },
-      { label: '$(eye) PR review in worktree…', commandId: command('prReviewInWorktree') },
-      {
-        label: '$(terminal) Open worktree dev terminal…',
-        commandId: command('openWorktreeDevTerminal'),
-      },
-      { label: 'Worktree changes', kind: QuickPickItemKind.Separator },
-      {
-        label: '$(diff-added) Copy staged changes to worktree…',
-        commandId: command('copyStagedChangesToWorktree'),
-      },
-      {
-        label: '$(copy) Copy WIP changes to worktree…',
-        commandId: command('copyWipChangesToWorktree'),
-      },
-      {
-        label: '$(arrow-left) Copy WIP from worktree…',
-        commandId: command('copyWipChangesFromWorktree'),
-      },
-      {
-        label: '$(arrow-right) Move WIP from worktree…',
-        commandId: command('moveWipChangesFromWorktree'),
-      },
-      { label: 'Remove worktrees', kind: QuickPickItemKind.Separator },
-      { label: '$(trash) Remove worktree…', commandId: command('removeWorktree') },
-      { label: '$(trash) Remove multiple worktrees…', commandId: command('removeMultipleWorktrees') },
-      {
-        label: '$(trash) Remove PR review worktree…',
-        commandId: command('removePRReviewInWorktree'),
-      },
-      { label: 'GitHub', kind: QuickPickItemKind.Separator },
-      { label: '$(repo-clone) Clone pull request…', commandId: command('clonePullRequest') },
-      { label: 'Settings', kind: QuickPickItemKind.Separator },
-      { label: '$(settings-gear) Open settings', commandId: command('openSettings') },
-    ];
+    const state = await gatherWorktreeQuickActionsState(
+      this.loggingService,
+      this.prReviewWorktreeStore,
+      this.vscodeGitProvider
+    );
+    const items = filterVisibleQuickActions(
+      buildQuickActionItems(modeDetails.briefLabel, state)
+    );
 
     const selection = await window.showQuickPick(items, {
       title: 'Git Smart Checkout',

--- a/src/test/e2e/statusBarMenu.test.ts
+++ b/src/test/e2e/statusBarMenu.test.ts
@@ -14,6 +14,7 @@ const commandId = (name: string) => `${EXTENSION_NAME}.${name}`;
 
 const MENU_PLACEHOLDER = 'Select an action';
 
+// Actions that are always shown, regardless of repository state.
 const EXPECTED_ACTIONS = [
   'switchMode',
   'checkoutTo',
@@ -25,6 +26,15 @@ const EXPECTED_ACTIONS = [
   'moveToNewWorktree',
   'prReviewInWorktree',
   'openWorktreeDevTerminal',
+  'clonePullRequest',
+  'openSettings',
+];
+
+// Actions gated on repository state (worktrees / pending changes). They are
+// absent from the menu when their precondition is not met — which is the case
+// in the clean, worktree-free e2e host. Their per-state visibility is covered
+// by the quickActions unit tests.
+const CONDITIONAL_ACTIONS = [
   'copyStagedChangesToWorktree',
   'copyWipChangesToWorktree',
   'copyWipChangesFromWorktree',
@@ -32,8 +42,6 @@ const EXPECTED_ACTIONS = [
   'removeWorktree',
   'removeMultipleWorktrees',
   'removePRReviewInWorktree',
-  'clonePullRequest',
-  'openSettings',
 ];
 
 function delay(ms = 0): Promise<void> {
@@ -119,6 +127,15 @@ describe('status bar quick actions menu', () => {
         assert.ok(
           actionCommands.includes(commandId(name)),
           `menu should include the ${name} action`
+        );
+      }
+
+      // The e2e host opens a clean window with no extra worktrees, so every
+      // state-gated action should be hidden.
+      for (const name of CONDITIONAL_ACTIONS) {
+        assert.ok(
+          !actionCommands.includes(commandId(name)),
+          `menu should hide the state-gated ${name} action in a clean workspace`
         );
       }
 

--- a/src/test/unit/quickActions.test.ts
+++ b/src/test/unit/quickActions.test.ts
@@ -1,0 +1,174 @@
+import * as assert from 'assert';
+
+import { QuickPickItemKind } from 'vscode';
+import { EXTENSION_NAME } from '../../const';
+import {
+  buildQuickActionItems,
+  filterVisibleQuickActions,
+} from '../../statusBar/statusBarManager';
+import { WorktreeQuickActionsState } from '../../statusBar/quickActionsState';
+
+const commandId = (name: string) => `${EXTENSION_NAME}.${name}`;
+
+const ALL_TRUE_STATE: WorktreeQuickActionsState = {
+  hasRemovableWorktree: true,
+  hasMultipleRemovableWorktrees: true,
+  hasOtherWorktree: true,
+  canCopyStagedToWorktree: true,
+  canCopyWipToWorktree: true,
+  hasPRReviewWorktree: true,
+};
+
+const ALL_FALSE_STATE: WorktreeQuickActionsState = {
+  hasRemovableWorktree: false,
+  hasMultipleRemovableWorktrees: false,
+  hasOtherWorktree: false,
+  canCopyStagedToWorktree: false,
+  canCopyWipToWorktree: false,
+  hasPRReviewWorktree: false,
+};
+
+const CONDITIONAL_COMMANDS = [
+  'copyStagedChangesToWorktree',
+  'copyWipChangesToWorktree',
+  'copyWipChangesFromWorktree',
+  'moveWipChangesFromWorktree',
+  'removeWorktree',
+  'removeMultipleWorktrees',
+  'removePRReviewInWorktree',
+];
+
+const ALWAYS_VISIBLE_COMMANDS = [
+  'switchMode',
+  'checkoutTo',
+  'checkoutPrevious',
+  'checkoutByPR',
+  'pullWithStash',
+  'pullRebaseWithStash',
+  'rebaseWithStash',
+  'moveToNewWorktree',
+  'prReviewInWorktree',
+  'openWorktreeDevTerminal',
+  'clonePullRequest',
+  'openSettings',
+];
+
+function visibleCommandIds(state: WorktreeQuickActionsState): string[] {
+  return filterVisibleQuickActions(buildQuickActionItems('Manual', state))
+    .filter((item) => item.commandId)
+    .map((item) => item.commandId as string);
+}
+
+function separatorLabels(state: WorktreeQuickActionsState): string[] {
+  return filterVisibleQuickActions(buildQuickActionItems('Manual', state))
+    .filter((item) => item.kind === QuickPickItemKind.Separator)
+    .map((item) => item.label);
+}
+
+describe('buildQuickActionItems', () => {
+  it('shows every conditional item when the state allows it', () => {
+    const ids = visibleCommandIds(ALL_TRUE_STATE);
+
+    for (const name of [...ALWAYS_VISIBLE_COMMANDS, ...CONDITIONAL_COMMANDS]) {
+      assert.ok(ids.includes(commandId(name)), `expected ${name} to be visible`);
+    }
+  });
+
+  it('puts the current stash mode brief label in the switch mode description', () => {
+    const switchMode = buildQuickActionItems('Auto pop', ALL_FALSE_STATE).find(
+      (item) => item.commandId === commandId('switchMode')
+    );
+
+    assert.ok(switchMode?.description?.includes('Auto pop'));
+  });
+
+  it('tags each conditional item with the matching state flag', () => {
+    const byCommand = (name: string) =>
+      buildQuickActionItems('Manual', ALL_FALSE_STATE).find(
+        (item) => item.commandId === commandId(name)
+      );
+
+    assert.strictEqual(byCommand('removeWorktree')?.visible, false);
+    assert.strictEqual(byCommand('removeMultipleWorktrees')?.visible, false);
+    assert.strictEqual(byCommand('removePRReviewInWorktree')?.visible, false);
+    assert.strictEqual(byCommand('copyStagedChangesToWorktree')?.visible, false);
+    assert.strictEqual(byCommand('copyWipChangesToWorktree')?.visible, false);
+    assert.strictEqual(byCommand('copyWipChangesFromWorktree')?.visible, false);
+    assert.strictEqual(byCommand('moveWipChangesFromWorktree')?.visible, false);
+    // Always-visible items leave `visible` undefined (defaults to shown).
+    assert.strictEqual(byCommand('checkoutTo')?.visible, undefined);
+  });
+});
+
+describe('filterVisibleQuickActions', () => {
+  it('keeps all always-visible actions regardless of state', () => {
+    const ids = visibleCommandIds(ALL_FALSE_STATE);
+
+    for (const name of ALWAYS_VISIBLE_COMMANDS) {
+      assert.ok(ids.includes(commandId(name)), `expected ${name} to remain visible`);
+    }
+  });
+
+  it('hides every conditional action and its now-empty separators in an empty state', () => {
+    const ids = visibleCommandIds(ALL_FALSE_STATE);
+
+    for (const name of CONDITIONAL_COMMANDS) {
+      assert.ok(!ids.includes(commandId(name)), `expected ${name} to be hidden`);
+    }
+
+    const separators = separatorLabels(ALL_FALSE_STATE);
+    assert.ok(
+      !separators.includes('Worktree changes'),
+      'the now-empty "Worktree changes" separator should be removed'
+    );
+    assert.ok(
+      !separators.includes('Remove worktrees'),
+      'the now-empty "Remove worktrees" separator should be removed'
+    );
+    // Sections that still have items keep their separators.
+    assert.ok(separators.includes('Worktree'));
+    assert.ok(separators.includes('Checkout'));
+  });
+
+  it('keeps a section separator when at least one item remains', () => {
+    const separators = separatorLabels(ALL_TRUE_STATE);
+
+    assert.ok(separators.includes('Worktree changes'));
+    assert.ok(separators.includes('Remove worktrees'));
+  });
+
+  it('shows "Remove worktree" but hides "Remove multiple worktrees" with a single removable worktree', () => {
+    const state: WorktreeQuickActionsState = {
+      ...ALL_FALSE_STATE,
+      hasRemovableWorktree: true,
+      hasOtherWorktree: true,
+    };
+
+    const ids = visibleCommandIds(state);
+
+    assert.ok(ids.includes(commandId('removeWorktree')));
+    assert.ok(!ids.includes(commandId('removeMultipleWorktrees')));
+    assert.ok(separatorLabels(state).includes('Remove worktrees'));
+  });
+
+  it('toggles the right copy-to-worktree item for staged-only vs wip-only states', () => {
+    const stagedOnly: WorktreeQuickActionsState = {
+      ...ALL_FALSE_STATE,
+      hasOtherWorktree: true,
+      canCopyStagedToWorktree: true,
+    };
+    const wipOnly: WorktreeQuickActionsState = {
+      ...ALL_FALSE_STATE,
+      hasOtherWorktree: true,
+      canCopyWipToWorktree: true,
+    };
+
+    const stagedIds = visibleCommandIds(stagedOnly);
+    assert.ok(stagedIds.includes(commandId('copyStagedChangesToWorktree')));
+    assert.ok(!stagedIds.includes(commandId('copyWipChangesToWorktree')));
+
+    const wipIds = visibleCommandIds(wipOnly);
+    assert.ok(wipIds.includes(commandId('copyWipChangesToWorktree')));
+    assert.ok(!wipIds.includes(commandId('copyStagedChangesToWorktree')));
+  });
+});


### PR DESCRIPTION
## Summary
- The status-bar **quick actions** menu listed every worktree command unconditionally. Selecting one in the wrong repository state just dead-ended in an info dialog (e.g. _"No PR review worktrees found."_, _"Need at least two removable worktrees…"_).
- The menu now computes the relevant repository state when it opens and **only shows condition-dependent items when their precondition is met**, removing now-empty section separators too. Preconditions mirror each command's own early-exit guard, so a shown action never immediately dead-ends.

### Gated actions and their preconditions
| Action | Shown when |
| --- | --- |
| Copy staged changes to worktree… | staged changes **and** another worktree |
| Copy WIP changes to worktree… | WIP changes **and** another worktree |
| Copy / Move WIP from worktree… | ≥1 other worktree |
| Remove worktree… | ≥1 removable worktree |
| Remove multiple worktrees… | ≥2 removable worktrees |
| Remove PR review worktree… | ≥1 tracked PR-review worktree still on disk |

Always-visible actions (checkout, pull/rebase, move-to-new-worktree, PR review, open dev terminal, clone PR, switch mode, open settings) are unchanged.

### Implementation
- New `src/statusBar/quickActionsState.ts` gathers state without prompting, following the OR-across-folders pattern already used for the Command Palette gating of `removeMultipleWorktrees`; degrades to an all-false state on error so the menu still opens.
- Menu construction is split into pure, unit-tested `buildQuickActionItems` + `filterVisibleQuickActions` in `statusBarManager.ts`.
- `StatusBarManager` now receives `PRReviewWorktreeStore` and `VscodeGitProvider` (wiring reordered in `extension.ts`).
- Docs updated in `docs/status-bar-quick-actions.md`.

## Test plan
- [x] Unit tests pass (`yarn test`) — added `src/test/unit/quickActions.test.ts` covering build/filter across all-true, all-false, single-worktree, and staged-only/wip-only states (351 unit tests green).
- [x] e2e `status bar quick actions menu` suite passes; updated `statusBarMenu.test.ts` to assert gated actions are hidden in the clean e2e host. (Two unrelated tag-push/remote e2e tests fail pre-existing on this machine.)
- [ ] Manual smoke in the Extension Host: gated items appear/disappear as worktrees and pending changes are created/removed.