### PR TITLE
fix: PR clone missing PR error

### DIFF
--- a/src/common/api/ghClient.ts
+++ b/src/common/api/ghClient.ts
@@ -23,6 +23,40 @@ interface GitHubContentsResponse {
   encoding?: string;
 }
 
+interface GitHubApiErrorDetails {
+  endpoint: string;
+  method: string;
+  url: string;
+  statusCode?: number;
+  statusMessage?: string;
+  responseBody?: string;
+}
+
+export class GitHubApiError extends Error {
+  readonly endpoint: string;
+  readonly method: string;
+  readonly url: string;
+  readonly statusCode?: number;
+  readonly statusMessage?: string;
+  readonly responseBody?: string;
+
+  constructor(details: GitHubApiErrorDetails) {
+    const status = `${details.statusCode ?? 'Unknown status'} ${
+      details.statusMessage || 'Unknown error'
+    }`;
+    const response = details.responseBody ? `\nResponse: ${details.responseBody}` : '';
+    super(`GitHub API error: ${status}${response}`);
+    this.name = 'GitHubApiError';
+    this.endpoint = details.endpoint;
+    this.method = details.method;
+    this.url = details.url;
+    this.statusCode = details.statusCode;
+    this.statusMessage = details.statusMessage;
+    this.responseBody = details.responseBody;
+    Object.setPrototypeOf(this, GitHubApiError.prototype);
+  }
+}
+
 /**
  * Decode a GitHub "get repository content" response into UTF-8 text. Returns
  * undefined when the payload is not a base64-encoded file (e.g. a directory
@@ -145,9 +179,14 @@ export class GitHubClient {
             }
           } else {
             reject(
-              new Error(
-                `GitHub API error: ${res.statusCode} ${res.statusMessage || 'Unknown error'}\nResponse: ${data}`
-              )
+              new GitHubApiError({
+                endpoint,
+                method,
+                url,
+                statusCode: res.statusCode,
+                statusMessage: res.statusMessage,
+                responseBody: data,
+              })
             );
           }
         });

--- a/src/test/unit/fetchPRLoadingState.test.ts
+++ b/src/test/unit/fetchPRLoadingState.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert';
 
 import { WebviewCommand } from '../../types/webviewCommands';
-import { fetchPRLoadingReducer } from '../../webview/Apps/PR/App/fetchPRLoadingState';
+import {
+  FETCH_PR_LOADING_TIMEOUT,
+  fetchPRLoadingReducer,
+} from '../../webview/Apps/PR/App/fetchPRLoadingState';
 
 describe('fetchPRLoadingReducer', () => {
   it('starts loading when a PR fetch is submitted', () => {
@@ -18,6 +21,10 @@ describe('fetchPRLoadingReducer', () => {
 
   it('stops loading when the user cancels', () => {
     assert.strictEqual(fetchPRLoadingReducer(true, WebviewCommand.CANCEL_PR_CLONE), false);
+  });
+
+  it('stops loading when the PR fetch response times out', () => {
+    assert.strictEqual(fetchPRLoadingReducer(true, FETCH_PR_LOADING_TIMEOUT), false);
   });
 
   it('preserves loading state for unrelated messages', () => {

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -1,8 +1,12 @@
 import * as assert from 'assert';
 import { type Webview } from 'vscode';
 
+import { GitHubApiError } from '../../common/api/ghClient';
 import { WebviewCommand } from '../../types/webviewCommands';
-import { postFetchPRError } from '../../view/PrCloneWebViewProvider';
+import {
+  getFetchPRErrorNotification,
+  postFetchPRError,
+} from '../../view/PrCloneWebViewProvider';
 
 describe('postFetchPRError', () => {
   it('posts the fetch failure to the PR webview', async () => {
@@ -23,5 +27,63 @@ describe('postFetchPRError', () => {
         message: 'Error: PR not found',
       },
     ]);
+  });
+
+  it('can post the user-facing fetch failure message', async () => {
+    const messages: unknown[] = [];
+    const webview = {
+      postMessage: async (message: unknown) => {
+        messages.push(message);
+        return true;
+      },
+    } as Pick<Webview, 'postMessage'>;
+
+    await postFetchPRError(webview, new Error('raw details'), 'PR #404 does not exist.');
+
+    assert.deepStrictEqual(messages, [
+      {
+        command: WebviewCommand.FETCH_PR_ERROR,
+        message: 'PR #404 does not exist.',
+      },
+    ]);
+  });
+});
+
+describe('getFetchPRErrorNotification', () => {
+  const ghClient = { owner: 'owner', repo: 'repo' };
+
+  it('shows a clear message when the selected PR does not exist', () => {
+    const error = new GitHubApiError({
+      endpoint: '/repos/owner/repo/pulls/404',
+      method: 'GET',
+      url: 'https://api.github.com/repos/owner/repo/pulls/404',
+      statusCode: 404,
+      statusMessage: 'Not Found',
+      responseBody:
+        '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/pulls/pulls#get-a-pull-request","status":"404"}',
+    });
+
+    const notification = getFetchPRErrorNotification(404, ghClient, error);
+
+    assert.strictEqual(notification.message, 'PR #404 does not exist.');
+    assert.match(
+      notification.detail,
+      /GET https:\/\/api\.github\.com\/repos\/owner\/repo\/pulls\/404/
+    );
+    assert.match(notification.detail, /Status: 404 Not Found/);
+    assert.match(notification.detail, /"message":"Not Found"/);
+  });
+
+  it('uses a generic message for other fetch failures and preserves details', () => {
+    const error = new Error('network timeout');
+
+    const notification = getFetchPRErrorNotification(42, ghClient, error);
+
+    assert.strictEqual(notification.message, 'Something went wrong');
+    assert.match(
+      notification.detail,
+      /GET https:\/\/api\.github\.com\/repos\/owner\/repo\/pulls\/42/
+    );
+    assert.match(notification.detail, /network timeout/);
   });
 });

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -1,12 +1,47 @@
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 import { type Webview } from 'vscode';
 
-import { GitHubApiError } from '../../common/api/ghClient';
+import { GitHubApiError, GitHubClient } from '../../common/api/ghClient';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { PrCloneService } from '../../services/prCloneService';
+import { GitHubPR } from '../../types/dataTypes';
 import { WebviewCommand } from '../../types/webviewCommands';
 import {
   getFetchPRErrorNotification,
   postFetchPRError,
+  PrCloneWebViewProvider,
 } from '../../view/PrCloneWebViewProvider';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function createPullRequest(number = 404): GitHubPR {
+  return {
+    number,
+    title: 'Example PR',
+    body: 'Body',
+    head: {
+      ref: 'feature/example',
+      sha: 'abc123',
+    },
+    base: {
+      ref: 'main',
+    },
+    html_url: `https://github.com/owner/repo/pull/${number}`,
+    labels: [],
+    assignees: [],
+  };
+}
+
+function createPrCloneService(
+  ghClient: GitHubClient,
+  git: Record<string, unknown> = {}
+): PrCloneService {
+  return {
+    onDidChangeRepository: () => ({ dispose: () => {} }),
+    git,
+    ghClient,
+  } as unknown as PrCloneService;
+}
 
 describe('postFetchPRError', () => {
   it('posts the fetch failure to the PR webview', async () => {
@@ -66,6 +101,7 @@ describe('getFetchPRErrorNotification', () => {
     const notification = getFetchPRErrorNotification(404, ghClient, error);
 
     assert.strictEqual(notification.message, 'PR #404 does not exist.');
+    assert.match(notification.detail, /^Exact error:\nGitHub API error: 404 Not Found/m);
     assert.match(
       notification.detail,
       /GET https:\/\/api\.github\.com\/repos\/owner\/repo\/pulls\/404/
@@ -80,10 +116,126 @@ describe('getFetchPRErrorNotification', () => {
     const notification = getFetchPRErrorNotification(42, ghClient, error);
 
     assert.strictEqual(notification.message, 'Something went wrong');
+    assert.match(notification.detail, /^Exact error:\nnetwork timeout/m);
     assert.match(
       notification.detail,
       /GET https:\/\/api\.github\.com\/repos\/owner\/repo\/pulls\/42/
     );
     assert.match(notification.detail, /network timeout/);
+  });
+});
+
+describe('PrCloneWebViewProvider fetch error handling', () => {
+  it('shows fetch failures as floating notifications with expandable details', async () => {
+    const messages: unknown[] = [];
+    const showErrorCalls: unknown[][] = [];
+    const originalShowErrorMessage = vscode.window.showErrorMessage.bind(vscode.window);
+    (vscode.window as any).showErrorMessage = async (...args: unknown[]) => {
+      showErrorCalls.push(args);
+      return 'OK';
+    };
+
+    const ghClient = new GitHubClient('owner', 'repo');
+    ghClient.fetchPullRequest = async () => {
+      throw new GitHubApiError({
+        endpoint: '/repos/owner/repo/pulls/404',
+        method: 'GET',
+        url: 'https://api.github.com/repos/owner/repo/pulls/404',
+        statusCode: 404,
+        statusMessage: 'Not Found',
+        responseBody: '{"message":"Not Found","status":"404"}',
+      });
+    };
+
+    const provider = new PrCloneWebViewProvider(
+      {} as vscode.ExtensionContext,
+      mockLogService,
+      {} as ConfigurationManager,
+      createPrCloneService(ghClient)
+    );
+    (provider as any).webviewView = {
+      webview: {
+        postMessage: async (message: unknown) => {
+          messages.push(message);
+          return true;
+        },
+      },
+    };
+
+    try {
+      await (provider as any).handleFetchPR('404');
+
+      assert.deepStrictEqual(messages, [
+        {
+          command: WebviewCommand.FETCH_PR_ERROR,
+          message: 'PR #404 does not exist.',
+        },
+      ]);
+      assert.strictEqual(showErrorCalls.length, 1);
+      assert.strictEqual(showErrorCalls[0][0], 'PR #404 does not exist.');
+      assert.deepStrictEqual(showErrorCalls[0][2], 'OK');
+
+      const options = showErrorCalls[0][1] as { modal?: boolean; detail?: string };
+      assert.strictEqual(options.modal, undefined);
+      assert.match(options.detail ?? '', /^Exact error:\nGitHub API error: 404 Not Found/m);
+      assert.match(options.detail ?? '', /"message":"Not Found"/);
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    }
+  });
+
+  it('posts FETCH_PR_ERROR when invalid default branch prevents showing fetched PR data', async () => {
+    const messages: unknown[] = [];
+    const errors: string[] = [];
+    const originalShowErrorMessage = vscode.window.showErrorMessage.bind(vscode.window);
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      errors.push(message);
+      return 'OK';
+    };
+
+    const ghClient = new GitHubClient('owner', 'repo');
+    ghClient.fetchPullRequest = async () => createPullRequest(42);
+    ghClient.fetchPullRequestCommits = async () => [];
+    ghClient.fetchCommitsDetails = async () => [];
+    ghClient.fetchPullRequestTemplate = async () => undefined;
+
+    const provider = new PrCloneWebViewProvider(
+      {} as vscode.ExtensionContext,
+      mockLogService,
+      {
+        get: () => ({
+          defaultTargetBranch: 'release/missing',
+          prBranchPrefix: '',
+        }),
+      } as unknown as ConfigurationManager,
+      createPrCloneService(ghClient, {
+        fetchSpecificBranch: async () => {},
+        getAllRefListExtended: async () => [{ name: 'main', remote: false, isTag: false }],
+      })
+    );
+    (provider as any).webviewView = {
+      webview: {
+        postMessage: async (message: unknown) => {
+          messages.push(message);
+          return true;
+        },
+      },
+    };
+
+    try {
+      await (provider as any).handleFetchPR('42');
+
+      const errorMessage =
+        "Default target branch 'release/missing' does not exist in your repository. Please update the extension settings.";
+      assert.deepStrictEqual(errors, [errorMessage]);
+      assert.deepStrictEqual(messages, [
+        {
+          command: WebviewCommand.FETCH_PR_ERROR,
+          message: errorMessage,
+        },
+      ]);
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    }
   });
 });

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -11,7 +11,7 @@ import {
   window,
 } from 'vscode';
 
-import { GitHubClient } from '../common/api/ghClient';
+import { GitHubApiError, GitHubClient } from '../common/api/ghClient';
 import { GitExecutor } from '../common/git/gitExecutor';
 import { ConfigurationManager } from '../configuration/configurationManager';
 import { EXTENSION_NAME } from '../const';
@@ -36,12 +36,84 @@ import {
 
 export function postFetchPRError(
   webview: Pick<Webview, 'postMessage'> | undefined,
-  error: unknown
+  error: unknown,
+  message = String(error)
 ): Thenable<boolean> | undefined {
   return webview?.postMessage({
     command: WebviewCommand.FETCH_PR_ERROR,
-    message: String(error),
+    message,
   });
+}
+
+interface FetchPRErrorNotification {
+  message: string;
+  detail: string;
+}
+
+function formatErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+
+  return String(error);
+}
+
+function getFetchPRRequestLine(
+  prNumber: number,
+  ghClient: Pick<GitHubClient, 'owner' | 'repo'>,
+  error: unknown
+): string {
+  if (error instanceof GitHubApiError) {
+    return `${error.method} ${error.url}`;
+  }
+
+  return `GET https://api.github.com/repos/${ghClient.owner}/${ghClient.repo}/pulls/${prNumber}`;
+}
+
+function isMissingPullRequestError(
+  prNumber: number,
+  ghClient: Pick<GitHubClient, 'owner' | 'repo'>,
+  error: unknown
+): boolean {
+  return (
+    error instanceof GitHubApiError &&
+    error.statusCode === 404 &&
+    error.method === 'GET' &&
+    error.endpoint === `/repos/${ghClient.owner}/${ghClient.repo}/pulls/${prNumber}`
+  );
+}
+
+export function getFetchPRErrorNotification(
+  prNumber: number,
+  ghClient: Pick<GitHubClient, 'owner' | 'repo'>,
+  error: unknown
+): FetchPRErrorNotification {
+  const message = isMissingPullRequestError(prNumber, ghClient, error)
+    ? `PR #${prNumber} does not exist.`
+    : 'Something went wrong';
+  const detailLines = [
+    `Failed while fetching PR #${prNumber}.`,
+    '',
+    'Failed request:',
+    getFetchPRRequestLine(prNumber, ghClient, error),
+  ];
+
+  if (error instanceof GitHubApiError) {
+    detailLines.push(
+      `Status: ${error.statusCode ?? 'Unknown'} ${error.statusMessage || 'Unknown error'}`
+    );
+
+    if (error.responseBody) {
+      detailLines.push('', 'Response:', error.responseBody);
+    }
+  }
+
+  detailLines.push('', 'Error details:', formatErrorDetail(error));
+
+  return {
+    message,
+    detail: detailLines.join('\n'),
+  };
 }
 
 export class PrCloneWebViewProvider implements WebviewViewProvider {
@@ -222,9 +294,15 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       this.updateWebviewWithPRData(prData, detailedCommits, branches, prTemplate);
     } catch (error) {
       this.loggingService.error(`Failed to fetch PR: ${error}`);
-      await postFetchPRError(this.webviewView?.webview, error);
+      const notification = getFetchPRErrorNotification(
+        parsePRInput(prInput)?.prNumber ?? Number.NaN,
+        this.prCloneService.ghClient,
+        error
+      );
+      await postFetchPRError(this.webviewView?.webview, error, notification.message);
       await window.showErrorMessage(
-        `Failed to fetch PR: ${error instanceof Error ? error.message : error}`,
+        notification.message,
+        { modal: true, detail: notification.detail },
         'OK'
       );
     }

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -50,9 +50,9 @@ interface FetchPRErrorNotification {
   detail: string;
 }
 
-function formatErrorDetail(error: unknown): string {
+function formatExactError(error: unknown): string {
   if (error instanceof Error) {
-    return error.stack || error.message;
+    return error.message;
   }
 
   return String(error);
@@ -92,7 +92,8 @@ export function getFetchPRErrorNotification(
     ? `PR #${prNumber} does not exist.`
     : 'Something went wrong';
   const detailLines = [
-    `Failed while fetching PR #${prNumber}.`,
+    'Exact error:',
+    formatExactError(error),
     '',
     'Failed request:',
     getFetchPRRequestLine(prNumber, ghClient, error),
@@ -107,8 +108,6 @@ export function getFetchPRErrorNotification(
       detailLines.push('', 'Response:', error.responseBody);
     }
   }
-
-  detailLines.push('', 'Error details:', formatErrorDetail(error));
 
   return {
     message,
@@ -291,7 +290,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
         this.loggingService.warn(`Failed to fetch PR template: ${templateError}`);
       }
 
-      this.updateWebviewWithPRData(prData, detailedCommits, branches, prTemplate);
+      await this.updateWebviewWithPRData(prData, detailedCommits, branches, prTemplate);
     } catch (error) {
       this.loggingService.error(`Failed to fetch PR: ${error}`);
       const notification = getFetchPRErrorNotification(
@@ -302,7 +301,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       await postFetchPRError(this.webviewView?.webview, error, notification.message);
       await window.showErrorMessage(
         notification.message,
-        { modal: true, detail: notification.detail },
+        { detail: notification.detail },
         'OK'
       );
     }
@@ -331,12 +330,12 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
     }
   }
 
-  private updateWebviewWithPRData(
+  private async updateWebviewWithPRData(
     prData: GitHubPR,
     commits: GitHubCommit[],
     branches: string[],
     prTemplate?: string
-  ) {
+  ): Promise<void> {
     this.currentCommits = commits;
 
     if (!this.webviewView) {
@@ -354,7 +353,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       defaultTargetBranch.trim() &&
       !branches.includes(defaultTargetBranch)
     ) {
-      this.handleInvalidDefaultBranch(defaultTargetBranch);
+      await this.handleInvalidDefaultBranch(defaultTargetBranch);
       return;
     }
 
@@ -480,6 +479,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   private async handleInvalidDefaultBranch(defaultTargetBranch: string) {
     const errorMessage = `Default target branch '${defaultTargetBranch}' does not exist in your repository. Please update the extension settings.`;
     this.loggingService.error(errorMessage);
+    await postFetchPRError(this.webviewView?.webview, errorMessage);
 
     // Hide the activity bar and webviews
     await setContextShowPRClone(false);

--- a/src/webview/Apps/PR/App/fetchPRLoadingState.ts
+++ b/src/webview/Apps/PR/App/fetchPRLoadingState.ts
@@ -1,12 +1,20 @@
 import { WebviewCommand } from '../../../types/commands';
 
-export function fetchPRLoadingReducer(isLoading: boolean, command: WebviewCommand): boolean {
-  switch (command) {
+export const FETCH_PR_LOADING_TIMEOUT = 'fetchPRLoadingTimeout';
+
+export type FetchPRLoadingAction = WebviewCommand | typeof FETCH_PR_LOADING_TIMEOUT;
+
+export function fetchPRLoadingReducer(
+  isLoading: boolean,
+  action: FetchPRLoadingAction
+): boolean {
+  switch (action) {
     case WebviewCommand.FETCH_PR:
       return true;
     case WebviewCommand.SHOW_PR_DATA:
     case WebviewCommand.FETCH_PR_ERROR:
     case WebviewCommand.CANCEL_PR_CLONE:
+    case FETCH_PR_LOADING_TIMEOUT:
       return false;
     default:
       return isLoading;

--- a/src/webview/Apps/PR/App/index.tsx
+++ b/src/webview/Apps/PR/App/index.tsx
@@ -11,12 +11,19 @@ import {
   writeWebviewState,
 } from '../../../../common/vscode/webviewState';
 
-import { fetchPRLoadingReducer } from './fetchPRLoadingState';
+import {
+  FETCH_PR_LOADING_TIMEOUT,
+  FetchPRLoadingAction,
+  fetchPRLoadingReducer,
+} from './fetchPRLoadingState';
+
+const FETCH_PR_RESPONSE_TIMEOUT_MS = 30_000;
 
 export const App: React.FC = () => {
   const logger = useLogger(false);
   const sendMessage = useSendMessage();
   const vscode = getVsCodeApi<AppState>();
+  const fetchPRTimeoutRef = React.useRef<number | undefined>(undefined);
 
   const [isFetchingPR, updateFetchPRLoading] = React.useReducer(
     fetchPRLoadingReducer,
@@ -39,6 +46,27 @@ export const App: React.FC = () => {
     owner: 'owner'
   });
 
+  const clearFetchPRTimeout = React.useCallback(() => {
+    if (fetchPRTimeoutRef.current !== undefined) {
+      window.clearTimeout(fetchPRTimeoutRef.current);
+      fetchPRTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const updateFetchPRState = React.useCallback(
+    (action: FetchPRLoadingAction) => {
+      if (action !== WebviewCommand.FETCH_PR) {
+        clearFetchPRTimeout();
+      }
+      updateFetchPRLoading(action);
+    },
+    [clearFetchPRTimeout]
+  );
+
+  useEffect(() => {
+    return clearFetchPRTimeout;
+  }, [clearFetchPRTimeout]);
+
   useEffect(() => {
     try {
       writeWebviewState(vscode, state);
@@ -48,8 +76,20 @@ export const App: React.FC = () => {
   }, [state, vscode, logger]);
 
   const handleFetchPR = (prInput: string) => {
+    clearFetchPRTimeout();
     updateFetchPRLoading(WebviewCommand.FETCH_PR);
-    sendMessage(WebviewCommand.FETCH_PR, { prInput });
+
+    try {
+      sendMessage(WebviewCommand.FETCH_PR, { prInput });
+      fetchPRTimeoutRef.current = window.setTimeout(() => {
+        logger.warn('Timed out waiting for PR fetch response');
+        fetchPRTimeoutRef.current = undefined;
+        updateFetchPRLoading(FETCH_PR_LOADING_TIMEOUT);
+      }, FETCH_PR_RESPONSE_TIMEOUT_MS);
+    } catch (error) {
+      logger.error(`Failed to request PR data: ${error}`);
+      updateFetchPRLoading(WebviewCommand.FETCH_PR_ERROR);
+    }
   };
 
   const handleClonePR = (data: any) => {
@@ -58,16 +98,16 @@ export const App: React.FC = () => {
   };
 
   const handleCancel = () => {
-    updateFetchPRLoading(WebviewCommand.CANCEL_PR_CLONE);
+    updateFetchPRState(WebviewCommand.CANCEL_PR_CLONE);
     // Send message to VS Code extension to close activity bar and hide webview
     sendMessage(WebviewCommand.CANCEL_PR_CLONE);
   };
 
-  const handleStartOver = () => {
+  const handleStartOver = React.useCallback(() => {
     logger.info('Starting over ...');
     const newState: AppState = { view: 'input', isCloning: false };
     setState(newState);
-  };
+  }, [logger]);
 
   // Handle messages from VS Code extension
   React.useEffect(() => {
@@ -77,7 +117,7 @@ export const App: React.FC = () => {
 
       switch (true) {
         case message.command === WebviewCommand.SHOW_PR_DATA:
-          updateFetchPRLoading(WebviewCommand.SHOW_PR_DATA);
+          updateFetchPRState(WebviewCommand.SHOW_PR_DATA);
           // Show notification about the fetched PR
           const prData = message.prData;
           
@@ -103,7 +143,7 @@ export const App: React.FC = () => {
           });
           break;
         case message.command === WebviewCommand.FETCH_PR_ERROR:
-          updateFetchPRLoading(WebviewCommand.FETCH_PR_ERROR);
+          updateFetchPRState(WebviewCommand.FETCH_PR_ERROR);
           break;
         case message.command === WebviewCommand.TARGET_BRANCH_SELECTED:
           setState(prev => ({
@@ -139,7 +179,7 @@ export const App: React.FC = () => {
 
       return () => window.removeEventListener('message', handleMessage);
     }
-  }, []);
+  }, [handleStartOver, logger, sendMessage, updateFetchPRState]);
 
   if (state.view === 'clone' && state.prData && state.commits && state.branches) {
     return (


### PR DESCRIPTION
## Summary
- Show "PR #n does not exist." when GitHub returns 404 for the selected PR
- Preserve failed request details, status, response body, and error details in the expandable error dialog
- Use "Something went wrong" for other fetch failures while keeping diagnostic details available

## Test plan
- [x] Unit/integration tests pass (`yarn test`)
- [x] Manual smoke test performed in VS Code extension host