### PR TITLE
fix(pr-clone): unlock Fetch PR Data button without waiting for error dismissal

### DIFF
--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -233,7 +233,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       const parsedInput = parsePRInput(prInput);
       if (!parsedInput) {
         await postFetchPRError(this.webviewView?.webview, INVALID_PR_INPUT_MESSAGE);
-        await window.showErrorMessage(INVALID_PR_INPUT_MESSAGE, 'OK');
+        void window.showErrorMessage(INVALID_PR_INPUT_MESSAGE, 'OK');
         return;
       }
 
@@ -243,7 +243,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       });
       if (repositoryMismatchMessage) {
         await postFetchPRError(this.webviewView?.webview, repositoryMismatchMessage);
-        await window.showErrorMessage(repositoryMismatchMessage, 'OK');
+        void window.showErrorMessage(repositoryMismatchMessage, 'OK');
         return;
       }
 
@@ -299,7 +299,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
         error
       );
       await postFetchPRError(this.webviewView?.webview, error, notification.message);
-      await window.showErrorMessage(
+      void window.showErrorMessage(
         notification.message,
         { detail: notification.detail },
         'OK'


### PR DESCRIPTION
## Summary

- `await showErrorMessage(...)` was suspending the extension host until the user clicked OK, preventing VS Code from flushing the queued `FETCH_PR_ERROR` webview message
- The button stayed locked while the notification was visible; it only unlocked after the user dismissed the notification
- Replaced `await` with `void` on all three `showErrorMessage` calls in `handleFetchPR` — the catch block now exits immediately after `postFetchPRError`, so VS Code can deliver the webview message before the user interacts with the notification
- `handleInvalidDefaultBranch` is unchanged — it still awaits to detect the "Open Settings" click

## Root cause

VS Code's `webview.postMessage` resolves when the IPC message is *queued*, not when the webview JS has *processed* it. While the extension was suspended waiting for the user to click OK, the pending `FETCH_PR_ERROR` message was not flushed to the webview. Switching to fire-and-forget lets the extension host exit the catch block immediately, unblocking message delivery.

## Test plan

- [x] All 357 unit/integration tests pass (`yarn test`)
- [ ] Manual smoke: fetch a non-existent PR number — button should unlock as soon as the error notification appears, before clicking OK