### PR TITLE
feat(website): actualize features, roadmap, and add dynamic version badge

### DIFF
--- a/website/src/components/Features/Features.tsx
+++ b/website/src/components/Features/Features.tsx
@@ -58,10 +58,19 @@ const features: Feature[] = [
     color: 'purple',
   },
   {
+    icon: '⭐',
+    title: 'Preferred Branches',
+    description:
+      'Star the branches, tags, and remotes you use most — they float to the top of the checkout picker, marked with a star. Toggle a star straight from the picker, no settings file to edit.',
+    command: 'Git Smart Checkout: Checkout to... (With Stash)',
+    tag: 'New',
+    color: 'blue',
+  },
+  {
     icon: '🍒',
     title: 'GitHub PR Clone',
     description:
-      'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR.',
+      'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
     command: 'Git Smart Checkout: Clone pull request...',
     tag: 'Beta',
     color: 'orange',
@@ -88,7 +97,6 @@ const features: Feature[] = [
     description:
       'Open a new integrated terminal straight in any worktree directory. Pick a project, choose the worktree, and get a shell in the right working directory — no manual navigation.',
     command: 'Git Smart Checkout: Open Worktree Dev Terminal...',
-    tag: 'New',
     color: 'blue',
   },
   {
@@ -105,14 +113,13 @@ const features: Feature[] = [
     description:
       'Create and check out a branch from a reusable template. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
     command: 'Git Smart Checkout: Create Branch from Template...',
-    tag: 'New',
     color: 'green',
   },
   {
     icon: '🌲',
     title: 'Worktree Workflows',
     description:
-      'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove worktrees safely.',
+      'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
     command: 'Git Smart Checkout: Move to new worktree',
     color: 'green',
   },
@@ -124,10 +131,20 @@ const features: Feature[] = [
     color: 'green',
   },
   {
+    icon: '📋',
+    title: 'Auto-Stash Manager',
+    description:
+      'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
+    command: 'Git Smart Checkout: Manage auto-stashes...',
+    tag: 'New',
+    color: 'green',
+  },
+  {
     icon: '📊',
     title: 'Status Bar Integration',
     description:
-      'See your current stash mode at a glance in the VS Code status bar. Click once to switch modes — no need to open settings.',
+      "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",
+    command: 'Git Smart Checkout: Quick Actions',
     color: 'purple',
   },
 ];

--- a/website/src/components/Hero/Hero.module.css
+++ b/website/src/components/Hero/Hero.module.css
@@ -14,6 +14,14 @@
   gap: 28px;
 }
 
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;

--- a/website/src/components/Hero/Hero.tsx
+++ b/website/src/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import { DownloadStats } from '../DownloadStats/DownloadStats';
+import { VersionBadge } from '../VersionBadge/VersionBadge';
 import { getCommandPaletteShortcut } from '../../utils/shortcuts';
 import styles from './Hero.module.css';
 
@@ -19,9 +20,12 @@ export function Hero() {
   return (
     <section className={styles.hero}>
       <div className={`container ${styles.inner}`}>
-        <div className={styles.badge}>
-          <span className={styles.badgeDot} />
-          Free & Open Source
+        <div className={styles.badgeRow}>
+          <div className={styles.badge}>
+            <span className={styles.badgeDot} />
+            Free & Open Source
+          </div>
+          <VersionBadge />
         </div>
 
         <h1 className={styles.title}>

--- a/website/src/components/PlannedFeatures/PlannedFeatures.tsx
+++ b/website/src/components/PlannedFeatures/PlannedFeatures.tsx
@@ -10,25 +10,11 @@ interface PlannedFeature {
 
 const planned: PlannedFeature[] = [
   {
-    icon: '⭐',
-    tier: 1,
-    title: 'Preferred Branches',
-    description:
-      'Star your most-used branches and see them at the top of the checkout picker — separated from the full branch list.',
-  },
-  {
     icon: '🕒',
     tier: 1,
     title: 'Recent Branches',
     description:
       'Automatically surface the last 5–10 branches you visited using reflog data, so your most relevant branches are always first.',
-  },
-  {
-    icon: '📋',
-    tier: 1,
-    title: 'Stash Manager',
-    description:
-      'A dedicated side panel listing all auto-created stashes with branch, age, file count, diff preview, and one-click Apply / Pop / Drop actions.',
   },
   {
     icon: '⚡',

--- a/website/src/components/VersionBadge/VersionBadge.module.css
+++ b/website/src/components/VersionBadge/VersionBadge.module.css
@@ -1,0 +1,21 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s, background-color 0.15s;
+}
+
+.badge:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+}

--- a/website/src/components/VersionBadge/VersionBadge.tsx
+++ b/website/src/components/VersionBadge/VersionBadge.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import styles from './VersionBadge.module.css';
+
+const EXTENSION_ID = 'vradchuk.git-smart-checkout';
+const [PUBLISHER, EXT_NAME] = EXTENSION_ID.split('.');
+
+const MARKETPLACE_URL = `https://marketplace.visualstudio.com/items?itemName=${EXTENSION_ID}`;
+
+async function fetchMsVersion(): Promise<string> {
+  const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json;api-version=3.0-preview.1',
+    },
+    body: JSON.stringify({
+      filters: [{ criteria: [{ filterType: 7, value: EXTENSION_ID }] }],
+      flags: 950,
+    }),
+  });
+  if (!response.ok) throw new Error(`MS API ${response.status}`);
+  const data = await response.json();
+  const version: string | undefined = data.results[0].extensions[0].versions[0].version;
+  if (!version) throw new Error('MS API: no version');
+  return version;
+}
+
+async function fetchOvsxVersion(): Promise<string> {
+  const response = await fetch(`https://open-vsx.org/api/${PUBLISHER}/${EXT_NAME}`);
+  if (!response.ok) throw new Error(`Open VSX API ${response.status}`);
+  const data = await response.json();
+  if (!data || data.error || !data.version) throw new Error('Open VSX API: no version');
+  return data.version;
+}
+
+export function VersionBadge() {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchMsVersion()
+      .catch(() => fetchOvsxVersion())
+      .then((v) => {
+        if (!cancelled) setVersion(v);
+      })
+      .catch(() => {
+        // Both sources failed — render nothing rather than a broken value.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!version) return null;
+
+  return (
+    <a
+      href={MARKETPLACE_URL}
+      className={styles.badge}
+      target="_blank"
+      rel="noreferrer"
+      title="Latest published version on the VS Code Marketplace"
+    >
+      v{version}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

The marketing site's feature/roadmap content was last updated on **2026-05-31** (#68). Since then the extension shipped **0.8.0 → 0.12.0**, and two items still shown on the roadmap as *planned* were actually implemented. This aligns the site with reality.

- **Features grid** — promoted **Preferred Branches** (star refs in the checkout picker, #68) and **Auto-Stash Manager** (`Manage auto-stashes...`, #107) from the roadmap into real feature cards.
- Refreshed descriptions: **Status Bar Integration** now covers the quick-actions menu (`Quick Actions`, #108/#114); **Worktree Workflows** mentions removing several worktrees at once (#110); **GitHub PR Clone** notes the GFM markdown preview + PR-template prefill (#109/#115). Moved stale `New` tags off the older Worktree Dev Terminal / Branch from Template cards onto the genuinely new cards.
- **Roadmap** — removed the now-shipped Stash Manager and Preferred Branches entries. Recent Branches, Inline Branch Actions, Upstream Indicator (verified *not* implemented) and the Tier-2 items remain.
- **Dynamic version badge** — new `VersionBadge` component fetches the latest **published** version at runtime (MS Marketplace primary, Open VSX fallback; renders nothing on failure) and shows a `v{version}` pill in the Hero. Avoids hardcoding — the Marketplace is already at 0.12.0 while repo `package.json` says 0.11.0.

## Test plan

- [x] `cd website && yarn build` — TypeScript type-check + Vite bundle pass clean
- [x] Manual smoke test of the deployed page: Features grid shows the two new cards, roadmap no longer lists them, Hero shows a live `vX.Y.Z` badge from the network (and renders nothing if the API calls fail)