### PR TITLE
docs: fix Git Smart Checkout: to GSC: command palette prefix in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,28 +23,30 @@ In fast-paced development environments, switching between Git branches is freque
 
 ## Features
 
+All commands are grouped under the `GSC:` prefix in the Command Palette.
+
 | Feature | Command | Details |
 | --- | --- | --- |
-| Checkout to a branch, tag, or remote ref with configurable stash behavior | `Git Smart Checkout: Checkout to ... (With Stash)` | [Checkout with stash](docs/checkout-with-stash.md) |
-| Checkout the previous branch with the same stash behavior | `Git Smart Checkout: Checkout previous branch (With Stash)` | [Checkout previous branch with stash](docs/checkout-previous-branch-with-stash.md) |
-| Copy the current branch name to the clipboard | `Git Smart Checkout: Copy current branch name to clipboard` | [Copy current branch name](docs/copy-current-branch-name.md) |
-| Checkout a GitHub pull request branch by PR number or URL | `Git Smart Checkout: Checkout by PR number... (With Stash)` | [Checkout by PR number with stash](docs/checkout-by-pr-number-with-stash.md) |
-| Review a GitHub pull request in a linked worktree and remove tracked review worktrees | `Git Smart Checkout: PR Review in Worktree`, `Git Smart Checkout: Remove PR review in Worktree` | [PR review in worktree](docs/pr-review-in-worktree.md) |
-| Pull the current branch while preserving local changes | `Git Smart Checkout: Pull (With Stash)` | [Pull with stash](docs/pull-with-stash.md) |
-| Pull with rebase while preserving local changes | `Git Smart Checkout: Pull (Rebase With Stash)` | [Pull rebase with stash](docs/pull-rebase-with-stash.md) |
-| Rebase the current branch onto another ref while preserving local changes | `Git Smart Checkout: Rebase ... (With Stash)` | [Rebase with stash](docs/rebase-with-stash.md) |
-| Inspect, recover, or remove stashes created by Git Smart Checkout | `Git Smart Checkout: Manage auto-stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
-| Copy staged or WIP changes between existing worktrees | `Git Smart Checkout: Copy staged changes to worktree ...`, `Git Smart Checkout: Copy WIP changes to worktree ...`, `Git Smart Checkout: Copy WIP from Worktree`, `Git Smart Checkout: Move WIP from Worktree` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
-| Open a terminal in a selected worktree's directory | `Git Smart Checkout: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
-| Remove several Git worktrees at once with a single confirmation | `Git Smart Checkout: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
-| Create a new PR from selected commits in another GitHub PR | `Git Smart Checkout: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
-| Generate and optionally push a tag from a reusable template | `Git Smart Checkout: Create Tag from Template` | [Create tag from template](docs/create-tag-from-template.md) |
-| Create and check out a branch from a template (Jira, file, regex, scripts) | `Git Smart Checkout: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
-| Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `Git Smart Checkout: Init Jira` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
-| Store the Jira API token securely in VS Code Secret Storage | `Git Smart Checkout: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
-| Change the default stash mode used by checkout-style commands | `Git Smart Checkout: Switch Mode` | [Switch mode](docs/switch-mode.md) |
-| Open a quick-actions menu of common commands (checkout, pull/rebase, all worktree commands, clone PR, open settings) from the status bar item | `Git Smart Checkout: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
-| Open this extension's settings | `Git Smart Checkout: Open Settings` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
+| Checkout to a branch, tag, or remote ref with configurable stash behavior | `GSC: Checkout to ... (With Stash)` | [Checkout with stash](docs/checkout-with-stash.md) |
+| Checkout the previous branch with the same stash behavior | `GSC: Checkout previous branch (With Stash)` | [Checkout previous branch with stash](docs/checkout-previous-branch-with-stash.md) |
+| Copy the current branch name to the clipboard | `GSC: Copy current branch name to clipboard` | [Copy current branch name](docs/copy-current-branch-name.md) |
+| Checkout a GitHub pull request branch by PR number or URL | `GSC: Checkout by PR number... (With Stash)` | [Checkout by PR number with stash](docs/checkout-by-pr-number-with-stash.md) |
+| Review a GitHub pull request in a linked worktree and remove tracked review worktrees | `GSC: PR Review in Worktree`, `GSC: Remove PR review in Worktree` | [PR review in worktree](docs/pr-review-in-worktree.md) |
+| Pull the current branch while preserving local changes | `GSC: Pull (With Stash)` | [Pull with stash](docs/pull-with-stash.md) |
+| Pull with rebase while preserving local changes | `GSC: Pull (Rebase With Stash)` | [Pull rebase with stash](docs/pull-rebase-with-stash.md) |
+| Rebase the current branch onto another ref while preserving local changes | `GSC: Rebase (With Stash)` | [Rebase with stash](docs/rebase-with-stash.md) |
+| Inspect, recover, or remove stashes created by Git Smart Checkout | `GSC: Manage auto-stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
+| Copy staged or WIP changes between existing worktrees | `GSC: Copy staged changes to worktree ...`, `GSC: Copy WIP changes to worktree ...`, `GSC: Copy WIP from Worktree`, `GSC: Move WIP from Worktree` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
+| Open a terminal in a selected worktree's directory | `GSC: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
+| Remove several Git worktrees at once with a single confirmation | `GSC: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
+| Create a new PR from selected commits in another GitHub PR | `GSC: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
+| Generate and optionally push a tag from a reusable template | `GSC: Create Tag from Template...` | [Create tag from template](docs/create-tag-from-template.md) |
+| Create and check out a branch from a template (Jira, file, regex, scripts) | `GSC: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
+| Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `GSC: Init Jira` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
+| Store the Jira API token securely in VS Code Secret Storage | `GSC: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
+| Change the default stash mode used by checkout-style commands | `GSC: Switch Mode` | [Switch mode](docs/switch-mode.md) |
+| Open a quick-actions menu of common commands (checkout, pull/rebase, all worktree commands, clone PR, open settings) from the status bar item | `GSC: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
+| Open this extension's settings | `GSC: Open Settings` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
 
 ## Extension Settings
 
@@ -66,7 +68,7 @@ Click a setting ID to open that setting in VS Code.
 | ⚙️ [`git-smart-checkout.jira.domain`](vscode://settings/git-smart-checkout.jira.domain) (Jira domain) | `string` | Jira Cloud host (e.g. `your-company.atlassian.net`). Required when the branch template uses Jira tokens. |
 | ⚙️ [`git-smart-checkout.jira.username`](vscode://settings/git-smart-checkout.jira.username) (Jira username) | `string` | Atlassian account username for Jira API authentication (usually your Atlassian account email). |
 | ⚙️ [`git-smart-checkout.jira.email`](vscode://settings/git-smart-checkout.jira.email) (Deprecated Jira email) | `string` | Deprecated compatibility fallback used only when `jira.username` is empty. Migrate to `git-smart-checkout.jira.username`. |
-| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | **Deprecated — stored in plaintext.** Use the `Git Smart Checkout: Set Jira token` command, which keeps the token in VS Code Secret Storage. Any value set here is migrated into Secret Storage and cleared on the next activation. |
+| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | **Deprecated — stored in plaintext.** Use the `GSC: Set Jira token` command, which keeps the token in VS Code Secret Storage. Any value set here is migrated into Secret Storage and cleared on the next activation. |
 | ⚙️ [`git-smart-checkout.jira.projectKeys`](vscode://settings/git-smart-checkout.jira.projectKeys) (Jira project keys) | `array` | Optional list of project keys that limit the Jira issue picker, e.g. `["KEY", "HOME"]`. Empty (default) shows all issues assigned to you. |
 | ⚙️ [`git-smart-checkout.pushTagWithoutConfirmation`](vscode://settings/git-smart-checkout.pushTagWithoutConfirmation) (Push tag without confirmation) | `boolean` | Pushes the created Git tag to the remote without asking for confirmation. |
 | ⚙️ [`git-smart-checkout.tagRemote`](vscode://settings/git-smart-checkout.tagRemote) (Tag remote) | `string` | Git remote used when pushing created tags. |

--- a/website/src/components/Features/Features.tsx
+++ b/website/src/components/Features/Features.tsx
@@ -18,7 +18,7 @@ const features: Feature[] = [
     title: 'Smart Branch Checkout',
     description:
       'Switch branches without worrying about uncommitted changes. Choose your stash strategy once or per checkout — the extension handles everything else.',
-    command: 'Git Smart Checkout: Checkout to... (With Stash)',
+    command: 'GSC: Checkout to... (With Stash)',
     color: 'blue',
   },
   {
@@ -26,7 +26,7 @@ const features: Feature[] = [
     title: 'Pull with Stash',
     description:
       'Pull the latest changes from remote without losing your local work. Changes are stashed before the pull and restored automatically after.',
-    command: 'Git Smart Checkout: Pull (With Stash)',
+    command: 'GSC: Pull (With Stash)',
     color: 'green',
   },
   {
@@ -34,7 +34,7 @@ const features: Feature[] = [
     title: 'Pull with Rebase',
     description:
       'Pull with rebase while preserving local changes. The extension stashes your work, rebases onto the remote branch, and restores your changes afterward.',
-    command: 'Git Smart Checkout: Pull (Rebase With Stash)',
+    command: 'GSC: Pull (Rebase With Stash)',
     color: 'orange',
   },
   {
@@ -42,7 +42,7 @@ const features: Feature[] = [
     title: 'Rebase with Stash',
     description:
       'Rebase the current branch onto any other branch, tag, or ref while your local changes are stashed and restored automatically — no need to commit or clean up first.',
-    command: 'Git Smart Checkout: Rebase ... (With Stash)',
+    command: 'GSC: Rebase (With Stash)',
     color: 'purple',
   },
   {
@@ -54,7 +54,7 @@ const features: Feature[] = [
         magic. Think of it as <kbd>Ctrl + Z</kbd> for branch switching.
       </>
     ),
-    command: 'Git Smart Checkout: Checkout previous branch (With Stash)',
+    command: 'GSC: Checkout previous branch (With Stash)',
     color: 'purple',
   },
   {
@@ -62,7 +62,7 @@ const features: Feature[] = [
     title: 'Preferred Branches',
     description:
       'Star the branches, tags, and remotes you use most — they float to the top of the checkout picker, marked with a star. Toggle a star straight from the picker, no settings file to edit.',
-    command: 'Git Smart Checkout: Checkout to... (With Stash)',
+    command: 'GSC: Checkout to... (With Stash)',
     tag: 'New',
     color: 'blue',
   },
@@ -71,7 +71,7 @@ const features: Feature[] = [
     title: 'GitHub PR Clone',
     description:
       'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
-    command: 'Git Smart Checkout: Clone pull request...',
+    command: 'GSC: Clone pull request...',
     tag: 'Beta',
     color: 'orange',
   },
@@ -80,7 +80,7 @@ const features: Feature[] = [
     title: 'Checkout by PR Number',
     description:
       "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
-    command: 'Git Smart Checkout: Checkout by PR number... (With Stash)',
+    command: 'GSC: Checkout by PR number... (With Stash)',
     color: 'orange',
   },
   {
@@ -88,7 +88,7 @@ const features: Feature[] = [
     title: 'PR Review in Worktree',
     description:
       'Open a GitHub PR in an isolated linked worktree, track its review metadata, and remove the review worktree later with dirty-state stash handling.',
-    command: 'Git Smart Checkout: PR Review in Worktree',
+    command: 'GSC: PR Review in Worktree',
     color: 'purple',
   },
   {
@@ -96,7 +96,7 @@ const features: Feature[] = [
     title: 'Worktree Dev Terminal',
     description:
       'Open a new integrated terminal straight in any worktree directory. Pick a project, choose the worktree, and get a shell in the right working directory — no manual navigation.',
-    command: 'Git Smart Checkout: Open Worktree Dev Terminal...',
+    command: 'GSC: Open Worktree Dev Terminal...',
     color: 'blue',
   },
   {
@@ -104,7 +104,7 @@ const features: Feature[] = [
     title: 'Tag from Template',
     description:
       'Generate version tags from a configurable template. Read values from package.json, extract ticket IDs from branch names, and auto-increment to avoid collisions.',
-    command: 'Git Smart Checkout: Create Tag from Template',
+    command: 'GSC: Create Tag from Template...',
     color: 'blue',
   },
   {
@@ -112,7 +112,7 @@ const features: Feature[] = [
     title: 'Branch from Template',
     description:
       'Create and check out a branch from a reusable template. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
-    command: 'Git Smart Checkout: Create Branch from Template...',
+    command: 'GSC: Create Branch from Template...',
     color: 'green',
   },
   {
@@ -120,7 +120,7 @@ const features: Feature[] = [
     title: 'Worktree Workflows',
     description:
       'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
-    command: 'Git Smart Checkout: Move to new worktree',
+    command: 'GSC: Move to new worktree',
     color: 'green',
   },
   {
@@ -135,7 +135,7 @@ const features: Feature[] = [
     title: 'Auto-Stash Manager',
     description:
       'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
-    command: 'Git Smart Checkout: Manage auto-stashes...',
+    command: 'GSC: Manage auto-stashes...',
     tag: 'New',
     color: 'green',
   },
@@ -144,7 +144,7 @@ const features: Feature[] = [
     title: 'Status Bar Integration',
     description:
       "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",
-    command: 'Git Smart Checkout: Quick Actions',
+    command: 'GSC: Quick Actions',
     color: 'purple',
   },
 ];

--- a/website/src/components/Hero/Hero.tsx
+++ b/website/src/components/Hero/Hero.tsx
@@ -76,7 +76,7 @@ export function Hero() {
 
         <div className={styles.codeBlock}>
           <kbd className={styles.codePrompt}>{commandPaletteShortcut}</kbd>
-          <span className={styles.codeCmd}>Git Smart Checkout: Checkout to... (With Stash)</span>
+          <span className={styles.codeCmd}>GSC: Checkout to... (With Stash)</span>
           <span className={styles.codeCursor} aria-hidden="true">▋</span>
         </div>
       </div>

--- a/website/src/components/Installation/Installation.tsx
+++ b/website/src/components/Installation/Installation.tsx
@@ -74,7 +74,7 @@ export function Installation() {
               <div className={styles.qsNum}>2</div>
               <div>
                 <p className={styles.qsLabel}>Type the command</p>
-                <code className={styles.code}>Git Smart Checkout: Checkout to... (With Stash)</code>
+                <code className={styles.code}>GSC: Checkout to... (With Stash)</code>
               </div>
             </div>
             <div className={styles.qsArrow}>→</div>


### PR DESCRIPTION
## Summary
- Every command's `category` in `package.json` is `"GSC"` (bulk-renamed in #70), so the command palette shows entries like `GSC: Checkout to... (With Stash)`. Both `README.md` and the marketing website (`website/src/components/{Features,Hero,Installation}`) still told users to type `Git Smart Checkout: ...`, which matches zero commands — new users following the docs find nothing and think the extension is broken.
- Replaced every `Git Smart Checkout: ` command reference with the real `GSC: ` prefix in `README.md` and in the website's `Features.tsx`, `Hero.tsx`, and `Installation.tsx`.
- Fixed two additional drifts found while auditing: `Rebase ... (With Stash)` → `Rebase (With Stash)` (matches the actual command title), and `Create Tag from Template` → `Create Tag from Template...` (missing trailing ellipsis to match the actual title).
- Added a clarifying line to the README: "All commands are grouped under the `GSC:` prefix in the Command Palette."

To verify manually: open the Command Palette in VS Code with the extension loaded and type `GSC:` — all commands listed in the README table should now appear exactly as documented.

## Test plan
- [x] `yarn compile` passes
- [x] `yarn test:unit` passes (378 passing)
- [x] `yarn test` passes (378 passing)
- [x] Website builds (`cd website && yarn build`)
- [x] Verified no remaining `Git Smart Checkout:` command references in README.md or website/src