### PR TITLE
fix(pull-with-stash): don't strand changes in stash when branch has no upstream

### DIFF
--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -114,6 +114,13 @@ export class AutoStashService {
       ? AnalyticsEvent.PullRebaseWithStash
       : AnalyticsEvent.PullWithStash;
     const stashMessage = getStashMessage(currentBranch, true);
+
+    if (!(await git.hasUpstreamBranch(currentBranch))) {
+      throw new Error(
+        `Branch "${currentBranch}" has no upstream branch to pull from. Publish the branch first (git push -u origin ${currentBranch}).`
+      );
+    }
+
     const isWorkdirHasChangesBeforeStash = await git.isWorkdirHasChanges();
 
     if (isWorkdirHasChangesBeforeStash) {
@@ -126,6 +133,16 @@ export class AutoStashService {
       captureException(e);
       const msg = e instanceof Error ? e.message : String(e);
       const operation = strategy === 'rebase' ? 'Pull with rebase' : 'Pull';
+
+      if (isWorkdirHasChangesBeforeStash) {
+        const isWorkdirHasChangesAfterFailedPull = await git.isWorkdirHasChanges();
+        if (!isWorkdirHasChangesAfterFailedPull) {
+          // Nothing partially merged/rebased - safe to restore the user's changes.
+          await git.popStash(stashMessage);
+          throw new Error(`${operation} failed: ${msg}`);
+        }
+      }
+
       throw new Error(`${operation} failed: ${msg}${isWorkdirHasChangesBeforeStash ? '\n\nYour changes are preserved in the stash.' : ''}`);
     }
 

--- a/src/test/unit/pullAndStashChanges.test.ts
+++ b/src/test/unit/pullAndStashChanges.test.ts
@@ -1,0 +1,105 @@
+import * as assert from 'assert';
+
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    isWorkdirHasChanges: async () => true,
+    createStash: async () => {},
+    hasUpstreamBranch: async () => true,
+    pullFromRemoteBranch: async () => {},
+    popStash: async () => {},
+    resetLocalChanges: async () => {},
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+describe('AutoStashService.pullAndStashChanges', () => {
+  it('throws a clear "no upstream" error and never creates a stash when the branch has no upstream', async () => {
+    const stashCalls: string[] = [];
+    const git = makeGitStub({
+      hasUpstreamBranch: async () => false,
+      createStash: (async (msg: string) => {
+        stashCalls.push(msg);
+      }) as unknown as GitExecutor['createStash'],
+    });
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await assert.rejects(
+      () => service.pullAndStashChanges(git, 'feature-x', 'merge'),
+      (err: Error) => {
+        assert.match(err.message, /no upstream branch to pull from/);
+        assert.match(err.message, /feature-x/);
+        return true;
+      }
+    );
+
+    assert.deepStrictEqual(stashCalls, []);
+  });
+
+  it('restores the stash before rethrowing when a pull fails and the working tree ends up clean', async () => {
+    const popCalls: string[] = [];
+    const git = makeGitStub({
+      isWorkdirHasChanges: async () => true,
+      pullFromRemoteBranch: async () => {
+        throw new Error('There is no tracking information for the current branch');
+      },
+      popStash: (async (msg: string) => {
+        popCalls.push(msg);
+      }) as unknown as GitExecutor['popStash'],
+    });
+
+    // After the failed pull, isWorkdirHasChanges should report clean (nothing partially merged).
+    let callCount = 0;
+    git.isWorkdirHasChanges = (async () => {
+      callCount += 1;
+      // first call: before stash (dirty), second call: after failed pull (clean)
+      return callCount === 1;
+    }) as unknown as GitExecutor['isWorkdirHasChanges'];
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await assert.rejects(
+      () => service.pullAndStashChanges(git, 'feature-x', 'merge'),
+      (err: Error) => {
+        assert.match(err.message, /Pull failed/);
+        assert.doesNotMatch(err.message, /preserved in the stash/);
+        return true;
+      }
+    );
+
+    assert.strictEqual(popCalls.length, 1);
+  });
+
+  it('preserves the stash and keeps the original error message when a pull fails and the tree is left dirty (real conflict)', async () => {
+    const popCalls: string[] = [];
+    const git = makeGitStub({
+      pullFromRemoteBranch: async () => {
+        throw new Error('CONFLICT (content): Merge conflict in file.ts');
+      },
+      popStash: (async (msg: string) => {
+        popCalls.push(msg);
+      }) as unknown as GitExecutor['popStash'],
+    });
+
+    // Both before-stash and after-failed-pull checks report dirty (conflict markers left in tree).
+    git.isWorkdirHasChanges = (async () => true) as unknown as GitExecutor['isWorkdirHasChanges'];
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await assert.rejects(
+      () => service.pullAndStashChanges(git, 'feature-x', 'merge'),
+      (err: Error) => {
+        assert.match(err.message, /Pull failed/);
+        assert.match(err.message, /preserved in the stash/);
+        return true;
+      }
+    );
+
+    assert.deepStrictEqual(popCalls, []);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #35: `Pull (With Stash)` on a branch with no upstream would stash the user's changes, then immediately fail on `git pull` ("no tracking information"), leaving the working tree empty with no automatic recovery path.
- `pullAndStashChanges` now checks `hasUpstreamBranch` before stashing anything, and throws a clear error ("Branch \"X\" has no upstream branch to pull from. Publish the branch first...") instead of stashing at all in that case.
- Additionally, if a pull still fails after stashing (a real failure, distinct from the no-upstream case) and the working tree ends up clean (nothing partially merged/rebased), the stash is popped back before the error is rethrown, so the user's tree is restored exactly as it was. The existing "preserved in the stash" behavior is unchanged for the case where the tree is left dirty (a real merge/rebase conflict).
- To test manually: create a local-only branch (no `git push -u`), make an uncommitted edit, run `Git Smart Checkout: Pull (With Stash)` — verify the edit remains in the working tree and a clear "no upstream" error is shown, with no stash created (`git stash list`).

## Test plan
- [x] Unit tests pass (`yarn test:unit`) — added `src/test/unit/pullAndStashChanges.test.ts` covering: no-upstream (no stash created), pull failure with clean tree (stash restored), pull failure with dirty tree/conflict (stash preserved, existing behavior)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host