### PR TITLE
fix(auto-stash): re-resolve stale stash@{N} selector before pop/drop/apply

### DIFF
--- a/src/commands/manageAutoStashesCommand/index.ts
+++ b/src/commands/manageAutoStashesCommand/index.ts
@@ -159,18 +159,24 @@ export class ManageAutoStashesCommand extends BaseCommand {
     action: StashAction
   ): Promise<void> {
     switch (action) {
-      case 'apply':
-        await git.applyStash(stash.selector);
+      case 'apply': {
+        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+        await git.applyStash(selector);
         await vscode.window.showInformationMessage('Auto-stash applied.', 'OK');
         return;
-      case 'pop':
-        await git.popStashBySelector(stash.selector);
+      }
+      case 'pop': {
+        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+        await git.popStashBySelector(selector);
         await vscode.window.showInformationMessage('Auto-stash popped.', 'OK');
         return;
-      case 'drop':
-        await git.dropStash(stash.selector);
+      }
+      case 'drop': {
+        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+        await git.dropStash(selector);
         await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
         return;
+      }
       case 'diff': {
         const patch = await git.getStashPatch(stash.selector);
         if (!patch) {

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -582,6 +582,32 @@ export class GitExecutor {
     return stdout.trim().length !== 0;
   }
 
+  /**
+   * A `stash@{N}` selector is positional: if any stash is created or removed
+   * elsewhere between listing and acting on it, the index can silently point
+   * at a different stash. This re-verifies the selector still resolves to the
+   * expected commit hash and, if not, re-lists stashes to find the selector
+   * that now matches the hash.
+   */
+  async resolveStashSelector(selector: string, expectedHash: string): Promise<string> {
+    try {
+      const { stdout } = await this.#execGitCommand(['rev-parse', selector]);
+      if (stdout.trim() === expectedHash) {
+        return selector;
+      }
+    } catch {
+      // fall through to re-list and resolve by hash
+    }
+
+    const stashes = await this.listStashes();
+    const match = stashes.find((stash) => stash.hash === expectedHash);
+    if (!match) {
+      throw new Error('The selected stash no longer exists.');
+    }
+
+    return match.selector;
+  }
+
   async getStagedChangesPatch(): Promise<string> {
     const { stdout } = await this.#execGitCommand(['diff', '--cached', '--binary']);
     return stdout;

--- a/src/test/unit/resolveStashSelector.test.ts
+++ b/src/test/unit/resolveStashSelector.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert';
+
+import { createTestRepo, TestRepo } from '../e2e/helpers/gitTestRepo';
+
+describe('GitExecutor.resolveStashSelector', () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('returns the selector unchanged when it still points at the expected hash', async () => {
+    repo.makeChange('file1.txt', 'first stash change\n');
+    await repo.git.createStash('auto-stash-main-1', 'all');
+
+    const [stash] = await repo.git.listStashes();
+
+    const resolved = await repo.git.resolveStashSelector(stash.selector, stash.hash);
+
+    assert.strictEqual(resolved, stash.selector);
+  });
+
+  it('re-resolves the selector by hash when the stash index has shifted', async () => {
+    // Create two stashes: stash@{1} is the older one we will "remember".
+    repo.makeChange('file1.txt', 'older stash change\n');
+    await repo.git.createStash('auto-stash-main-older', 'all');
+
+    repo.makeChange('file1.txt', 'newer stash change\n');
+    await repo.git.createStash('auto-stash-main-newer', 'all');
+
+    const stashesBefore = await repo.git.listStashes();
+    assert.strictEqual(stashesBefore.length, 2);
+
+    const older = stashesBefore.find((s) => s.message === 'auto-stash-main-older');
+    assert.ok(older, 'expected to find the older stash');
+    assert.strictEqual(older!.selector, 'stash@{1}');
+
+    // Simulate the list shifting elsewhere: drop the newer stash (stash@{0}),
+    // which shifts the older stash from stash@{1} down to stash@{0}.
+    await repo.git.dropStash('stash@{0}');
+
+    const resolved = await repo.git.resolveStashSelector(older!.selector, older!.hash);
+
+    assert.strictEqual(resolved, 'stash@{0}');
+
+    const stashesAfter = await repo.git.listStashes();
+    const matched = stashesAfter.find((s) => s.selector === resolved);
+    assert.strictEqual(matched?.hash, older!.hash);
+  });
+
+  it('throws a friendly error when the stash no longer exists', async () => {
+    repo.makeChange('file1.txt', 'a stash that will be dropped\n');
+    await repo.git.createStash('auto-stash-main-gone', 'all');
+
+    const [stash] = await repo.git.listStashes();
+    await repo.git.dropStash(stash.selector);
+
+    await assert.rejects(
+      repo.git.resolveStashSelector(stash.selector, stash.hash),
+      /The selected stash no longer exists\./
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `stash@{N}` is a positional reference. The auto-stash manager lists stashes once per loop iteration, then the user picks an action from a QuickPick that can stay open indefinitely. If any stash is created or dropped elsewhere in the meantime (another terminal, another VS Code window, or another GSC command), the index shifts and acting on the captured `stash@{N}` can silently apply, pop, or permanently **drop the wrong stash**.
- Adds `GitExecutor.resolveStashSelector(selector, expectedHash)`: verifies the selector still resolves (`git rev-parse`) to the stash's original commit hash, and if not, re-lists stashes and finds the selector that now matches the hash. Throws a friendly error if the hash no longer exists anywhere.
- `ManageAutoStashesCommand.runAction` now resolves the selector fresh immediately before `apply`/`pop`/`drop`, instead of using the value captured at list time.
- To test manually: open the auto-stash manager, select a stash, and — while the action QuickPick is open — drop or create another stash from a separate terminal so indices shift, then choose Drop; verify the originally-selected stash (not a different one) is what gets removed.

## Test plan
- [x] Unit tests pass (`yarn test`) — added `src/test/unit/resolveStashSelector.test.ts` covering: selector unchanged when still valid, re-resolution by hash when the index shifts, and the friendly error when the stash is gone.
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host