### PR TITLE
fix(checkout): treat picker/input dismissal as cancellation, not an error

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -10,6 +10,7 @@ import { LoggingService } from '../../logging/loggingService';
 import { AutoStashService } from '../../services/autoStashService';
 import { RefDetailsCache } from '../../services/refDetailsCache';
 import { getRepoId } from '../../utils/getRepoId';
+import { UserCancelledError } from '../../utils/userCancelledError';
 import { BaseCommand } from '../command';
 import { attachLazyEnrichment } from '../utils/enrichOnActive';
 import { prepareInitialRefDetails, refreshRemainingRefDetails } from '../utils/refDetailsPrefetch';
@@ -60,6 +61,10 @@ export class CheckoutToCommand extends BaseCommand {
       // label (which broke tags, whose label is "$(tag) v1.2.3").
       const newBranch = selectedRef ?? (await this.getTargetBranch(git, selection, branchList));
 
+      if (!newBranch) {
+        return;
+      }
+
       if (!isNewBranch) {
         const conflictWorktree = await findWorktreeForBranch(git, newBranch.name);
         if (conflictWorktree) {
@@ -94,6 +99,10 @@ export class CheckoutToCommand extends BaseCommand {
         );
       }
     } catch (error) {
+      if (error instanceof UserCancelledError) {
+        // User dismissed a picker (e.g. the multi-root repository picker) — not an error.
+        return;
+      }
       if (error instanceof Error) {
         const message = error.message;
         message && (await vscode.window.showErrorMessage(message, 'OK'));
@@ -309,7 +318,7 @@ export class CheckoutToCommand extends BaseCommand {
     git: GitExecutor,
     selection: string,
     branchList: IGitRef[]
-  ): Promise<IGitRef> {
+  ): Promise<IGitRef | undefined> {
     switch (selection) {
       case LABEL_CREATE_NEW_BRANCH:
         return await this.createNewBranch(git);
@@ -320,14 +329,15 @@ export class CheckoutToCommand extends BaseCommand {
     }
   }
 
-  async createNewBranch(git: GitExecutor): Promise<IGitRef> {
-    const newBranchName = await vscode.window.showInputBox({
+  async createNewBranch(git: GitExecutor): Promise<IGitRef | undefined> {
+    const newBranchName = await this.showInputBox({
       placeHolder: 'Branch name',
       prompt: 'Please provide a new branch name',
     });
 
     if (!newBranchName) {
-      throw new Error('New branch name is not provided.');
+      // User pressed Escape / dismissed the input box — not an error.
+      return undefined;
     }
 
     try {
@@ -342,21 +352,26 @@ export class CheckoutToCommand extends BaseCommand {
     }
   }
 
-  async createNewBranchFrom(git: GitExecutor, branchList: IGitRef[]) {
+  async createNewBranchFrom(
+    git: GitExecutor,
+    branchList: IGitRef[]
+  ): Promise<IGitRef | undefined> {
     const repoId = await getRepoId(git);
     const baseRef = await this.pickBaseRef(branchList, repoId);
 
     if (!baseRef) {
-      throw new Error('Base branch name is not provided.');
+      // User dismissed the base-ref picker — not an error.
+      return undefined;
     }
 
-    const newBranchName = await vscode.window.showInputBox({
+    const newBranchName = await this.showInputBox({
       placeHolder: 'Branch name',
       prompt: 'Please provide a new branch name',
     });
 
     if (!newBranchName) {
-      throw new Error('New branch name is not provided.');
+      // User pressed Escape / dismissed the input box — not an error.
+      return undefined;
     }
 
     try {
@@ -387,7 +402,7 @@ export class CheckoutToCommand extends BaseCommand {
    * refs are grouped (local / remote / tags), preferred refs float to the top
    * of each group, and the inline star button toggles a ref's preferred state.
    */
-  private async pickBaseRef(
+  protected async pickBaseRef(
     branchList: IGitRef[],
     repoId: string
   ): Promise<IGitRef | undefined> {

--- a/src/commands/commandManager.ts
+++ b/src/commands/commandManager.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { showErrorMessageWithIssueAction } from '../utils/errorIssueNotification';
+import { UserCancelledError } from '../utils/userCancelledError';
 import { ICommand } from './command';
 
 export class CommandManager {
@@ -24,6 +25,9 @@ export class CommandManager {
         try {
           await command.execute(...args);
         } catch (error) {
+          if (error instanceof UserCancelledError) {
+            return;
+          }
           const errorMessage = error instanceof Error ? error.message : String(error);
           await showErrorMessageWithIssueAction(`Command failed: ${errorMessage}`, 'OK');
           console.error(`Error executing command ${commandId}:`, error);

--- a/src/test/e2e/multiRepoOperations.test.ts
+++ b/src/test/e2e/multiRepoOperations.test.ts
@@ -226,7 +226,7 @@ describe('Multi-repository workspace operations', () => {
   });
 
   describe('repo picker cancelled', () => {
-    it('surfaces an error and leaves both repositories unchanged', async () => {
+    it('is treated as a plain cancellation (no error) and leaves both repositories unchanged', async () => {
       const repoA = createTestRepo();
       const repoB = createTestRepo();
       const errors = stubErrorMessages();
@@ -242,9 +242,12 @@ describe('Multi-repository workspace operations', () => {
           await vscode.commands.executeCommand(commandId('checkoutTo'));
           await delay();
 
-          assert.ok(
-            errors.messages.some((m) => m.includes('No repository selected')),
-            'should report that no repository was selected'
+          // Dismissing the repository picker is a user cancellation, not an
+          // error — no notification should be shown.
+          assert.strictEqual(
+            errors.messages.length,
+            0,
+            `should not show an error notification, got: ${JSON.stringify(errors.messages)}`
           );
           assert.strictEqual(await repoA.git.getCurrentBranch(), repoA.mainBranch);
           assert.strictEqual(await repoB.git.getCurrentBranch(), repoB.mainBranch);

--- a/src/test/unit/checkoutToCreateBranchCancellation.test.ts
+++ b/src/test/unit/checkoutToCreateBranchCancellation.test.ts
@@ -1,0 +1,169 @@
+import * as assert from 'assert';
+
+import {
+  CheckoutToCommand,
+  LABEL_CREATE_NEW_BRANCH,
+  LABEL_CREATE_NEW_BRANCH_FROM,
+} from '../../commands/checkoutToCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+import { IGitRef } from '../../common/git/types';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const baseRef: IGitRef = { name: 'main', fullName: 'main', authorName: '', isTag: false };
+
+/** Escape pressed at the "Create new branch..." name prompt. */
+class EscapeAtBranchNameCommand extends CheckoutToCommand {
+  createBranchCalled = false;
+  errorShown = false;
+
+  constructor(autoStashService: AutoStashService) {
+    super({} as ConfigurationManager, mockLogService, autoStashService);
+  }
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {
+      repositoryPath: '/repo',
+      getCurrentBranch: async () => 'main',
+      worktreeListDetailed: async () => [],
+      createBranch: async () => {
+        this.createBranchCalled = true;
+        return baseRef;
+      },
+    } as unknown as GitExecutor;
+  }
+
+  async getSelectedOption() {
+    return {
+      currentBranch: 'main',
+      selection: LABEL_CREATE_NEW_BRANCH,
+      branchList: [] as IGitRef[],
+    };
+  }
+
+  protected async showInputBox(): Promise<string | undefined> {
+    // Simulate the user pressing Escape.
+    return undefined;
+  }
+
+  protected async showErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+    this.errorShown = true;
+    return undefined;
+  }
+}
+
+/** Escape pressed at the base-ref picker of "Create new branch from...". */
+class EscapeAtBaseRefCommand extends CheckoutToCommand {
+  createBranchCalled = false;
+  errorShown = false;
+
+  constructor(autoStashService: AutoStashService) {
+    super({} as ConfigurationManager, mockLogService, autoStashService);
+  }
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {
+      repositoryPath: '/repo',
+      getCurrentBranch: async () => 'main',
+      getRepoInfo: async () => undefined,
+      worktreeListDetailed: async () => [],
+      createBranch: async () => {
+        this.createBranchCalled = true;
+        return baseRef;
+      },
+    } as unknown as GitExecutor;
+  }
+
+  async getSelectedOption() {
+    return {
+      currentBranch: 'main',
+      selection: LABEL_CREATE_NEW_BRANCH_FROM,
+      branchList: [baseRef],
+    };
+  }
+
+  protected async pickBaseRef(): Promise<IGitRef | undefined> {
+    // Simulate the user dismissing the base-ref quick pick.
+    return undefined;
+  }
+
+  protected async showErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+    this.errorShown = true;
+    return undefined;
+  }
+}
+
+/** Escape pressed at the branch-name prompt of "Create new branch from...", after a base ref was picked. */
+class EscapeAtBranchNameFromCommand extends CheckoutToCommand {
+  createBranchCalled = false;
+  errorShown = false;
+
+  constructor(autoStashService: AutoStashService) {
+    super({} as ConfigurationManager, mockLogService, autoStashService);
+  }
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {
+      repositoryPath: '/repo',
+      getCurrentBranch: async () => 'main',
+      getRepoInfo: async () => undefined,
+      worktreeListDetailed: async () => [],
+      createBranch: async () => {
+        this.createBranchCalled = true;
+        return baseRef;
+      },
+    } as unknown as GitExecutor;
+  }
+
+  async getSelectedOption() {
+    return {
+      currentBranch: 'main',
+      selection: LABEL_CREATE_NEW_BRANCH_FROM,
+      branchList: [baseRef],
+    };
+  }
+
+  protected async pickBaseRef(): Promise<IGitRef | undefined> {
+    return baseRef;
+  }
+
+  protected async showInputBox(): Promise<string | undefined> {
+    return undefined;
+  }
+
+  protected async showErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+    this.errorShown = true;
+    return undefined;
+  }
+}
+
+describe('CheckoutToCommand user-cancellation (create branch flows)', () => {
+  it('does not error when Escape is pressed at "Create new branch..."', async () => {
+    const command = new EscapeAtBranchNameCommand({} as AutoStashService);
+
+    await command.execute();
+
+    assert.strictEqual(command.createBranchCalled, false);
+    assert.strictEqual(command.errorShown, false);
+  });
+
+  it('does not error when the base-ref picker is dismissed in "Create new branch from..."', async () => {
+    const command = new EscapeAtBaseRefCommand({} as AutoStashService);
+
+    await command.execute();
+
+    assert.strictEqual(command.createBranchCalled, false);
+    assert.strictEqual(command.errorShown, false);
+  });
+
+  it('does not error when Escape is pressed at the name prompt in "Create new branch from..."', async () => {
+    const command = new EscapeAtBranchNameFromCommand({} as AutoStashService);
+
+    await command.execute();
+
+    assert.strictEqual(command.createBranchCalled, false);
+    assert.strictEqual(command.errorShown, false);
+  });
+});

--- a/src/test/unit/commandManagerCancellation.test.ts
+++ b/src/test/unit/commandManagerCancellation.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { CommandManager } from '../../commands/commandManager';
+import { ICommand } from '../../commands/command';
+import { UserCancelledError } from '../../utils/userCancelledError';
+import * as errorIssueNotification from '../../utils/errorIssueNotification';
+
+describe('CommandManager user-cancellation handling', () => {
+  it('swallows UserCancelledError silently, without an error notification', async () => {
+    const manager = new CommandManager();
+    const commandId = 'gitSmartCheckout.test.userCancelledCommand';
+
+    const command: ICommand = {
+      execute: async () => {
+        throw new UserCancelledError();
+      },
+    };
+    manager.registerCommand(commandId, command);
+
+    const originalShow = errorIssueNotification.showErrorMessageWithIssueAction;
+    let notificationShown = false;
+    (
+      errorIssueNotification as unknown as {
+        showErrorMessageWithIssueAction: typeof originalShow;
+      }
+    ).showErrorMessageWithIssueAction = async (message: string, ...items: string[]) => {
+      notificationShown = true;
+      return undefined;
+    };
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+    try {
+      manager.registerAll(context);
+      await vscode.commands.executeCommand(commandId);
+
+      assert.strictEqual(notificationShown, false, 'should not show an error notification');
+    } finally {
+      (
+        errorIssueNotification as unknown as {
+          showErrorMessageWithIssueAction: typeof originalShow;
+        }
+      ).showErrorMessageWithIssueAction = originalShow;
+      manager.dispose();
+    }
+  });
+
+  it('still shows an error notification for a genuine failure', async () => {
+    const manager = new CommandManager();
+    const commandId = 'gitSmartCheckout.test.genuineFailureCommand';
+
+    const command: ICommand = {
+      execute: async () => {
+        throw new Error('boom');
+      },
+    };
+    manager.registerCommand(commandId, command);
+
+    const originalShow = errorIssueNotification.showErrorMessageWithIssueAction;
+    let notificationMessage: string | undefined;
+    (
+      errorIssueNotification as unknown as {
+        showErrorMessageWithIssueAction: typeof originalShow;
+      }
+    ).showErrorMessageWithIssueAction = async (message: string, ...items: string[]) => {
+      notificationMessage = message;
+      return undefined;
+    };
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+    try {
+      manager.registerAll(context);
+      await vscode.commands.executeCommand(commandId);
+
+      assert.strictEqual(notificationMessage, 'Command failed: boom');
+    } finally {
+      (
+        errorIssueNotification as unknown as {
+          showErrorMessageWithIssueAction: typeof originalShow;
+        }
+      ).showErrorMessageWithIssueAction = originalShow;
+      manager.dispose();
+    }
+  });
+});

--- a/src/test/unit/getGitExecutorCancellation.test.ts
+++ b/src/test/unit/getGitExecutorCancellation.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import * as commonVscode from '../../common/vscode';
+import { getGitExecutor } from '../../utils/getGitExecutor';
+import { UserCancelledError } from '../../utils/userCancelledError';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('getGitExecutor multi-root repository picker cancellation', () => {
+  it('throws UserCancelledError (not a plain Error) when the repository picker is dismissed', async () => {
+    const originalGetFolders = commonVscode.getWorkspaceFoldersFormatted;
+    const originalShowQuickPick = vscode.window.showQuickPick;
+
+    (commonVscode as unknown as { getWorkspaceFoldersFormatted: () => unknown }).getWorkspaceFoldersFormatted =
+      () => [
+        { name: 'repo-a', path: '/tmp/gsc-repo-a' },
+        { name: 'repo-b', path: '/tmp/gsc-repo-b' },
+      ];
+    (vscode.window as unknown as { showQuickPick: () => Promise<undefined> }).showQuickPick = async () =>
+      undefined;
+
+    try {
+      await assert.rejects(
+        () => getGitExecutor(mockLogService),
+        (error: unknown) => error instanceof UserCancelledError
+      );
+    } finally {
+      (
+        commonVscode as unknown as { getWorkspaceFoldersFormatted: typeof originalGetFolders }
+      ).getWorkspaceFoldersFormatted = originalGetFolders;
+      (vscode.window as unknown as { showQuickPick: typeof originalShowQuickPick }).showQuickPick =
+        originalShowQuickPick;
+    }
+  });
+});

--- a/src/utils/getGitExecutor.ts
+++ b/src/utils/getGitExecutor.ts
@@ -4,6 +4,7 @@ import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
 import { getWorkspaceFoldersFormatted } from '../common/vscode';
 import { LoggingService } from '../logging/loggingService';
 import { execCommand } from './execCommand';
+import { UserCancelledError } from './userCancelledError';
 
 type RepositoryQuickPickItem = QuickPickItem & {
   path: string;
@@ -58,7 +59,7 @@ export const getGitExecutor = async (
   });
 
   if (!selectedOption) {
-    throw new Error('No repository selected');
+    throw new UserCancelledError('No repository selected');
   }
 
   const repositoryRoot = await resolveGitRepositoryRoot(

--- a/src/utils/userCancelledError.ts
+++ b/src/utils/userCancelledError.ts
@@ -1,0 +1,11 @@
+/**
+ * Sentinel error thrown when the user dismisses a picker/input box (e.g. by
+ * pressing Escape) instead of an actual failure. Callers should treat this
+ * as plain cancellation — no error notification, no exception capture.
+ */
+export class UserCancelledError extends Error {
+  constructor(message = 'Operation cancelled by the user') {
+    super(message);
+    this.name = 'UserCancelledError';
+  }
+}


### PR DESCRIPTION
## Summary
- Pressing Escape at the "Create new branch..." / "Create new branch from..." prompts, or dismissing the multi-root repository picker, previously threw plain `Error`s that were caught by the generic command-error handler and surfaced as a red error toast (complete with a "Copy and open issue" action) plus `captureException`/console noise. These are user cancellations, not failures.
- `createNewBranch` / `createNewBranchFrom` in `checkoutToCommand` now return `undefined` on dismissal instead of throwing; `execute()` early-returns silently when the target branch is `undefined`.
- Added a `UserCancelledError` sentinel (`src/utils/userCancelledError.ts`, mirroring the existing `OperationCancelledError` pattern in `prCloneTempWorktreeService.ts`). `getGitExecutor` now throws it when the multi-root repository picker is dismissed instead of a generic `Error('No repository selected')`.
- `CommandManager.registerAll`'s catch handler, and `CheckoutToCommand.execute()`'s own local catch, now silently `return` when `error instanceof UserCancelledError` — no toast, no `captureException`, no console noise.
- Refactored `createNewBranch`/`createNewBranchFrom` to use the overridable `this.showInputBox` helper (and made `pickBaseRef` protected) so these cancellation paths are unit-testable without driving real VS Code UI.

## How to test manually
1. Run the extension (F5), open "Checkout to...", pick "Create new branch...", press Escape at the name prompt → no error notification appears.
2. Same for "Create new branch from...": dismiss the base-ref picker, and separately dismiss the name prompt after picking a base ref → no error notification in either case.
3. In a multi-root workspace, run any git-smart-checkout command and dismiss the repository picker → no "Command failed: No repository selected" toast.

## Test plan
- [x] Unit tests pass (`yarn test:unit` — 406 passing; 2 pre-existing failures in `AutoStashService conflict preview ref resolution` confirmed unrelated/pre-existing on `main` HEAD)
- [x] Type check passes (`yarn compile`)
- [x] New unit tests cover: Escape at "Create new branch..." name prompt, dismissing the base-ref picker in "Create new branch from...", Escape at the name prompt after picking a base ref, `getGitExecutor` throwing `UserCancelledError` on repository-picker dismissal, and `CommandManager` swallowing `UserCancelledError` silently (while still surfacing genuine errors)