### PR TITLE
fix(checkout): don't report success when checkout is cancelled at the conflict-preview dialog

### DIFF
--- a/src/commands/checkoutByPRCommand/index.ts
+++ b/src/commands/checkoutByPRCommand/index.ts
@@ -118,7 +118,10 @@ export class CheckoutByPRCommand extends BaseCommand {
         return;
       }
 
-      await this.autoStashService.checkoutAndStashChanges(git, currentBranch, prBranch, autoStashMode);
+      const outcome = await this.autoStashService.checkoutAndStashChanges(git, currentBranch, prBranch, autoStashMode);
+      if (outcome === 'cancelled') {
+        return;
+      }
 
       await this.showInformationMessage(`Switched to PR #${prNumber}: ${pr.title}`, 'OK');
 

--- a/src/commands/checkoutPreviousCommand/index.ts
+++ b/src/commands/checkoutPreviousCommand/index.ts
@@ -54,7 +54,10 @@ export class CheckoutPreviousCommand extends BaseCommand {
       }
 
       // Perform checkout with auto stash
-      await this.autoStashService.checkoutAndStashChanges(git, currentBranch, previousBranch, autoStashMode);
+      const outcome = await this.autoStashService.checkoutAndStashChanges(git, currentBranch, previousBranch, autoStashMode);
+      if (outcome === 'cancelled') {
+        return;
+      }
 
       capture(AnalyticsEvent.CheckoutPreviousBranch, { stash_mode: autoStashMode });
 

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -14,6 +14,8 @@ import { VscodeGitProvider } from "../common/git/vscodeGitProvider";
 
 export type TPullWithStashStrategy = 'merge' | 'rebase';
 
+export type CheckoutOutcome = 'completed' | 'cancelled';
+
 export class AutoStashService {
   
   constructor(
@@ -196,15 +198,16 @@ export class AutoStashService {
     currentBranch: string,
     nextBranch: IGitRef,
     autoStashMode: TAutoStashMode = AUTO_STASH_CURRENT_BRANCH
-  ) {
+  ): Promise<CheckoutOutcome> {
     const nextBranchName = nextBranch.name;
     const isWorkdirHasChanges = await git.isWorkdirHasChanges();
+    let outcome: CheckoutOutcome = 'completed';
     switch (autoStashMode) {
       case AUTO_STASH_CURRENT_BRANCH:
-        await this.doAutoStashCurrentBranch(git, currentBranch, nextBranchName, isWorkdirHasChanges);
+        outcome = await this.doAutoStashCurrentBranch(git, currentBranch, nextBranchName, isWorkdirHasChanges);
         break;
       case AUTO_STASH_AND_POP_IN_NEW_BRANCH:
-        await this.doAutoStashAndPopInNewBranch(
+        outcome = await this.doAutoStashAndPopInNewBranch(
           git,
           currentBranch,
           nextBranchName,
@@ -212,7 +215,7 @@ export class AutoStashService {
         );
         break;
       case AUTO_STASH_AND_APPLY_IN_NEW_BRANCH:
-        await this.doAutoStashAndPopInNewBranch(
+        outcome = await this.doAutoStashAndPopInNewBranch(
           git,
           currentBranch,
           nextBranchName,
@@ -233,7 +236,12 @@ export class AutoStashService {
         }
         break;
     }
-    capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges });
+
+    if (outcome === 'completed') {
+      capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges });
+    }
+
+    return outcome;
   }
 
   async doAutoStashCurrentBranch(
@@ -241,7 +249,7 @@ export class AutoStashService {
     currentBranch: string,
     nextBranch: string,
     isWorkdirHasChanges: boolean
-  ) {
+  ): Promise<CheckoutOutcome> {
     try {
       if (isWorkdirHasChanges) {
         const stashMessage = getStashMessage(currentBranch);
@@ -274,6 +282,8 @@ export class AutoStashService {
     } catch (e) {
       handleErrorMessage(e, 'No stash found', 'No stash to pop on the new branch.', 'Failed to pop the stash on the new branch.');
     }
+
+    return 'completed';
   }
 
   async #confirmStashConflicts(files: string[], operation: string): Promise<boolean> {
@@ -293,7 +303,7 @@ export class AutoStashService {
     nextBranch: string,
     isWorkdirHasChanges: boolean,
     apply: boolean = false
-  ) {
+  ): Promise<CheckoutOutcome> {
     const stashMessage = getStashMessage(currentBranch, true);
     const operation = apply ? 'apply' : 'pop';
 
@@ -304,7 +314,7 @@ export class AutoStashService {
           const proceed = await this.#confirmStashConflicts(conflicts, operation);
           if (!proceed) {
             this.logService.info('User cancelled checkout due to predicted stash conflicts');
-            return;
+            return 'cancelled';
           }
         }
         await git.createStash(stashMessage);
@@ -326,7 +336,7 @@ export class AutoStashService {
 
     // nothing to pop if no changes were stashed before checkout
     if (!isWorkdirHasChanges) {
-      return;
+      return 'completed';
     }
 
     // Pop or apply the stash on the new branch
@@ -338,5 +348,7 @@ export class AutoStashService {
     } catch (e) {
       handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
     }
+
+    return 'completed';
   }
 }

--- a/src/test/unit/checkoutCancelOutcome.test.ts
+++ b/src/test/unit/checkoutCancelOutcome.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { AUTO_STASH_AND_POP_IN_NEW_BRANCH } from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const nextBranch: IGitRef = {
+  name: 'feature-x',
+  fullName: 'feature-x',
+  remote: false,
+  isTag: false,
+} as unknown as IGitRef;
+
+function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    isWorkdirHasChanges: async () => true,
+    getStashConflictPreview: async () => ['file.ts'],
+    createStash: async () => {},
+    checkout: async () => {},
+    hasUpstreamBranch: async () => false,
+    isStashWithMessageExists: async () => false,
+    popStash: async () => {},
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+describe('AutoStashService checkout cancellation outcome', () => {
+  it('reports "cancelled" and never checks out when the user rejects the conflict warning', async () => {
+    const checkoutCalls: string[] = [];
+    const git = makeGitStub({
+      checkout: (async (branch: string) => {
+        checkoutCalls.push(branch);
+      }) as unknown as GitExecutor['checkout'],
+    });
+
+    const originalShowWarningMessage = vscode.window.showWarningMessage.bind(vscode.window);
+    (vscode.window as any).showWarningMessage = async () => undefined;
+
+    try {
+      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+      const outcome = await service.checkoutAndStashChanges(
+        git,
+        'main',
+        nextBranch,
+        AUTO_STASH_AND_POP_IN_NEW_BRANCH
+      );
+
+      assert.strictEqual(outcome, 'cancelled');
+      assert.deepStrictEqual(checkoutCalls, []);
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
+  it('reports "completed" and checks out when the user confirms the conflict warning', async () => {
+    const checkoutCalls: string[] = [];
+    const git = makeGitStub({
+      checkout: (async (branch: string) => {
+        checkoutCalls.push(branch);
+      }) as unknown as GitExecutor['checkout'],
+    });
+
+    const originalShowWarningMessage = vscode.window.showWarningMessage.bind(vscode.window);
+    (vscode.window as any).showWarningMessage = async () => 'Continue';
+
+    try {
+      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+      const outcome = await service.checkoutAndStashChanges(
+        git,
+        'main',
+        nextBranch,
+        AUTO_STASH_AND_POP_IN_NEW_BRANCH
+      );
+
+      assert.strictEqual(outcome, 'completed');
+      assert.deepStrictEqual(checkoutCalls, ['feature-x']);
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
+  it('reports "completed" when there is nothing to stash (no conflict preview requested)', async () => {
+    const git = makeGitStub({ isWorkdirHasChanges: async () => false });
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(
+      git,
+      'main',
+      nextBranch,
+      AUTO_STASH_AND_POP_IN_NEW_BRANCH
+    );
+
+    assert.strictEqual(outcome, 'completed');
+  });
+});

--- a/src/test/unit/checkoutPreviousCancelNotification.test.ts
+++ b/src/test/unit/checkoutPreviousCancelNotification.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+
+import { CheckoutPreviousCommand } from '../../commands/checkoutPreviousCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+class TestCheckoutPreviousCommand extends CheckoutPreviousCommand {
+  infoMessages: string[] = [];
+
+  protected override async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {
+      repositoryPath: '/repo',
+      getCurrentBranch: async () => 'main',
+      getPreviousBranch: async () => ({ name: 'feature-x', fullName: 'feature-x', remote: false, isTag: false }),
+      worktreeListDetailed: async () => [],
+    } as unknown as GitExecutor;
+  }
+
+  protected override async showInformationMessage(message: string): Promise<string | undefined> {
+    this.infoMessages.push(message);
+    return undefined;
+  }
+}
+
+describe('CheckoutPreviousCommand cancellation', () => {
+  it('does not show a success notification when the auto-stash checkout is cancelled', async () => {
+    const autoStashService = {
+      getAutoStashMode: async () => 'Auto stash and pop in new branch',
+      checkoutAndStashChanges: async () => 'cancelled' as const,
+    } as unknown as AutoStashService;
+
+    const command = new TestCheckoutPreviousCommand(mockLogService, autoStashService);
+
+    await command.execute();
+
+    assert.deepStrictEqual(command.infoMessages, []);
+  });
+
+  it('shows the success notification when the checkout completes', async () => {
+    const autoStashService = {
+      getAutoStashMode: async () => 'Auto stash and pop in new branch',
+      checkoutAndStashChanges: async () => 'completed' as const,
+    } as unknown as AutoStashService;
+
+    const command = new TestCheckoutPreviousCommand(mockLogService, autoStashService);
+
+    await command.execute();
+
+    assert.strictEqual(command.infoMessages.length, 1);
+    assert.match(command.infoMessages[0], /Switched to previous branch: feature-x/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #51 and REVIEW_WITH_FIXES.md Issue 2: `doAutoStashAndPopInNewBranch` returned `void`, so callers could not distinguish "checked out" from "user cancelled at the stash-conflict warning." The branch was never switched, yet the user still saw "Switched to previous branch: X" / "Switched to PR #N: ..." and analytics recorded a completed checkout.
- `checkoutAndStashChanges` and its helpers (`doAutoStashAndPopInNewBranch`, `doAutoStashCurrentBranch`) now return a `CheckoutOutcome` (`'completed' | 'cancelled'`). Analytics capture only fires when the outcome is `'completed'`.
- `CheckoutPreviousCommand` and `CheckoutByPRCommand` now only show their success notification when the outcome is `'completed'`.

To test manually: set mode `autoStashAndPop`, modify a tracked file that differs on the previous branch (so a conflict is predicted), run "GSC: Checkout previous branch (With Stash)", and press Escape/dismiss the conflict warning modal. No "Switched to..." notification should appear and `git branch --show-current` should show you never moved.

## Test plan
- [x] Unit/integration tests pass (`yarn test:unit`, 372 passing)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host