### PR TITLE
fix(test): repair unit-test regression from combining PR #130 and #133

### DIFF
--- a/src/test/unit/remoteBranchConflictPreview.test.ts
+++ b/src/test/unit/remoteBranchConflictPreview.test.ts
@@ -53,7 +53,10 @@ describe('AutoStashService conflict preview ref resolution', () => {
     };
 
     try {
-      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+      const configManager = {
+        get: () => ({ pullAfterCheckout: 'off' }),
+      } as unknown as ConfigurationManager;
+      const service = new AutoStashService(configManager, mockLogService);
       const outcome = await service.checkoutAndStashChanges(
         git,
         'main',
@@ -78,7 +81,10 @@ describe('AutoStashService conflict preview ref resolution', () => {
       }) as unknown as GitExecutor['getStashConflictPreview'],
     });
 
-    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+    const configManager = {
+      get: () => ({ pullAfterCheckout: 'off' }),
+    } as unknown as ConfigurationManager;
+    const service = new AutoStashService(configManager, mockLogService);
     const outcome = await service.checkoutAndStashChanges(
       git,
       'main',


### PR DESCRIPTION
## Summary
- Fixes a real regression on `main`: `src/test/unit/remoteBranchConflictPreview.test.ts` (added in PR #130 for issue 7) constructs `AutoStashService` with a bare `{} as ConfigurationManager` stub. PR #133 (issue 10) later added a `configManager.get()` call inside `AutoStashService`'s post-checkout pull logic (`#maybePullAfterCheckout`). Individually each PR's CI was green, but once both merged to `main`, these two tests started throwing `TypeError: this.configManager.get is not a function`.
- Fix: give the test's `ConfigurationManager` stub a working `get()` returning `{ pullAfterCheckout: 'off' }`, so the post-checkout pull logic is a no-op during these unrelated conflict-preview tests.
- Not part of the numbered issue list in REVIEW_WITH_FIXES.md — discovered while working through it, since CI doesn't currently gate on `yarn test:unit`.

## Test plan
- [x] `yarn test:unit` passes locally (411 passing, was 408 passing + 2 failing before this fix)
- [x] `yarn compile` passes
- [ ] N/A — test-only change, no runtime behavior affected