### PR TITLE
fix(config): correct useInPlaceCherryPick and defaultWorktreeDirectory descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -352,7 +352,7 @@
         "git-smart-checkout.defaultWorktreeDirectory": {
           "type": "string",
           "default": "",
-          "description": "Directory where PR clone temporary worktrees are created. Leave empty to create them one level up from the current repository."
+          "description": "Base directory where 'Move to new worktree' and 'PR Review in Worktree' create worktrees. Supports ~ expansion. Leave empty to use the repository's parent directory."
         },
         "git-smart-checkout.prBranchPrefix": {
           "type": "string",
@@ -367,7 +367,7 @@
         "git-smart-checkout.useInPlaceCherryPick": {
           "type": "boolean",
           "default": true,
-          "description": "Use in-place cherry-pick instead of temporary worktree for PR cloning (this method doesn't allow to solve conflicts, so use when completely sure that there will be no conflicts during cherry pick"
+          "markdownDescription": "PR clone strategy. **Enabled (default):** cherry-pick in the current working tree — your changes are auto-stashed, and merge conflicts can be resolved interactively. **Disabled:** cherry-pick in a temporary worktree — your working tree is never touched, but the clone fails if any commit conflicts."
         },
         "git-smart-checkout.pullAfterCheckout": {
           "type": "string",


### PR DESCRIPTION
## Summary
- `useInPlaceCherryPick`'s description stated the exact opposite of reality: the in-place strategy is actually the one supporting interactive conflict resolution (`PrCloneInPlaceService.cherryPickNext` pauses on conflicts and offers a "Conflicts resolved" action), while the temp-worktree strategy hard-fails on any conflicting commit (`PrCloneTempWorktreeService.cherryPickCommits` throws). Also fixed an unclosed parenthesis in the old text.
- `defaultWorktreeDirectory`'s description falsely claimed it controls where PR-clone temp worktrees are created (those always use `os.tmpdir()`); it actually configures the base directory used by "Move to new worktree" and "PR Review in Worktree" (both call `selectWorktreePath`/`getBaseWorktreeDirectory` in `src/commands/utils/worktreePath.ts`, which supports `~` expansion and falls back to the repo's parent directory when empty).
- To test manually: open VS Code Settings UI, search "git-smart-checkout", and confirm both settings now show the corrected descriptions (with Markdown formatting rendered for `useInPlaceCherryPick`).

## Test plan
- [x] Type check + lint pass (`yarn compile`)
- [x] `package.json` JSON validity verified
- [ ] `yarn test:unit` — pre-existing failure in `remoteBranchConflictPreview.test.ts` (2 tests, `configManager.get is not a function`) unrelated to this change; reproduces identically on `main` before this branch's changes, and is not part of the `Build and Test` / `E2E Tests` CI workflows (which run `build-all` and `test:e2e:ci` respectively, not the `unit` label)
- [x] Manual smoke test: confirmed no other `description`/`markdownDescription` duplication and no stale references to the old text remain in `package.json`