### PR TITLE
fix(pr-clone): fetch PR head via pull/<n>/head so fork PRs clone correctly

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -289,6 +289,19 @@ export class GitExecutor {
     await this.#execGitCommand(['fetch', remoteUrl, `${headRef}:${headRef}`]);
   }
 
+  async fetchPullRequestHead(prNumber: number, remoteName = 'origin'): Promise<void> {
+    await this.#execGitCommand(['fetch', remoteName, `pull/${prNumber}/head`]);
+  }
+
+  async commitExists(sha: string): Promise<boolean> {
+    try {
+      await this.#execGitCommand(['cat-file', '-e', `${sha}^{commit}`]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async pullCurrentBranch() {
     await this.#execGitCommand(['pull']);
   }

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -249,13 +249,13 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
         }
       }
 
-      // Step 2: Fetch the PR's origin branch
-      updateProgress.report({ message: `Fetching PR branch: ${data.prData.head.ref}...` });
+      // Step 2: Fetch the PR's commits (works for same-repo and fork PRs alike)
+      updateProgress.report({ message: `Fetching PR #${data.prData.number} commits...` });
       try {
-        await this.git.fetchSpecificBranch(data.prData.head.ref);
-        this.loggingService.info(`Fetched PR branch: ${data.prData.head.ref}`);
+        await this.git.fetchPullRequestHead(data.prData.number);
+        this.loggingService.info(`Fetched PR #${data.prData.number} commits`);
       } catch (fetchError) {
-        this.loggingService.warn(`Failed to fetch PR branch: ${fetchError}`);
+        throw new Error(`Could not fetch the PR's commits from GitHub: ${fetchError}`);
       }
 
       // Step 3: Switch to base branch and pull latest changes
@@ -287,6 +287,13 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       this.loggingService.info(
         `Created and switched to feature branch: ${this.serviceStore.createdBranchName}`
       );
+
+      // Preflight: ensure every selected commit is actually available locally
+      for (const sha of data.selectedCommits) {
+        if (!(await this.git.commitExists(sha))) {
+          throw new Error(`Commit ${sha} is not available locally`);
+        }
+      }
 
       // create commits generator
       this.commitGenerator = new CommitsGenerator(data.selectedCommits)[Symbol.asyncIterator]();

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -72,9 +72,9 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
 
             throwIfCancellationRequested(token);
 
-            // Step 2: Pull all branches
-            progress.report({ message: 'Fetching latest branches...' });
-            await this.fetchAllBranches();
+            // Step 2: Fetch the target branch and the PR's commits (works for forks too)
+            progress.report({ message: `Fetching PR #${data.prData.number} commits...` });
+            await this.fetchAllBranches(data.prData.number);
 
             throwIfCancellationRequested(token);
 
@@ -193,12 +193,18 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     return tempPath;
   }
 
-  private async fetchAllBranches(): Promise<void> {
+  private async fetchAllBranches(prNumber: number): Promise<void> {
     if (!this.tempGit) {
       throw new Error('Temporary git workspace not initialized');
     }
 
     await this.tempGit.fetchAllRemoteBranchesAndTags();
+
+    try {
+      await this.tempGit.fetchPullRequestHead(prNumber);
+    } catch (fetchError) {
+      throw new Error(`Could not fetch the PR's commits from GitHub: ${fetchError}`);
+    }
   }
 
   private async createUniqueFeatureBranch(
@@ -242,6 +248,12 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     this.loggingService.info('Cherry-picking commits in GitHub API order:', orderedCommits);
 
     throwIfCancellationRequested(token);
+
+    for (const sha of orderedCommits) {
+      if (!(await this.tempGit.commitExists(sha))) {
+        throw new Error(`Commit ${sha} is not available locally`);
+      }
+    }
 
     try {
       await this.tempGit.cherryPick(orderedCommits, false, 'skip');

--- a/src/test/unit/commitOrder.test.ts
+++ b/src/test/unit/commitOrder.test.ts
@@ -48,10 +48,11 @@ describe('PR commit ordering', () => {
       cherryPickCommits(commitShas: string[], token: CancellationToken): Promise<void>;
     };
     testableService.tempGit = {
+      commitExists: async () => true,
       cherryPick: async (commits: string | string[]) => {
         cherryPicks.push(commits);
       },
-    } as GitExecutor;
+    } as unknown as GitExecutor;
 
     await testableService.cherryPickCommits(
       ['parent', 'middle', 'child'],

--- a/src/test/unit/forkPrClone.test.ts
+++ b/src/test/unit/forkPrClone.test.ts
@@ -1,0 +1,195 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { GitHubClient } from '../../common/api/ghClient';
+import { LoggingService } from '../../logging/loggingService';
+import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
+import { PrCloneTempWorktreeService } from '../../services/prCloneTempWorktreeService';
+import { PrCloneData } from '../../services/prCloneService';
+import { GitHubPR } from '../../types/dataTypes';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function makeFakeGitBin(script: string[]): { fakeBin: string; gitLog: string } {
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-fake-git-'));
+  const gitLog = path.join(fakeBin, 'commands.log');
+  const gitPath = path.join(fakeBin, 'git');
+  fs.writeFileSync(gitPath, ['#!/bin/sh', ...script, ''].join('\n'), { mode: 0o755 });
+  return { fakeBin, gitLog };
+}
+
+describe('GitExecutor fork-PR helpers', () => {
+  it('fetchPullRequestHead fetches the synthetic pull/<n>/head ref from origin', async () => {
+    const { fakeBin, gitLog } = makeFakeGitBin([
+      'printf "%s\\n" "$*" >> "$GSC_GIT_TEST_LOG"',
+      'exit 0',
+    ]);
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_GIT_TEST_LOG;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_GIT_TEST_LOG = gitLog;
+
+    try {
+      const git = new GitExecutor(fakeBin, mockLogService as unknown as LoggingService);
+      await git.fetchPullRequestHead(42);
+
+      assert.deepStrictEqual(
+        fs.readFileSync(gitLog, 'utf8').trim().split('\n'),
+        ['fetch origin pull/42/head']
+      );
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) {
+        delete process.env.GSC_GIT_TEST_LOG;
+      } else {
+        process.env.GSC_GIT_TEST_LOG = oldLog;
+      }
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('commitExists reports true/false based on cat-file exit status', async () => {
+    const { fakeBin } = makeFakeGitBin([
+      'if [ "$1" = "cat-file" ] && [ "$3" = "present^{commit}" ]; then',
+      '  exit 0',
+      'fi',
+      'exit 1',
+    ]);
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ''}`;
+
+    try {
+      const git = new GitExecutor(fakeBin, mockLogService as unknown as LoggingService);
+      assert.strictEqual(await git.commitExists('present'), true);
+      assert.strictEqual(await git.commitExists('missing'), false);
+    } finally {
+      process.env.PATH = oldPath;
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+});
+
+const prData = {
+  number: 71,
+  title: 'Fork PR',
+  head: { ref: 'source', sha: 'abc123', repo: { full_name: 'fork/repo', clone_url: '' } },
+  base: { ref: 'main', repo: { full_name: 'owner/repo' } },
+  labels: [],
+  assignees: [],
+} as unknown as GitHubPR;
+
+const cloneData: PrCloneData = {
+  prData,
+  targetBranch: 'main',
+  featureBranch: 'feature/clone',
+  description: '',
+  selectedCommits: ['abc123'],
+  isDraft: false,
+};
+
+describe('PrCloneInPlaceService fork-PR fetch handling', () => {
+  it('aborts the clone with a clear error when fetching the PR head fails', async () => {
+    let cleanedUp = false;
+    const git = {
+      getCurrentBranch: async () => 'original',
+      isWorkdirHasChanges: async () => false,
+      fetchPullRequestHead: async () => {
+        throw new Error('unknown revision or path not in the working tree');
+      },
+      isCherryPickInProgress: async () => false,
+      checkout: async () => {
+        cleanedUp = true;
+      },
+    } as unknown as GitExecutor;
+
+    class TestService extends PrCloneInPlaceService {
+      reportedError: unknown;
+      protected override async showCloneError(error: unknown): Promise<void> {
+        this.reportedError = error;
+      }
+    }
+
+    const service = new TestService(git, {} as GitHubClient, mockLogService);
+
+    await assert.rejects(service.clonePR(cloneData));
+
+    assert.ok(cleanedUp, 'should restore the original branch during recovery');
+    assert.match(
+      String((service.reportedError as Error)?.message ?? service.reportedError),
+      /Could not fetch the PR's commits from GitHub/
+    );
+  });
+
+  it('aborts before cherry-picking when a selected commit is not available locally', async () => {
+    const git = {
+      getCurrentBranch: async () => 'original',
+      isWorkdirHasChanges: async () => false,
+      fetchPullRequestHead: async () => {},
+      checkout: async () => {},
+      pullCurrentBranch: async () => {},
+      createUniqueFeatureBranch: async () => 'feature/clone',
+      commitExists: async () => false,
+      isCherryPickInProgress: async () => false,
+    } as unknown as GitExecutor;
+
+    class TestService extends PrCloneInPlaceService {
+      reportedError: unknown;
+      protected override async showCloneError(error: unknown): Promise<void> {
+        this.reportedError = error;
+      }
+    }
+
+    const service = new TestService(git, {} as GitHubClient, mockLogService);
+
+    await assert.rejects(service.clonePR(cloneData));
+
+    assert.match(
+      String((service.reportedError as Error)?.message ?? service.reportedError),
+      /Commit abc123 is not available locally/
+    );
+  });
+});
+
+describe('PrCloneTempWorktreeService fork-PR fetch handling', () => {
+  it('surfaces a clear error when fetching the PR head fails', async () => {
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    (service as any).tempGit = {
+      fetchAllRemoteBranchesAndTags: async () => {},
+      fetchPullRequestHead: async () => {
+        throw new Error('couldn\'t find remote ref pull/71/head');
+      },
+    };
+
+    await assert.rejects(
+      (service as any).fetchAllBranches(71),
+      /Could not fetch the PR's commits from GitHub/
+    );
+  });
+
+  it('rejects cherry-picking when a selected commit is missing locally', async () => {
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    (service as any).tempGit = {
+      commitExists: async () => false,
+      cherryPick: async () => {
+        throw new Error('should not be called');
+      },
+    };
+
+    await assert.rejects(
+      (service as any).cherryPickCommits(['deadbeef'], { isCancellationRequested: false }),
+      /Commit deadbeef is not available locally/
+    );
+  });
+});

--- a/src/test/unit/prCloneErrorRecovery.test.ts
+++ b/src/test/unit/prCloneErrorRecovery.test.ts
@@ -46,7 +46,7 @@ describe('PrCloneInPlaceService error recovery', () => {
         return 'original';
       },
       isWorkdirHasChanges: async () => false,
-      fetchSpecificBranch: async () => {},
+      fetchPullRequestHead: async () => {},
       checkout: async (branch: string) => {
         events.push(`checkout:${branch}`);
         if (branch === 'main' && !targetCheckoutAttempted) {
@@ -106,7 +106,8 @@ describe('PrCloneInPlaceService error recovery', () => {
       createStash: async (message: string) => {
         events.push(`stash:${message}`);
       },
-      fetchSpecificBranch: async () => {},
+      fetchPullRequestHead: async () => {},
+      commitExists: async () => true,
       checkout: async (branch: string) => {
         events.push(`checkout:${branch}`);
       },

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -209,7 +209,7 @@ describe('PrCloneWebViewProvider fetch error handling', () => {
         }),
       } as unknown as ConfigurationManager,
       createPrCloneService(ghClient, {
-        fetchSpecificBranch: async () => {},
+        fetchPullRequestHead: async () => {},
         getAllRefListExtended: async () => [{ name: 'main', remote: false, isTag: false }],
       })
     );

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -251,18 +251,13 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       const prData = await ghClient.fetchPullRequest(prNumber);
       this.currentPrData = prData; // Store PR data for later use
 
-      // Fetch the latest changes for the PR's specific branch
-      this.loggingService.info(`Fetching latest changes for PR branch: ${prData.head.ref}`);
+      // Fetch the PR's commits (works for same-repo and fork PRs alike)
+      this.loggingService.info(`Fetching commits for PR #${prNumber}`);
       try {
-        await git.fetchSpecificBranch(prData.head.ref);
-        this.loggingService.info(
-          `Successfully fetched latest changes for branch: ${prData.head.ref}`
-        );
+        await git.fetchPullRequestHead(prNumber);
+        this.loggingService.info(`Successfully fetched commits for PR #${prNumber}`);
       } catch (fetchError) {
-        this.loggingService.warn(
-          `Failed to fetch latest changes for branch ${prData.head.ref}: ${fetchError}`
-        );
-        // Continue with PR fetching even if fetch fails
+        throw new Error(`Could not fetch the PR's commits from GitHub: ${fetchError}`);
       }
 
       // GitHub's list-commits endpoint caps at 250 commits. If the PR reports


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #71 and REVIEW_WITH_FIXES.md Issue 1: PR Clone silently failed to fetch fork PR branches (the failure was only logged as a warning), leaving the clone to continue with commit SHAs that were never fetched locally. The first cherry-pick then failed late with a cryptic `fatal: bad object` error.
- Both clone strategies (in-place and temp-worktree) now fetch GitHub's synthetic `pull/<n>/head` ref, which exists on the base repo for every PR including forks. The fetch failure is now fatal (aborts the clone with a clear message) instead of being swallowed, and a preflight check verifies every selected commit SHA is actually present locally before cherry-picking starts.
- `PrCloneWebViewProvider.handleFetchPR` uses the same fetch method instead of fetching `head.ref` from origin.

To test manually: in a repo where you have push access, run "GSC: Clone pull request..." and enter the number of a PR opened from a fork. The clone should now succeed (or fail early with a clear "Could not fetch the PR's commits from GitHub" message instead of a late cryptic error).

## Test plan
- [x] Unit/integration tests pass (`yarn test:unit`, 373 passing)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host (clone a real fork PR)