### PR TITLE
fix(quick-actions): add Create Branch/Tag from Template commands

### DIFF
--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -61,6 +61,8 @@ export function buildQuickActionItems(
     { label: '$(arrow-swap) Checkout to…', commandId: command('checkoutTo') },
     { label: '$(history) Checkout previous branch', commandId: command('checkoutPrevious') },
     { label: '$(git-pull-request) Checkout by PR number…', commandId: command('checkoutByPR') },
+    { label: '$(git-branch) Create branch from template…', commandId: command('createBranchFromTemplate') },
+    { label: '$(tag) Create tag from template…', commandId: command('createTagFromTemplate') },
     { label: 'Update branch', kind: QuickPickItemKind.Separator },
     { label: '$(repo-pull) Pull (With Stash)', commandId: command('pullWithStash') },
     { label: '$(repo-pull) Pull (Rebase With Stash)', commandId: command('pullRebaseWithStash') },

--- a/src/test/unit/quickActions.test.ts
+++ b/src/test/unit/quickActions.test.ts
@@ -43,6 +43,8 @@ const ALWAYS_VISIBLE_COMMANDS = [
   'checkoutTo',
   'checkoutPrevious',
   'checkoutByPR',
+  'createBranchFromTemplate',
+  'createTagFromTemplate',
   'pullWithStash',
   'pullRebaseWithStash',
   'rebaseWithStash',


### PR DESCRIPTION
## Summary
- Added **Create branch from template…** and **Create tag from template…** to the quick actions panel (status bar menu), in the Checkout section after "Checkout by PR number…"
- Both commands already existed (`createBranchFromTemplate`, `createTagFromTemplate`) — this surfaces them in the quick pick for faster access
- Updated `ALWAYS_VISIBLE_COMMANDS` in the unit test to cover the two new entries

## Test plan
- [x] Unit/integration tests pass (`yarn test` — 367 passing)
- [ ] Manual smoke test: click the GSC status bar item and confirm both template commands appear in the Checkout section