### PR TITLE
fix(pr-clone): resolve default target branch from PR base, not head

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
         "git-smart-checkout.defaultTargetBranch": {
           "type": "string",
           "default": "main",
-          "description": "Default target branch for PR cloning. Leave empty to use the first available branch."
+          "description": "Default target branch for PR cloning. Leave empty to use the original PR's base branch."
         },
         "git-smart-checkout.defaultWorktreeDirectory": {
           "type": "string",

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -239,3 +239,119 @@ describe('PrCloneWebViewProvider fetch error handling', () => {
     }
   });
 });
+
+describe('PrCloneWebViewProvider default target branch resolution', () => {
+  async function runFetchPR(options: {
+    defaultTargetBranch: string;
+    branches: string[];
+    prBaseRef?: string;
+  }): Promise<{ messages: unknown[]; errors: string[] }> {
+    const messages: unknown[] = [];
+    const errors: string[] = [];
+    const originalShowErrorMessage = vscode.window.showErrorMessage.bind(vscode.window);
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      errors.push(message);
+      return 'OK';
+    };
+
+    const pr = createPullRequest(42);
+    if (options.prBaseRef !== undefined) {
+      pr.base = { ref: options.prBaseRef };
+    }
+
+    const ghClient = new GitHubClient('owner', 'repo');
+    ghClient.fetchPullRequest = async () => pr;
+    ghClient.fetchPullRequestCommits = async () => [];
+    ghClient.fetchCommitsDetails = async () => [];
+    ghClient.fetchPullRequestTemplate = async () => undefined;
+
+    const provider = new PrCloneWebViewProvider(
+      {} as vscode.ExtensionContext,
+      mockLogService,
+      {
+        get: () => ({
+          defaultTargetBranch: options.defaultTargetBranch,
+          prBranchPrefix: '',
+        }),
+      } as unknown as ConfigurationManager,
+      createPrCloneService(ghClient, {
+        fetchPullRequestHead: async () => {},
+        getAllRefListExtended: async () =>
+          options.branches.map((name) => ({ name, remote: false, isTag: false })),
+      })
+    );
+    (provider as any).webviewView = {
+      webview: {
+        postMessage: async (message: unknown) => {
+          messages.push(message);
+          return true;
+        },
+      },
+    };
+
+    try {
+      await (provider as any).handleFetchPR('42');
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    }
+
+    return { messages, errors };
+  }
+
+  function getShowPrDataMessage(messages: unknown[]): any {
+    return messages.find(
+      (message: any) => message.command === WebviewCommand.SHOW_PR_DATA
+    );
+  }
+
+  it('uses the configured branch when it exists', async () => {
+    const { messages, errors } = await runFetchPR({
+      defaultTargetBranch: 'develop',
+      branches: ['main', 'develop'],
+      prBaseRef: 'main',
+    });
+
+    assert.deepStrictEqual(errors, []);
+    const showPrData = getShowPrDataMessage(messages);
+    assert.ok(showPrData, 'expected SHOW_PR_DATA message');
+    assert.strictEqual(showPrData.defaultTargetBranch, 'develop');
+  });
+
+  it('triggers invalid-branch handling when the configured branch does not exist', async () => {
+    const { messages, errors } = await runFetchPR({
+      defaultTargetBranch: 'release/missing',
+      branches: ['main'],
+      prBaseRef: 'main',
+    });
+
+    assert.strictEqual(errors.length, 1);
+    assert.match(errors[0], /release\/missing.*does not exist/);
+    assert.strictEqual(getShowPrDataMessage(messages), undefined);
+  });
+
+  it('falls back to the PR base branch when config is empty and the base branch exists', async () => {
+    const { messages, errors } = await runFetchPR({
+      defaultTargetBranch: '',
+      branches: ['master', 'develop'],
+      prBaseRef: 'develop',
+    });
+
+    assert.deepStrictEqual(errors, []);
+    const showPrData = getShowPrDataMessage(messages);
+    assert.ok(showPrData, 'expected SHOW_PR_DATA message');
+    assert.strictEqual(showPrData.defaultTargetBranch, 'develop');
+  });
+
+  it('falls back to the first available branch when config is empty and the PR base branch is missing locally', async () => {
+    const { messages, errors } = await runFetchPR({
+      defaultTargetBranch: '',
+      branches: ['master', 'develop'],
+      prBaseRef: 'release/not-local',
+    });
+
+    assert.deepStrictEqual(errors, []);
+    const showPrData = getShowPrDataMessage(messages);
+    assert.ok(showPrData, 'expected SHOW_PR_DATA message');
+    assert.strictEqual(showPrData.defaultTargetBranch, 'master');
+  });
+});

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -339,18 +339,28 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
     // Get default target branch and PR branch prefix from configuration
     const config = this.configurationManager.get();
-    const defaultTargetBranch = config.defaultTargetBranch || 'main';
     const prBranchPrefix = config.prBranchPrefix || '';
 
-    // Validate that the default target branch exists in available branches
-    if (
-      defaultTargetBranch &&
-      defaultTargetBranch.trim() &&
-      !branches.includes(defaultTargetBranch)
-    ) {
-      await this.handleInvalidDefaultBranch(defaultTargetBranch);
+    // Resolve the effective default target branch in priority order:
+    // 1. explicitly configured branch (if it still exists)
+    // 2. the original PR's base branch (if it exists locally)
+    // 3. the first available branch
+    const configuredTargetBranch = config.defaultTargetBranch?.trim();
+
+    // Only treat this as an error when the user explicitly configured a branch
+    // that no longer exists - never for the empty/auto-resolved case.
+    if (configuredTargetBranch && !branches.includes(configuredTargetBranch)) {
+      await this.handleInvalidDefaultBranch(configuredTargetBranch);
       return;
     }
+
+    const defaultTargetBranch =
+      (configuredTargetBranch &&
+        branches.includes(configuredTargetBranch) &&
+        configuredTargetBranch) ||
+      (prData.base?.ref && branches.includes(prData.base.ref) && prData.base.ref) ||
+      branches[0] ||
+      '';
 
     this.webviewView.webview.postMessage({
       command: WebviewCommand.SHOW_PR_DATA,

--- a/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
@@ -47,7 +47,7 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
     if (defaultTargetBranch && defaultTargetBranch.trim()) {
       return defaultTargetBranch;
     }
-    return prData.head.ref || branches[0] || 'main';
+    return prData.base?.ref || branches[0] || 'main';
   });
   
   // Create the prefix - add "/" if the prefix doesn't end with "/" and is not empty


### PR DESCRIPTION
## Summary
- Fixes two related defects in PR Clone's target-branch resolution (issue 8 in REVIEW_WITH_FIXES.md):
  1. An empty `defaultTargetBranch` setting previously coerced to `'main'` in `PrCloneWebViewProvider.updateWebviewWithPRData`, so fetching a PR on a repo whose default branch is `master`/`develop` aborted with "Default target branch 'main' does not exist" even though the user never configured anything.
  2. The webview form (`PrCloneForm`) initialized the target-branch fallback to `prData.head.ref` — the PR's *source* branch — instead of its base branch, risking a nonsense PR created against the original feature branch.
- New resolution order: explicitly configured branch (if it still exists) > the PR's actual base branch (if present locally) > the first available branch. The "invalid default branch" warning now only fires when the user explicitly configured a branch that no longer exists, never for the empty/auto case.
- Updated the `defaultTargetBranch` setting description in `package.json` to say "Leave empty to use the original PR's base branch."
- Added unit tests covering the full resolution matrix (configured+valid, configured+invalid, empty+base-exists, empty+base-missing).

To test manually: set `defaultTargetBranch` to empty (or to `master` on a repo whose branches don't include `main`), fetch a PR, and confirm the target branch dropdown pre-fills with the PR's actual base branch instead of erroring or defaulting to the PR's feature branch.

## Test plan
- [x] Unit tests pass (`yarn test`, `yarn test:unit`)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host