### PR TITLE
feat(pr-clone): full GitHub-Flavored Markdown description preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,10 @@ All Git commands should go through `GitExecutor` for consistency. The utility fu
 
 The WebView provider creates HTML with VS Code CSS variables for proper theming. Message handling between WebView and extension happens through `onDidReceiveMessage`.
 
+### Markdown Preview
+
+The PR Clone description **Preview** renders full GitHub-Flavored Markdown via `markdown-it` (plus `markdown-it-task-lists`) in `src/webview/utils/renderMarkdown.ts` — covering tables, images, nested lists, autolinks and the GitHub raw-HTML subset (`<details>`, `<kbd>`, `<sub>`/`<sup>`). The raw HTML is sanitized with DOMPurify in `src/webview/utils/sanitizeHtml.ts` before being injected via `dangerouslySetInnerHTML` in the `MarkdownPreview` component. Rendering is fully client-side (no web server). Styling lives in `MarkdownPreview/module.css` and uses VS Code theme variables; class names produced by the renderer (e.g. `task-list-item`) must be matched with `:global(...)` selectors in the CSS module.
+
 ## React Development Guidelines
 
 - When creating React components, create them in a separate folder along with own CSS module file, and add styles related to this component to neighbour CSS module file, avoid using global CSS file unless it's necessary

--- a/package.json
+++ b/package.json
@@ -464,6 +464,8 @@
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^30.0.0",
     "@types/jira-client": "^7.1.9",
+    "@types/jsdom": "^28.0.3",
+    "@types/markdown-it": "^14.1.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
     "@types/react": "^18.2.0",
@@ -479,6 +481,7 @@
     "eslint": "^9.25.1",
     "glob": "^12.0.0",
     "html-webpack-plugin": "^5.5.3",
+    "jsdom": "^29.1.1",
     "mini-css-extract-plugin": "^2.7.6",
     "mocha": "^10.1.0",
     "mocha-junit-reporter": "^2.2.1",
@@ -498,7 +501,10 @@
   "dependencies": {
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.11",
     "jira-client": "^8.2.2",
+    "markdown-it": "^14.2.0",
+    "markdown-it-task-lists": "^2.1.1",
     "posthog-node": "^5.33.0"
   },
   "resolutions": {

--- a/src/test/unit/renderMarkdown.test.ts
+++ b/src/test/unit/renderMarkdown.test.ts
@@ -2,31 +2,32 @@ import * as assert from 'assert';
 
 import { renderMarkdown } from '../../webview/utils/renderMarkdown';
 
+// `renderMarkdown` now returns raw (pre-sanitize) GFM HTML from markdown-it.
+// Output carries trailing newlines and full block wrapping, so assertions use
+// `includes`/normalized checks rather than exact-string equality. XSS/`javascript:`
+// guarantees live in sanitizeHtml.test.ts, which covers the actual injection path.
+
+const norm = (html: string): string => html.replace(/\n+/g, '').trim();
+
 describe('renderMarkdown', () => {
   it('returns an empty string for empty input', () => {
-    assert.strictEqual(renderMarkdown(''), '');
+    assert.strictEqual(renderMarkdown('').trim(), '');
   });
 
   it('renders headings at the right level', () => {
-    assert.strictEqual(renderMarkdown('# Title'), '<h1>Title</h1>');
-    assert.strictEqual(renderMarkdown('### Sub'), '<h3>Sub</h3>');
+    assert.strictEqual(norm(renderMarkdown('# Title')), '<h1>Title</h1>');
+    assert.strictEqual(norm(renderMarkdown('### Sub')), '<h3>Sub</h3>');
   });
 
   it('wraps plain text in a paragraph', () => {
-    assert.strictEqual(renderMarkdown('hello world'), '<p>hello world</p>');
+    assert.strictEqual(norm(renderMarkdown('hello world')), '<p>hello world</p>');
   });
 
   it('renders bold, italic, strikethrough and inline code', () => {
-    assert.strictEqual(renderMarkdown('**bold**'), '<p><strong>bold</strong></p>');
-    assert.strictEqual(renderMarkdown('*italic*'), '<p><em>italic</em></p>');
-    assert.strictEqual(renderMarkdown('~~gone~~'), '<p><del>gone</del></p>');
-    assert.strictEqual(renderMarkdown('`code`'), '<p><code>code</code></p>');
-  });
-
-  it('escapes HTML so embedded markup cannot execute', () => {
-    const html = renderMarkdown('<script>alert(1)</script>');
-    assert.ok(!html.includes('<script>'), 'raw <script> must not appear');
-    assert.ok(html.includes('&lt;script&gt;'));
+    assert.ok(renderMarkdown('**bold**').includes('<strong>bold</strong>'));
+    assert.ok(renderMarkdown('*italic*').includes('<em>italic</em>'));
+    assert.ok(renderMarkdown('~~gone~~').includes('<s>gone</s>'));
+    assert.ok(renderMarkdown('`code`').includes('<code>code</code>'));
   });
 
   it('does not reinterpret characters inside inline code', () => {
@@ -35,13 +36,11 @@ describe('renderMarkdown', () => {
     assert.ok(html.includes('<em>real</em>'), 'emphasis still works outside code');
   });
 
-  it('renders safe links and rejects dangerous schemes', () => {
-    const safe = renderMarkdown('[text](https://example.com)');
-    assert.ok(safe.includes('<a href="https://example.com"'));
-    assert.ok(safe.includes('rel="noopener noreferrer"'));
-
-    const dangerous = renderMarkdown('[x](javascript:alert(1))');
-    assert.ok(!dangerous.includes('<a '), 'javascript: links must not become anchors');
+  it('renders safe links with target and rel attributes', () => {
+    const html = renderMarkdown('[text](https://example.com)');
+    assert.ok(html.includes('href="https://example.com"'));
+    assert.ok(html.includes('target="_blank"'));
+    assert.ok(html.includes('rel="noopener noreferrer"'));
   });
 
   it('keeps underscores inside link URLs intact', () => {
@@ -50,25 +49,59 @@ describe('renderMarkdown', () => {
     assert.ok(!html.includes('<em>'), 'URL underscores must not turn into emphasis');
   });
 
-  it('renders unordered lists', () => {
-    assert.strictEqual(renderMarkdown('- one\n- two'), '<ul><li>one</li><li>two</li></ul>');
+  it('autolinks bare URLs', () => {
+    const html = renderMarkdown('see https://example.com for details');
+    assert.ok(html.includes('href="https://example.com"'));
+  });
+
+  it('renders images', () => {
+    const html = renderMarkdown('![alt text](https://example.com/i.png)');
+    assert.ok(html.includes('<img'));
+    assert.ok(html.includes('src="https://example.com/i.png"'));
+    assert.ok(html.includes('alt="alt text"'));
+  });
+
+  it('renders unordered and nested lists', () => {
+    const html = renderMarkdown('- one\n- two\n  - nested');
+    assert.ok(html.includes('<ul>'));
+    assert.ok(html.includes('<li>one'));
+    assert.ok(html.includes('nested'));
+    assert.ok(/<li>[\s\S]*<ul>[\s\S]*nested/.test(html), 'nested list rendered inside item');
   });
 
   it('renders task list checkboxes', () => {
     const html = renderMarkdown('- [ ] todo\n- [x] done');
-    assert.ok(html.includes('type="checkbox" disabled />'), 'unchecked box rendered');
-    assert.ok(html.includes('type="checkbox" disabled checked />'), 'checked box rendered');
+    assert.ok(html.includes('type="checkbox"'));
+    assert.ok(html.includes('task-list-item'));
+    assert.ok(html.includes('checked'), 'checked box rendered');
     assert.ok(html.includes('todo'));
     assert.ok(html.includes('done'));
   });
 
   it('renders ordered lists', () => {
-    assert.strictEqual(renderMarkdown('1. a\n2. b'), '<ol><li>a</li><li>b</li></ol>');
+    const html = renderMarkdown('1. a\n2. b');
+    assert.ok(html.includes('<ol>'));
+    assert.ok(html.includes('<li>a</li>'));
+    assert.ok(html.includes('<li>b</li>'));
+  });
+
+  it('renders GFM tables', () => {
+    const html = renderMarkdown('| H1 | H2 |\n| --- | --- |\n| a | b |');
+    assert.ok(html.includes('<table>'));
+    assert.ok(html.includes('<th>H1</th>'));
+    assert.ok(html.includes('<td>a</td>'));
+  });
+
+  it('passes through GitHub-allowed raw HTML (sanitized later)', () => {
+    const html = renderMarkdown('<details><summary>more</summary>hidden</details>');
+    assert.ok(html.includes('<details>'));
+    assert.ok(html.includes('<summary>more</summary>'));
   });
 
   it('renders fenced code blocks without inline formatting', () => {
     const html = renderMarkdown('```\nconst a = **b**;\n```');
-    assert.ok(html.startsWith('<pre><code>'));
+    assert.ok(html.includes('<pre>'));
+    assert.ok(html.includes('<code>'));
     assert.ok(html.includes('const a = **b**;'), 'code content kept literal');
     assert.ok(!html.includes('<strong>'));
   });
@@ -80,6 +113,6 @@ describe('renderMarkdown', () => {
   });
 
   it('renders horizontal rules', () => {
-    assert.strictEqual(renderMarkdown('---'), '<hr />');
+    assert.ok(renderMarkdown('---').includes('<hr>'));
   });
 });

--- a/src/test/unit/sanitizeHtml.test.ts
+++ b/src/test/unit/sanitizeHtml.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+
+import { JSDOM } from 'jsdom';
+
+import { createSanitize } from '../../webview/utils/sanitizeHtml';
+
+// DOMPurify needs a DOM. The extension-host test runner has no global `window`,
+// so we drive the sanitizer through `createSanitize` with a jsdom window — the
+// same code path the webview uses with its real browser window.
+const sanitize = createSanitize(new JSDOM('').window as never);
+
+describe('sanitizeHtml', () => {
+  it('strips <script> tags', () => {
+    const out = sanitize('<p>ok</p><script>alert(1)</script>');
+    assert.ok(out.includes('<p>ok</p>'));
+    assert.ok(!out.includes('<script'), 'script tag removed');
+    assert.ok(!out.includes('alert(1)'), 'script body removed');
+  });
+
+  it('removes inline event handlers and neutralizes img onerror', () => {
+    const out = sanitize('<img src="x" onerror="alert(1)">');
+    assert.ok(!out.includes('onerror'), 'event handler attribute removed');
+  });
+
+  it('drops javascript: links but keeps the text', () => {
+    const out = sanitize('<a href="javascript:alert(1)">click</a>');
+    assert.ok(!out.includes('javascript:'), 'dangerous scheme removed');
+    assert.ok(out.includes('click'), 'link text preserved');
+  });
+
+  it('keeps safe http links', () => {
+    const out = sanitize('<a href="https://example.com" target="_blank" rel="noopener">x</a>');
+    assert.ok(out.includes('href="https://example.com"'));
+    assert.ok(out.includes('target="_blank"'));
+  });
+
+  it('preserves GFM tables', () => {
+    const out = sanitize('<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>v</td></tr></tbody></table>');
+    assert.ok(out.includes('<table>'));
+    assert.ok(out.includes('<th>H</th>'));
+    assert.ok(out.includes('<td>v</td>'));
+  });
+
+  it('preserves details/summary, kbd and sub/sup', () => {
+    const out = sanitize('<details><summary>s</summary>x</details><kbd>Ctrl</kbd><sub>a</sub><sup>b</sup>');
+    assert.ok(out.includes('<details>'));
+    assert.ok(out.includes('<summary>s</summary>'));
+    assert.ok(out.includes('<kbd>Ctrl</kbd>'));
+    assert.ok(out.includes('<sub>a</sub>'));
+    assert.ok(out.includes('<sup>b</sup>'));
+  });
+
+  it('preserves disabled task-list checkboxes', () => {
+    const out = sanitize(
+      '<li class="task-list-item"><input type="checkbox" disabled checked> done</li>'
+    );
+    assert.ok(out.includes('type="checkbox"'));
+    assert.ok(out.includes('disabled'));
+    assert.ok(out.includes('task-list-item'));
+  });
+});

--- a/src/types/markdown-it-task-lists.d.ts
+++ b/src/types/markdown-it-task-lists.d.ts
@@ -1,0 +1,15 @@
+// Ambient declaration mirrored from src/webview/types so the root tsconfig
+// (which excludes src/webview/**) can type-check renderMarkdown.ts when it is
+// pulled in by unit tests. markdown-it-task-lists ships no types of its own.
+declare module 'markdown-it-task-lists' {
+  import type MarkdownIt from 'markdown-it';
+
+  interface TaskListsOptions {
+    enabled?: boolean;
+    label?: boolean;
+    labelAfter?: boolean;
+  }
+
+  const taskLists: (md: MarkdownIt, options?: TaskListsOptions) => void;
+  export default taskLists;
+}

--- a/src/webview/components/MarkdownPreview/index.tsx
+++ b/src/webview/components/MarkdownPreview/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { FC } from 'react';
 
 import { renderMarkdown } from '@/utils/renderMarkdown';
+import { sanitizeHtml } from '@/utils/sanitizeHtml';
 
 import styles from './module.css';
 
@@ -22,6 +23,9 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown, className 
   }
 
   return (
-    <div className={classes} dangerouslySetInnerHTML={{ __html: renderMarkdown(markdown) }} />
+    <div
+      className={classes}
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(renderMarkdown(markdown)) }}
+    />
   );
 };

--- a/src/webview/components/MarkdownPreview/module.css
+++ b/src/webview/components/MarkdownPreview/module.css
@@ -76,13 +76,24 @@
   margin: 2px 0;
 }
 
-.preview li.task {
+.preview ul ul,
+.preview ul ol,
+.preview ol ul,
+.preview ol ol {
+  margin: 2px 0;
+}
+
+.preview li :global(.task-list-item) {
+  list-style: none;
+}
+
+.preview li:global(.task-list-item) {
   list-style: none;
   margin-left: -18px;
 }
 
-.preview li.task input {
-  margin-right: 6px;
+.preview li:global(.task-list-item) input[type='checkbox'] {
+  margin: 0 6px 0 0;
   vertical-align: middle;
 }
 
@@ -119,4 +130,63 @@
   margin: 12px 0;
   border: none;
   background-color: var(--vscode-widget-border);
+}
+
+.preview img {
+  max-width: 100%;
+  height: auto;
+  box-sizing: border-box;
+}
+
+.preview table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  margin: 0 0 10px;
+  overflow: auto;
+  border-collapse: collapse;
+}
+
+.preview th,
+.preview td {
+  padding: 5px 12px;
+  border: 1px solid var(--vscode-widget-border);
+}
+
+.preview th {
+  font-weight: 600;
+}
+
+.preview tr {
+  background-color: transparent;
+}
+
+.preview tr:nth-child(2n) {
+  background-color: var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.1));
+}
+
+.preview kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 0.85em;
+  line-height: 1.4;
+  color: var(--vscode-foreground);
+  vertical-align: middle;
+  background-color: var(--vscode-textCodeBlock-background, rgba(127, 127, 127, 0.2));
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 4px;
+}
+
+.preview details {
+  margin: 0 0 10px;
+}
+
+.preview summary {
+  cursor: pointer;
+}
+
+.preview sub,
+.preview sup {
+  font-size: 0.75em;
 }

--- a/src/webview/types/markdown-it-task-lists.d.ts
+++ b/src/webview/types/markdown-it-task-lists.d.ts
@@ -1,0 +1,12 @@
+declare module 'markdown-it-task-lists' {
+  import type MarkdownIt from 'markdown-it';
+
+  interface TaskListsOptions {
+    enabled?: boolean;
+    label?: boolean;
+    labelAfter?: boolean;
+  }
+
+  const taskLists: (md: MarkdownIt, options?: TaskListsOptions) => void;
+  export default taskLists;
+}

--- a/src/webview/utils/renderMarkdown.ts
+++ b/src/webview/utils/renderMarkdown.ts
@@ -1,193 +1,40 @@
 /**
- * Minimal, dependency-free Markdown -> HTML renderer used for the PR description
- * preview in the PR Clone webview.
+ * GitHub-Flavored-Markdown -> HTML renderer for the PR description preview in
+ * the PR Clone webview.
  *
- * Safety: every piece of raw text is HTML-escaped *before* any markup is
- * injected, and only a fixed whitelist of tags is produced. Link targets are
- * scheme-validated, so a malicious `javascript:` URL in a PR body cannot be
- * turned into a clickable link. This makes the output safe to assign through
- * `dangerouslySetInnerHTML`.
+ * Rendering is delegated to `markdown-it` (CommonMark + GFM tables, strike-
+ * through and autolinking) plus the task-list plugin, so the preview matches
+ * the way GitHub renders a PR body — including tables, images, nested lists,
+ * bare-URL autolinks and the small subset of raw HTML GitHub allows
+ * (`<details>`, `<kbd>`, `<sub>`/`<sup>`, ...).
  *
- * The goal is a faithful-enough preview (headings, emphasis, code, lists,
- * task lists, block quotes, links, rules), not full CommonMark/GFM compliance.
+ * The output is RAW HTML and is therefore *not* safe to inject on its own:
+ * `html: true` lets author-controlled markup through. Callers MUST pass the
+ * result through {@link sanitizeHtml} before assigning it to
+ * `dangerouslySetInnerHTML`. Keeping this module DOM-free (no DOMPurify) lets
+ * it run and be unit-tested in a plain Node context.
  */
 
-const PLACEHOLDER = '';
+import MarkdownIt from 'markdown-it';
+import taskLists from 'markdown-it-task-lists';
 
-const escapeHtml = (value: string): string =>
-  value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  breaks: true,
+}).use(taskLists, { enabled: true, label: false });
 
-/**
- * Return the URL when it uses a safe scheme (http/https/mailto), is an anchor
- * or relative path, or carries no scheme at all. Returns `null` for anything
- * else (e.g. `javascript:`/`data:`) so the caller can fall back to plain text.
- */
-const sanitizeUrl = (url: string): string | null => {
-  const trimmed = url.trim();
+// Open links in the user's browser (VS Code intercepts webview link clicks) and
+// harden the relationship to avoid reverse-tabnabbing.
+const defaultLinkOpen =
+  md.renderer.rules.link_open ??
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
 
-  if (/^(https?:\/\/|mailto:)/i.test(trimmed)) {
-    return trimmed;
-  }
-
-  if (/^[#/]/.test(trimmed)) {
-    return trimmed;
-  }
-
-  // No scheme at all -> treat as a relative link.
-  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
-    return trimmed;
-  }
-
-  return null;
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  const token = tokens[idx];
+  token.attrSet('target', '_blank');
+  token.attrSet('rel', 'noopener noreferrer');
+  return defaultLinkOpen(tokens, idx, options, env, self);
 };
 
-/**
- * Apply inline formatting to a single line of already HTML-escaped text. Code
- * spans and links are stashed behind placeholders before emphasis runs so that
- * characters inside them (e.g. underscores in a URL) are never reinterpreted.
- */
-const renderInline = (escaped: string): string => {
-  const tokens: string[] = [];
-  const stash = (html: string): string => {
-    tokens.push(html);
-    return `${PLACEHOLDER}${tokens.length - 1}${PLACEHOLDER}`;
-  };
-
-  let result = escaped.replace(/`([^`]+)`/g, (_match, code) => stash(`<code>${code}</code>`));
-
-  result = result.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, text, url) => {
-    const safe = sanitizeUrl(url);
-    if (!safe) {
-      return match;
-    }
-    return stash(`<a href="${safe}" target="_blank" rel="noopener noreferrer">${text}</a>`);
-  });
-
-  result = result
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/__([^_]+)__/g, '<strong>$1</strong>')
-    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
-    .replace(/(^|[^A-Za-z0-9])_([^_]+)_(?=[^A-Za-z0-9]|$)/g, '$1<em>$2</em>')
-    .replace(/~~([^~]+)~~/g, '<del>$1</del>');
-
-  result = result.replace(new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, 'g'), (_match, index) =>
-    tokens[Number(index)]
-  );
-
-  return result;
-};
-
-const isBlank = (line: string): boolean => /^\s*$/.test(line);
-const isFence = (line: string): boolean => /^\s*```/.test(line);
-const isHeading = (line: string): boolean => /^#{1,6}\s+/.test(line);
-const isQuote = (line: string): boolean => /^\s*>\s?/.test(line);
-const isUnordered = (line: string): boolean => /^\s*[-*+]\s+/.test(line);
-const isOrdered = (line: string): boolean => /^\s*\d+[.)]\s+/.test(line);
-const isRule = (line: string): boolean => /^\s*([-*_])(\s*\1){2,}\s*$/.test(line);
-
-const isBlockStart = (line: string): boolean =>
-  isBlank(line) ||
-  isFence(line) ||
-  isHeading(line) ||
-  isQuote(line) ||
-  isUnordered(line) ||
-  isOrdered(line) ||
-  isRule(line);
-
-export const renderMarkdown = (markdown: string): string => {
-  const lines = (markdown ?? '').replace(/\r\n/g, '\n').split('\n');
-  const html: string[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (isFence(line)) {
-      const code: string[] = [];
-      i++;
-      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
-        code.push(lines[i]);
-        i++;
-      }
-      i++; // skip the closing fence (if present)
-      html.push(`<pre><code>${escapeHtml(code.join('\n'))}</code></pre>`);
-      continue;
-    }
-
-    if (isBlank(line)) {
-      i++;
-      continue;
-    }
-
-    if (isRule(line)) {
-      html.push('<hr />');
-      i++;
-      continue;
-    }
-
-    const heading = line.match(/^(#{1,6})\s+(.*)$/);
-    if (heading) {
-      const level = heading[1].length;
-      html.push(`<h${level}>${renderInline(escapeHtml(heading[2].trim()))}</h${level}>`);
-      i++;
-      continue;
-    }
-
-    if (isQuote(line)) {
-      const quoted: string[] = [];
-      while (i < lines.length && isQuote(lines[i])) {
-        quoted.push(lines[i].replace(/^\s*>\s?/, ''));
-        i++;
-      }
-      html.push(`<blockquote>${renderMarkdown(quoted.join('\n'))}</blockquote>`);
-      continue;
-    }
-
-    if (isUnordered(line)) {
-      const items: string[] = [];
-      while (i < lines.length && isUnordered(lines[i])) {
-        const content = lines[i].replace(/^\s*[-*+]\s+/, '');
-        const task = content.match(/^\[([ xX])\]\s+(.*)$/);
-        if (task) {
-          const checked = task[1].toLowerCase() === 'x' ? ' checked' : '';
-          items.push(
-            `<li class="task"><input type="checkbox" disabled${checked} /> ${renderInline(
-              escapeHtml(task[2])
-            )}</li>`
-          );
-        } else {
-          items.push(`<li>${renderInline(escapeHtml(content))}</li>`);
-        }
-        i++;
-      }
-      html.push(`<ul>${items.join('')}</ul>`);
-      continue;
-    }
-
-    if (isOrdered(line)) {
-      const items: string[] = [];
-      while (i < lines.length && isOrdered(lines[i])) {
-        const content = lines[i].replace(/^\s*\d+[.)]\s+/, '');
-        items.push(`<li>${renderInline(escapeHtml(content))}</li>`);
-        i++;
-      }
-      html.push(`<ol>${items.join('')}</ol>`);
-      continue;
-    }
-
-    const paragraph: string[] = [];
-    while (i < lines.length && !isBlockStart(lines[i])) {
-      paragraph.push(lines[i]);
-      i++;
-    }
-    const rendered = paragraph.map((entry) => renderInline(escapeHtml(entry))).join('<br />');
-    html.push(`<p>${rendered}</p>`);
-  }
-
-  return html.join('\n');
-};
+export const renderMarkdown = (markdown: string): string => md.render(markdown ?? '');

--- a/src/webview/utils/sanitizeHtml.ts
+++ b/src/webview/utils/sanitizeHtml.ts
@@ -1,0 +1,67 @@
+/**
+ * HTML sanitizer for the rendered PR description preview.
+ *
+ * `renderMarkdown` runs `markdown-it` with `html: true`, so its output can
+ * contain author-controlled markup (the PR body comes from an arbitrary GitHub
+ * user). Before that HTML is handed to `dangerouslySetInnerHTML` it MUST pass
+ * through here, where DOMPurify drops `<script>`, inline event handlers
+ * (`onerror`, `onclick`, ...) and dangerous URL schemes (`javascript:`) while
+ * preserving the Core-GFM element set GitHub renders.
+ */
+
+import createDOMPurify, { type Config, type WindowLike } from 'dompurify';
+
+// Core-GFM tags beyond DOMPurify's defaults that we explicitly want to keep.
+const ALLOWED_TAGS = [
+  'details',
+  'summary',
+  'kbd',
+  'sub',
+  'sup',
+  'input', // disabled task-list checkboxes
+];
+
+const ALLOWED_ATTR = [
+  'target',
+  'rel',
+  'align', // GFM table column alignment
+  'type',
+  'checked',
+  'disabled',
+  'class', // task-list-item markers
+];
+
+const SANITIZE_CONFIG: Config = {
+  ADD_TAGS: ALLOWED_TAGS,
+  ADD_ATTR: ALLOWED_ATTR,
+  // Allow http(s)/mailto/anchors/relative links; everything else (javascript:,
+  // data:, vbscript:) is stripped by DOMPurify.
+  ALLOW_DATA_ATTR: false,
+};
+
+type Sanitize = (html: string) => string;
+
+/**
+ * Build a sanitizer bound to a specific window. Used directly by unit tests
+ * (which pass a jsdom window) and internally for the live webview window.
+ */
+export const createSanitize = (windowObj: WindowLike): Sanitize => {
+  const purify = createDOMPurify(windowObj);
+  return (html: string) => purify.sanitize(html, SANITIZE_CONFIG) as string;
+};
+
+let cached: Sanitize | undefined;
+
+/**
+ * Sanitize HTML using the global browser `window`. Available in the webview;
+ * throws if called without a DOM (use {@link createSanitize} in that case).
+ */
+export const sanitizeHtml = (html: string): string => {
+  if (!cached) {
+    if (typeof window === 'undefined') {
+      throw new Error('sanitizeHtml requires a DOM window; use createSanitize(window) instead.');
+    }
+    cached = createSanitize(window as unknown as WindowLike);
+  }
+  return cached(html);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^5.1.11":
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-5.1.11.tgz#28a0aac8220a4cc19045ac3bd9a813d4060bd375"
+  integrity sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==
+  dependencies:
+    "@asamuzakjp/generational-cache" "^1.0.1"
+    "@csstools/css-calc" "^3.2.0"
+    "@csstools/css-color-parser" "^4.1.0"
+    "@csstools/css-parser-algorithms" "^4.0.0"
+    "@csstools/css-tokenizer" "^4.0.0"
+
+"@asamuzakjp/dom-selector@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz#01880086bb2490098f167beb58555da1a6c9adbd"
+  integrity sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==
+  dependencies:
+    "@asamuzakjp/generational-cache" "^1.0.1"
+    "@asamuzakjp/nwsapi" "^2.3.9"
+    bidi-js "^1.0.3"
+    css-tree "^3.2.1"
+    is-potential-custom-element-name "^1.0.1"
+
+"@asamuzakjp/generational-cache@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz#3d0bf6be4fc059851390a7070720c6007af793ec"
+  integrity sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==
+
+"@asamuzakjp/nwsapi@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
+  integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
+
 "@azu/format-text@^1.0.1", "@azu/format-text@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@azu/format-text/-/format-text-1.0.2.tgz#abd46dab2422e312bd1bfe36f0d427ab6039825d"
@@ -141,10 +173,50 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bramus/specificity@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
+  integrity sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==
+  dependencies:
+    css-tree "^3.0.0"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@csstools/color-helpers@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz#82c59fd30649cf0b4d3c82160489748666e6550b"
+  integrity sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==
+
+"@csstools/css-calc@^3.2.0", "@csstools/css-calc@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-3.2.1.tgz#b30e061ca9f297ccb2b3b032bfee32fda02b1b27"
+  integrity sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==
+
+"@csstools/css-color-parser@^4.1.0":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz#ca32fc74a3cdec7c288651fe01241fcd59f95a0e"
+  integrity sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==
+  dependencies:
+    "@csstools/color-helpers" "^6.0.2"
+    "@csstools/css-calc" "^3.2.1"
+
+"@csstools/css-parser-algorithms@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz#e1c65dc09378b42f26a111fca7f7075fc2c26164"
+  integrity sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==
+
+"@csstools/css-syntax-patches-for-csstree@^1.1.3":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz#b8e26e0fe25e9a6ec607d045470cc46d2f62731e"
+  integrity sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==
+
+"@csstools/css-tokenizer@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
+  integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
@@ -370,6 +442,11 @@
   dependencies:
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
+
+"@exodus/bytes@^1.11.0", "@exodus/bytes@^1.15.0", "@exodus/bytes@^1.6.0":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
+  integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
 
 "@humanfs/core@^0.19.2":
   version "0.19.2"
@@ -1760,10 +1837,38 @@
     "@types/node" "*"
     "@types/request" "*"
 
+"@types/jsdom@^28.0.3":
+  version "28.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-28.0.3.tgz#a5a900ae4d5bb1d874dee24a89afc06b34d3c1a0"
+  integrity sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^8.0.0"
+    undici-types "^7.21.0"
+
 "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/linkify-it@^5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
+  integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
+
+"@types/markdown-it@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-14.1.2.tgz#57f2532a0800067d9b934f3521429a2e8bfb4c61"
+  integrity sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
+  dependencies:
+    "@types/linkify-it" "^5"
+    "@types/mdurl" "^2"
+
+"@types/mdurl@^2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
 "@types/mime@^1":
   version "1.3.5"
@@ -1895,6 +2000,11 @@
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/vscode@1.74.0":
   version "1.74.0"
@@ -2621,6 +2731,13 @@ before-after-hook@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-4.0.0.tgz#cf1447ab9160df6a40f3621da64d6ffc36050cb9"
   integrity sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==
+
+bidi-js@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bidi-js/-/bidi-js-1.0.3.tgz#6f8bcf3c877c4d9220ddf49b9bb6930c88f877d2"
+  integrity sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==
+  dependencies:
+    require-from-string "^2.0.2"
 
 bin-links@^5.0.0:
   version "5.0.0"
@@ -3352,6 +3469,14 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
+css-tree@^3.0.0, css-tree@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.2.1.tgz#86cac7011561272b30e6b1e042ba6ce047aa7518"
+  integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
+  dependencies:
+    mdn-data "2.27.1"
+    source-map-js "^1.2.1"
+
 css-what@^6.0.1, css-what@^6.1.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
@@ -3373,6 +3498,14 @@ dashdash@^1.12.0:
   integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-7.0.0.tgz#6dce8b63226a1ecfdd907ce18a8ccfb1eee506d3"
+  integrity sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==
+  dependencies:
+    whatwg-mimetype "^5.0.0"
+    whatwg-url "^16.0.0"
 
 data-view-buffer@^1.0.2:
   version "1.0.2"
@@ -3424,6 +3557,11 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+decimal.js@^10.6.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -3570,6 +3708,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.4.11:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -3731,6 +3876,11 @@ entities@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
+entities@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
+  integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 env-ci@^11.0.0:
   version "11.2.0"
@@ -4778,6 +4928,13 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-encoding-sniffer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
+  integrity sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==
+  dependencies:
+    "@exodus/bytes" "^1.6.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -5303,6 +5460,11 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
@@ -5599,6 +5761,33 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+jsdom@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
+  integrity sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==
+  dependencies:
+    "@asamuzakjp/css-color" "^5.1.11"
+    "@asamuzakjp/dom-selector" "^7.1.1"
+    "@bramus/specificity" "^2.4.2"
+    "@csstools/css-syntax-patches-for-csstree" "^1.1.3"
+    "@exodus/bytes" "^1.15.0"
+    css-tree "^3.2.1"
+    data-urls "^7.0.0"
+    decimal.js "^10.6.0"
+    html-encoding-sniffer "^6.0.0"
+    is-potential-custom-element-name "^1.0.1"
+    lru-cache "^11.3.5"
+    parse5 "^8.0.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^6.0.1"
+    undici "^7.25.0"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^8.0.1"
+    whatwg-mimetype "^5.0.0"
+    whatwg-url "^16.0.1"
+    xml-name-validator "^5.0.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -6055,7 +6244,7 @@ lru-cache@^10.0.1, lru-cache@^10.2.0, lru-cache@^10.2.2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lru-cache@^11.0.0:
+lru-cache@^11.0.0, lru-cache@^11.3.5:
   version "11.5.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.1.tgz#f3daa3540847b9737ebc02499ddb36765e54db4a"
   integrity sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==
@@ -6100,7 +6289,12 @@ make-fetch-happen@^14.0.0, make-fetch-happen@^14.0.2, make-fetch-happen@^14.0.3:
     promise-retry "^2.0.1"
     ssri "^12.0.0"
 
-markdown-it@14.2.0, markdown-it@^12.3.2, markdown-it@^14.1.0:
+markdown-it-task-lists@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz#f68f4d2ac2bad5a2c373ba93081a1a6848417088"
+  integrity sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==
+
+markdown-it@14.2.0, markdown-it@^12.3.2, markdown-it@^14.1.0, markdown-it@^14.2.0:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.2.0.tgz#06d48d9035e77d5b1c85adb315482fc8240289ef"
   integrity sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==
@@ -6143,6 +6337,11 @@ md5@^2.3.0:
     charenc "0.0.2"
     crypt "0.0.2"
     is-buffer "~1.1.6"
+
+mdn-data@2.27.1:
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
+  integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
 mdurl@^2.0.0:
   version "2.0.0"
@@ -7194,6 +7393,13 @@ parse5@^7.0.0, parse5@^7.3.0:
   dependencies:
     entities "^6.0.0"
 
+parse5@^8.0.0, parse5@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.1.tgz#f43bcd2cd683efe084075333e9ce0da7d06da31e"
+  integrity sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==
+  dependencies:
+    entities "^8.0.0"
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -7925,6 +8131,13 @@ sax@>=0.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.0.tgz#da59637629307b97e7c4cb28e080a7bc38560d5b"
   integrity sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.2:
   version "0.23.2"
@@ -8659,6 +8872,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 table@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
@@ -8823,6 +9041,18 @@ tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.4"
 
+tldts-core@^7.4.3:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.4.3.tgz#d43401c0499cd884eeaf1ccf073df841a1e4e2dd"
+  integrity sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==
+
+tldts@^7.0.5:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.4.3.tgz#536c93aecffc96d41ce5627a4b7e12f9c2cfceb5"
+  integrity sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==
+  dependencies:
+    tldts-core "^7.4.3"
+
 tmp@^0.2.1, tmp@^0.2.3:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
@@ -8839,6 +9069,20 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tough-cookie@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
+  integrity sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==
+  dependencies:
+    tldts "^7.0.5"
+
+tr46@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-6.0.0.tgz#f5a1ae546a0adb32a277a2278d0d17fa2f9093e6"
+  integrity sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==
+  dependencies:
+    punycode "^2.3.1"
 
 traverse@0.6.8:
   version "0.6.8"
@@ -9033,10 +9277,20 @@ underscore@^1.12.1:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
+undici-types@^7.21.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.28.0.tgz#295c3e632e0c0bbfaf9ab66b6d573e97df39b9b3"
+  integrity sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==
+
 undici@^7.19.0:
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
   integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+
+undici@^7.25.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"
@@ -9188,6 +9442,13 @@ version-range@^4.15.0:
   resolved "https://registry.yarnpkg.com/version-range/-/version-range-4.15.0.tgz#89df1e921b14d37515aab5e42ed4ac0515cab2c1"
   integrity sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==
 
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
 walk-up-path@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-3.0.1.tgz#c8d78d5375b4966c717eb17ada73dbd41490e886"
@@ -9212,6 +9473,11 @@ web-worker@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
   integrity sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==
+
+webidl-conversions@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz#0657e571fe6f06fcb15ca50ed1fdbcb495cd1686"
+  integrity sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==
 
 webpack-cli@^5.1.4:
   version "5.1.4"
@@ -9346,6 +9612,20 @@ whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-mimetype@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz#d8232895dbd527ceaee74efd4162008fb8a8cf48"
+  integrity sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==
+
+whatwg-url@^16.0.0, whatwg-url@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-16.0.1.tgz#047f7f4bd36ef76b7198c172d1b1cebc66f764dd"
+  integrity sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==
+  dependencies:
+    "@exodus/bytes" "^1.11.0"
+    tr46 "^6.0.0"
+    webidl-conversions "^8.0.1"
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
@@ -9493,6 +9773,11 @@ wsl-utils@^0.1.0:
   dependencies:
     is-wsl "^3.1.0"
 
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
 xml2js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
@@ -9510,6 +9795,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Summary
- Replace the hand-written PR Clone description preview renderer with `markdown-it` (+ `markdown-it-task-lists`) so the preview matches GitHub's rendering: tables, images, nested/loose lists, bare-URL autolinks, strikethrough, task-list checkboxes, and the GitHub raw-HTML subset (`<details>`/`<summary>`, `<kbd>`, `<sub>`/`<sup>`, `<br>`).
- Sanitize the rendered HTML with **DOMPurify** (`src/webview/utils/sanitizeHtml.ts`) before `dangerouslySetInnerHTML`, preserving the previous XSS / `javascript:`-link protections while broadening the allowed element set.
- Rendering is **fully client-side in the webview — no local web server** (the look mirrors `gh-markdown-preview`, which only needs a server because it is a standalone CLI).
- Styling stays GitHub-layout but **themed with VS Code variables** (`MarkdownPreview/module.css`) so the preview blends with the editor; renderer-produced classes are matched via `:global(...)`.
- No CSP/manifest changes: the libs are inlined into the existing webview bundle; CSP already permits bundled CSS and https images.

## Test plan
- [x] Unit/integration tests pass (`yarn test` — 361 passing), including rewritten `renderMarkdown` tests (tables, raw HTML, images, nested lists, autolinks) and new jsdom-backed `sanitizeHtml` tests (script/`onerror`/`javascript:` stripped; tables/details/kbd/task-list checkboxes preserved)
- [x] `yarn build-webview` bundles successfully
- [ ] Manual smoke test in VS Code extension host: fetch a PR with a table, checklist, `<details>`, image, nested list and bare URL → toggle Preview → confirm GitHub-style rendering and that an `<img onerror>` / `<script>` / `javascript:` link payload does not execute