### PR TITLE
fix(templates): resolve branch/tag template tokens against selected repo in multi-root workspaces

### DIFF
--- a/src/commands/createBranchFromTemplateCommand/index.ts
+++ b/src/commands/createBranchFromTemplateCommand/index.ts
@@ -38,7 +38,6 @@ export class CreateBranchFromTemplateCommand extends BaseCommand {
       await this.showErrorMessage('No workspace folder is open.');
       return;
     }
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
 
     let git: Awaited<ReturnType<typeof this.getGitExecutor>>;
     try {
@@ -48,6 +47,7 @@ export class CreateBranchFromTemplateCommand extends BaseCommand {
       await this.showErrorMessage('Current workspace is not a Git repository.');
       return;
     }
+    const workspaceRoot = git.repositoryPath;
 
     const cfg = this.configManager.get();
     const template = (cfg.branchTemplate ?? '').trim();

--- a/src/commands/createTagFromTemplateCommand/index.ts
+++ b/src/commands/createTagFromTemplateCommand/index.ts
@@ -32,8 +32,6 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
       await this.showErrorMessage('No workspace folder is open.');
       return;
     }
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    log(`Current workspace folder: ${workspaceRoot}`);
 
     let git: Awaited<ReturnType<typeof this.getGitExecutor>>;
     try {
@@ -43,6 +41,8 @@ export class CreateTagFromTemplateCommand extends BaseCommand {
       await this.showErrorMessage('Current workspace is not a Git repository.');
       return;
     }
+    const workspaceRoot = git.repositoryPath;
+    log(`Current workspace folder: ${workspaceRoot}`);
 
     const cfg = this.configManager.get();
     const template = (cfg.tagTemplate ?? '').trim();


### PR DESCRIPTION
## Summary
- In multi-root VS Code workspaces, `{f:...}` (file read) and `{s:...}` (script) tokens in the branch/tag template were resolved against `workspaceFolders[0].uri.fsPath`, even when `getGitExecutor()` prompted the user and returned a *different* repository. This produced wrong version strings / script execution in the wrong directory.
- Fixed both `CreateBranchFromTemplateCommand` and `CreateTagFromTemplateCommand` to derive `workspaceRoot` from the resolved `GitExecutor.repositoryPath` (computed after the git executor/repo picker resolves), instead of always reading workspace folder #1. The existing "no workspace open" guard is unchanged.

## Test plan
- [x] `yarn compile` passes
- [x] `yarn test:unit` — 409 passing; 2 pre-existing failures in `remoteBranchConflictPreview.test.ts` (AutoStashService conflict preview) unrelated to this change, reproducible on `origin/main` HEAD before this patch; not covered by CI (CI's Build-and-Test workflow only runs `yarn build-all`, and unit tests aren't part of any workflow)
- [ ] Manual smoke test: open a multi-root workspace with 2 git repos, set a branch template using `{f:package.json:.version}`, run "Create Branch from Template", pick the *second* repo in the picker, and confirm the version is read from that repo's `package.json`, not the first folder's.