### PR TITLE
fix(pr-clone): guard Cancel PR clone command with no active clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,10 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "git-smart-checkout.prCancelCloneMenu",
+          "when": "false"
+        },
+        {
           "command": "git-smart-checkout.prConflictsResolvedMenu",
           "when": "false"
         },

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -35,6 +35,12 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
   }
 
   async cherryPickNext(isContinue = false) {
+    if (!this.commitGenerator) {
+      await window.showInformationMessage('No PR clone in progress.');
+
+      return;
+    }
+
     if (await this.git.hasConflicts()) {
       await window.showWarningMessage(
         'Working directory still has conflicts, resolve them to proceed',

--- a/src/services/prCloneService.ts
+++ b/src/services/prCloneService.ts
@@ -143,6 +143,10 @@ export class PrCloneService {
   }
 
   async abortClonePR() {
+    if (!this.isInited) {
+      return;
+    }
+
     const config = this.configurationManager.get();
 
     if (config.useInPlaceCherryPick) {

--- a/src/test/unit/prCloneAbort.test.ts
+++ b/src/test/unit/prCloneAbort.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { window as vscodeWindow } from 'vscode';
 
 import { GitExecutor } from '../../common/git/gitExecutor';
 import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
@@ -133,6 +134,46 @@ describe('PrCloneInPlaceService.cleanUp (abort) guard', () => {
       calls.checkout,
       ['main'],
       'the original branch should still be restored'
+    );
+  });
+});
+
+describe('PrCloneInPlaceService.cherryPickNext guard', () => {
+  const createGitStub = () => {
+    const calls = { hasConflicts: 0 };
+
+    const gitStub = {
+      hasConflicts: async () => {
+        calls.hasConflicts += 1;
+        return false;
+      },
+    } as unknown as GitExecutor;
+
+    return { gitStub, calls };
+  };
+
+  it('shows "No PR clone in progress." and does not throw when no clone is active', async () => {
+    const { gitStub, calls } = createGitStub();
+    const service = new PrCloneInPlaceService(gitStub, {} as any, mockLogService);
+
+    const messages: string[] = [];
+    const originalShowInformationMessage = vscodeWindow.showInformationMessage;
+    (vscodeWindow as any).showInformationMessage = async (message: string) => {
+      messages.push(message);
+      return undefined;
+    };
+
+    try {
+      await assert.doesNotReject(() => service.cherryPickNext());
+    } finally {
+      (vscodeWindow as any).showInformationMessage = originalShowInformationMessage;
+    }
+
+    assert.deepStrictEqual(messages, ['No PR clone in progress.']);
+    assert.strictEqual(
+      calls.hasConflicts,
+      0,
+      'should return before touching git state when no clone is in progress'
     );
   });
 });

--- a/src/test/unit/prCloneService.test.ts
+++ b/src/test/unit/prCloneService.test.ts
@@ -105,6 +105,16 @@ describe('PrCloneService re-initialization', () => {
   });
 });
 
+describe('PrCloneService.abortClonePR guard', () => {
+  it('resolves without throwing when called before init() (no active clone)', async () => {
+    const service = new PrCloneService(context, mockLogService, configurationManager);
+
+    await assert.doesNotReject(() => service.abortClonePR());
+
+    service.dispose();
+  });
+});
+
 describe('PrCloneWebViewProvider repository refresh', () => {
   it('clears stale PR data and posts updated repository info after re-init', () => {
     const service = new PrCloneService(context, mockLogService, configurationManager);


### PR DESCRIPTION
## Summary
- Hides "GSC: Cancel PR clone" from the command palette (gated with `when: false`, matching the existing `prConflictsResolvedMenu` pattern) so it can only be triggered from the PR Clone view's title bar where it's meaningful.
- Hardens `PrCloneService.abortClonePR()` to no-op when the service hasn't been initialized (`isInited` false), instead of dereferencing `InPlaceService`/`TempWorktreeService` getters that throw `Getter "..." is not initialized`.
- Hardens `PrCloneInPlaceService.cherryPickNext()` to show an information message "No PR clone in progress." and return early instead of throwing a `TypeError` when `commitGenerator` is undefined (e.g. from a stale keybinding).
- Added unit tests covering both no-op/guarded paths.

To verify manually: open a workspace with no PR clone in progress, open the command palette, and confirm "GSC: Cancel PR clone" no longer appears. Then, without the fix reverted, you can confirm the underlying guard by calling `vscode.commands.executeCommand('git-smart-checkout.prCancelCloneMenu')` from the Debug Console — it resolves silently instead of showing an error toast.

## Test plan
- [x] Unit/integration tests pass (`yarn test`)
- [x] Type check passes (`yarn compile`)
- [x] Manual smoke test performed in VS Code extension host