### PR TITLE
fix(webview): replace no-op alert() with inline validation errors

### DIFF
--- a/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
@@ -65,6 +65,7 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
   );
   const [isPreview, setIsPreview] = useState(false);
   const [selectedCommits, setSelectedCommits] = useState<string[]>([]);
+  const [validationError, setValidationError] = useState<string | undefined>();
 
   const logger = useLogger(false);
   const sendMessage = useSendMessage();
@@ -124,17 +125,19 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
 
   const handleSubmit = (isDraft: boolean = false) => {
     if (isCloning) return; // Prevent submit during cloning
-    
+
     if (!featureBranch.trim()) {
-      alert('Please enter a feature branch name');
+      setValidationError('Please enter a feature branch name');
       return;
     }
-    
+
     logger.log(`selectedCommits.length = ${selectedCommits.length}`);
     if (selectedCommits.length === 0) {
-      alert('Please select at least one commit');
+      setValidationError('Please select at least one commit');
       return;
     }
+
+    setValidationError(undefined);
 
     // Show confirmation modal
     const isDraftPr = isDraft ? " draft " : " ";
@@ -192,7 +195,10 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
             <Input
               type="text"
               value={featureBranch}
-              onChange={(e) => setFeatureBranch(e.target.value)}
+              onChange={(e) => {
+                setFeatureBranch(e.target.value);
+                setValidationError(undefined);
+              }}
               placeholder="Feature branch name"
               disabled={isCloning}
             />
@@ -243,15 +249,20 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
         </div>
 
 
+        {validationError && (
+          <Text.Error className={styles.validationError}>{validationError}</Text.Error>
+        )}
+
         <div className={styles.actions}>
           <Button type="button" variant="secondary" onClick={handleCancel} disabled={isCloning}>
             Cancel
           </Button>
-          <DropDownButton 
+          <DropDownButton
             actions={dropdownActions}
             defaultActionId="create"
             popupDirection="up"
             loading={isCloning}
+            disabled={selectedCommits.length === 0}
           />
         </div>
       </div>

--- a/src/webview/Apps/PR/pages/PrCloneForm/module.css
+++ b/src/webview/Apps/PR/pages/PrCloneForm/module.css
@@ -106,6 +106,11 @@
   }
 }
 
+.validationError {
+  display: block;
+  margin-bottom: 8px;
+}
+
 /* TODO: Consider extracting button group layout pattern to shared CSS class - similar pattern in PrInputForm/module.css:2-5 */
 .actions {
   display: flex;

--- a/src/webview/Apps/PR/pages/PrInputForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrInputForm/index.tsx
@@ -23,6 +23,7 @@ export const PrInputForm: React.FC<PrInputFormProps> = ({
   isLoading,
 }) => {
   const [prInput, setPrInput] = useState('');
+  const [validationError, setValidationError] = useState<string | undefined>();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const logger = useLogger();
@@ -56,9 +57,10 @@ export const PrInputForm: React.FC<PrInputFormProps> = ({
     logger.info('Fetching PR data ...');
     e.preventDefault();
     if (!prInput.trim()) {
-      alert('Please enter a PR number or URL');
+      setValidationError('Please enter a PR number or URL');
       return;
     }
+    setValidationError(undefined);
     onFetchPR(prInput.trim());
   };
 
@@ -72,9 +74,16 @@ export const PrInputForm: React.FC<PrInputFormProps> = ({
           type="text"
           label="PR Number or URL:"
           value={prInput}
-          onChange={(e) => setPrInput(e.target.value)}
+          onChange={(e) => {
+            setPrInput(e.target.value);
+            setValidationError(undefined);
+          }}
           placeholder={`e.g., 123 or https://github.com/${repoOwner}/${repoName}/pull/123`}
         />
+
+        {validationError && (
+          <Text.Error className={styles.validationError}>{validationError}</Text.Error>
+        )}
 
         <div className={styles.buttonGroup}>
           <Button

--- a/src/webview/Apps/PR/pages/PrInputForm/module.css
+++ b/src/webview/Apps/PR/pages/PrInputForm/module.css
@@ -1,3 +1,8 @@
+.validationError {
+  display: block;
+  margin-top: 8px;
+}
+
 /* TODO: Consider extracting button group layout pattern to shared CSS class - similar pattern in PrCloneForm/module.css:65-69 */
 .buttonGroup {
   display: flex;

--- a/src/webview/components/Text/index.tsx
+++ b/src/webview/components/Text/index.tsx
@@ -32,9 +32,20 @@ const Label: FC<TextProps> = ({ children, className }) => {
   return <span className={style}>{children}</span>;
 };
 
+const ErrorText: FC<TextProps> = ({ children, className }) => {
+  const style = classNames(styles.textCommon, styles.textError, className);
+
+  return (
+    <span className={style} role="alert">
+      {children}
+    </span>
+  );
+};
+
 export const Text = {
   Paragraph,
   Header,
   SubHeader,
-  Label
+  Label,
+  Error: ErrorText
 };

--- a/src/webview/components/Text/module.css
+++ b/src/webview/components/Text/module.css
@@ -31,4 +31,10 @@
     white-space: pre-wrap;
     font-weight: 400;
   }
+
+  &.textError {
+    font-size: 12px;
+    white-space: pre-wrap;
+    color: var(--vscode-errorForeground);
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes REVIEW_WITH_FIXES.md Issue 3: `window.alert()` is a no-op in VS Code's sandboxed webviews. Clearing the feature-branch field or unchecking all commits in PR Clone and clicking Create did nothing visible — the click was simply dead with no feedback.
- Added a `Text.Error` variant to the shared `Text` component (styled with `var(--vscode-errorForeground)`) and used it for inline validation in `PrCloneForm` (empty feature branch / no selected commits) and `PrInputForm` (empty PR number/URL), replacing all three `alert(...)` calls.
- The Create dropdown in `PrCloneForm` is now also disabled when no commits are selected, so invalid submits are unreachable in the common path.
- No React component-rendering test harness exists in this repo yet (existing webview tests cover pure reducers/utilities, not JSX rendering), so this was verified via `yarn check-types-webview` and `yarn build-webview`, plus the existing unit suite (no regressions). Manual verification recommended: open PR Clone, fetch a PR, clear the branch name field and click Create — an inline red error should appear instead of nothing happening.

## Test plan
- [x] Unit tests pass (`yarn test:unit`, 373 passing, no regressions)
- [x] Type check passes (`yarn compile`, `yarn check-types-webview`)
- [x] Webview bundle builds (`yarn build-webview`)
- [ ] Manual smoke test performed in VS Code extension host