### PR TITLE
fix(autostash): resolve stash conflict preview ref for remote-only branches

### DIFF
--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -200,6 +200,7 @@ export class AutoStashService {
     autoStashMode: TAutoStashMode = AUTO_STASH_CURRENT_BRANCH
   ): Promise<CheckoutOutcome> {
     const nextBranchName = nextBranch.name;
+    const previewRef = nextBranch.remote ? nextBranch.fullName : nextBranch.name;
     const isWorkdirHasChanges = await git.isWorkdirHasChanges();
     let outcome: CheckoutOutcome = 'completed';
     switch (autoStashMode) {
@@ -211,7 +212,9 @@ export class AutoStashService {
           git,
           currentBranch,
           nextBranchName,
-          isWorkdirHasChanges
+          isWorkdirHasChanges,
+          false,
+          previewRef
         );
         break;
       case AUTO_STASH_AND_APPLY_IN_NEW_BRANCH:
@@ -220,7 +223,8 @@ export class AutoStashService {
           currentBranch,
           nextBranchName,
           isWorkdirHasChanges,
-          true
+          true,
+          previewRef
         );
         break;
       case AUTO_STASH_IGNORE:
@@ -302,14 +306,15 @@ export class AutoStashService {
     currentBranch: string,
     nextBranch: string,
     isWorkdirHasChanges: boolean,
-    apply: boolean = false
+    apply: boolean = false,
+    previewRef: string = nextBranch
   ): Promise<CheckoutOutcome> {
     const stashMessage = getStashMessage(currentBranch, true);
     const operation = apply ? 'apply' : 'pop';
 
     try {
       if (isWorkdirHasChanges) {
-        const conflicts = await git.getStashConflictPreview(nextBranch);
+        const conflicts = await git.getStashConflictPreview(previewRef);
         if (conflicts.length > 0) {
           const proceed = await this.#confirmStashConflicts(conflicts, operation);
           if (!proceed) {

--- a/src/test/unit/remoteBranchConflictPreview.test.ts
+++ b/src/test/unit/remoteBranchConflictPreview.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { AUTO_STASH_AND_POP_IN_NEW_BRANCH } from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const remoteOnlyBranch: IGitRef = {
+  name: 'feature-x',
+  fullName: 'origin/feature-x',
+  remote: 'origin',
+  isTag: false,
+} as unknown as IGitRef;
+
+const localBranch: IGitRef = {
+  name: 'feature-x',
+  fullName: 'feature-x',
+  remote: false,
+  isTag: false,
+} as unknown as IGitRef;
+
+function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    isWorkdirHasChanges: async () => true,
+    getStashConflictPreview: async () => [],
+    createStash: async () => {},
+    checkout: async () => {},
+    hasUpstreamBranch: async () => false,
+    isStashWithMessageExists: async () => false,
+    popStash: async () => {},
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+describe('AutoStashService conflict preview ref resolution', () => {
+  it('uses the fully-qualified remote ref (not the bare branch name) when previewing conflicts for a remote-only branch', async () => {
+    const previewCalls: string[] = [];
+    const git = makeGitStub({
+      getStashConflictPreview: (async (ref: string) => {
+        previewCalls.push(ref);
+        return ['conflicting-file.ts'];
+      }) as unknown as GitExecutor['getStashConflictPreview'],
+    });
+
+    const originalShowWarningMessage = vscode.window.showWarningMessage.bind(vscode.window);
+    let warningShown = false;
+    (vscode.window as any).showWarningMessage = async () => {
+      warningShown = true;
+      return 'Continue';
+    };
+
+    try {
+      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+      const outcome = await service.checkoutAndStashChanges(
+        git,
+        'main',
+        remoteOnlyBranch,
+        AUTO_STASH_AND_POP_IN_NEW_BRANCH
+      );
+
+      assert.deepStrictEqual(previewCalls, ['origin/feature-x']);
+      assert.strictEqual(warningShown, true, 'conflict-confirmation dialog should be shown when conflicts are returned');
+      assert.strictEqual(outcome, 'completed');
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
+  it('uses the plain branch name when previewing conflicts for a local branch (no behavior change)', async () => {
+    const previewCalls: string[] = [];
+    const git = makeGitStub({
+      getStashConflictPreview: (async (ref: string) => {
+        previewCalls.push(ref);
+        return [];
+      }) as unknown as GitExecutor['getStashConflictPreview'],
+    });
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+    const outcome = await service.checkoutAndStashChanges(
+      git,
+      'main',
+      localBranch,
+      AUTO_STASH_AND_POP_IN_NEW_BRANCH
+    );
+
+    assert.deepStrictEqual(previewCalls, ['feature-x']);
+    assert.strictEqual(outcome, 'completed');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a silent conflict-prediction bypass: when checking out a remote-only branch (e.g. `origin/feature-x` with no local `feature-x`), `doAutoStashAndPopInNewBranch` called `git.getStashConflictPreview(nextBranch)` with the bare branch name. `git merge-tree` cannot resolve that bare name for a remote-only ref, exits 128, and `gitExecutor.ts` treats any non-1 exit code as "preview unavailable" and returns `[]` — silently reporting "no conflicts" even when real conflicts exist.
- `checkoutAndStashChanges` now computes `previewRef = nextBranch.remote ? nextBranch.fullName : nextBranch.name` (mirroring the existing pattern in `moveToNewWorktreeCommand/index.ts`) and threads it into `doAutoStashAndPopInNewBranch` as a new parameter, separate from the branch name used for `git checkout`/`git branch`.
- To test manually: create a remote-only branch scenario (a branch that exists on `origin` but not locally), make local working-tree changes, then run "Checkout To..." with the `autoStashAndPop` mode targeting that remote branch. The conflict-preview dialog should now correctly reflect true conflicts before the stash is popped.

## Test plan
- [x] Unit/integration tests pass (`yarn test`)
- [x] Type check passes (`yarn compile`)
- [x] Added `src/test/unit/remoteBranchConflictPreview.test.ts`: asserts the preview is called with `origin/feature-x` for a remote-only ref and reaches the conflict-confirmation dialog; regression test confirms local-branch behavior (`getStashConflictPreview` called with bare name) is unchanged.