### PR TITLE
fix(pr-clone): copy reviewers and team reviewers when cloning a PR

### DIFF
--- a/src/common/api/ghClient.ts
+++ b/src/common/api/ghClient.ts
@@ -88,6 +88,8 @@ export class GitHubClient {
    */
   public static readonly MAX_PR_COMMITS = 250;
 
+  private cachedCurrentUserLogin?: Promise<string | undefined>;
+
   constructor(
     private readonly _owner: string,
     private readonly _repo: string,
@@ -320,7 +322,9 @@ export class GitHubClient {
     base: string,
     isDraft: boolean = false,
     labels?: string[],
-    assignees?: string[]
+    assignees?: string[],
+    reviewers?: string[],
+    teamReviewers?: string[]
   ): Promise<GitHubPR> {
     const endpoint = `/repos/${this.owner}/${this.repo}/pulls`;
     const requestBody: any = {
@@ -357,7 +361,36 @@ export class GitHubClient {
       }
     }
 
+    if (reviewers?.length || teamReviewers?.length) {
+      try {
+        await this.makeRequest(
+          `/repos/${this.owner}/${this.repo}/pulls/${newPr.number}/requested_reviewers`,
+          'POST',
+          { reviewers, team_reviewers: teamReviewers }
+        );
+      } catch (error) {
+        this.warn(`Failed to copy reviewers to PR #${newPr.number}:`, error);
+      }
+    }
+
     return newPr;
+  }
+
+  /**
+   * Fetch (and cache) the login of the currently authenticated GitHub user.
+   * Used to filter the authenticated user out of reviewer lists, since GitHub
+   * rejects requests where a PR author is requested as their own reviewer.
+   */
+  public async getCurrentUserLogin(): Promise<string | undefined> {
+    if (!this.cachedCurrentUserLogin) {
+      this.cachedCurrentUserLogin = this.makeRequest<GitHubUser>('/user')
+        .then((user) => user.login)
+        .catch((error) => {
+          this.warn('Failed to fetch authenticated GitHub user:', error);
+          return undefined;
+        });
+    }
+    return this.cachedCurrentUserLogin;
   }
 
   /**

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -361,6 +361,14 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
     const labels = originalPr.labels?.map((label) => label.name) || [];
     const assignees = originalPr.assignees?.map((assignee) => assignee.login) || [];
 
+    // Extract reviewers/team reviewers from original PR, excluding the
+    // authenticated user (GitHub rejects requesting a review from the PR author).
+    const currentUserLogin = await this.ghClient.getCurrentUserLogin();
+    const reviewers = (originalPr.requested_reviewers?.map((reviewer) => reviewer.login) || []).filter(
+      (login) => login !== currentUserLogin
+    );
+    const teamReviewers = originalPr.requested_teams?.map((team) => team.slug) || [];
+
     // Create PR using the GitHub API
     const newPr = await this.ghClient.createPullRequest(
       originalPr.title, // Use original PR title
@@ -369,7 +377,9 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       targetBranch,
       isDraft,
       labels,
-      assignees
+      assignees,
+      reviewers,
+      teamReviewers
     );
 
     this.loggingService.info(`Created PR #${newPr.number}: ${newPr.title}`);

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -275,6 +275,14 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     const labels = originalPr.labels?.map((label) => label.name) || [];
     const assignees = originalPr.assignees?.map((assignee) => assignee.login) || [];
 
+    // Extract reviewers/team reviewers from original PR, excluding the
+    // authenticated user (GitHub rejects requesting a review from the PR author).
+    const currentUserLogin = await this.ghClient.getCurrentUserLogin();
+    const reviewers = (originalPr.requested_reviewers?.map((reviewer) => reviewer.login) || []).filter(
+      (login) => login !== currentUserLogin
+    );
+    const teamReviewers = originalPr.requested_teams?.map((team) => team.slug) || [];
+
     // Create PR using the GitHub API
     const newPr = await this.ghClient.createPullRequest(
       originalPr.title, // Use original PR title
@@ -283,7 +291,9 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
       targetBranch,
       isDraft,
       labels,
-      assignees
+      assignees,
+      reviewers,
+      teamReviewers
     );
 
     this.loggingService.info(`Created PR #${newPr.number}: ${newPr.title}`);

--- a/src/test/unit/ghClient.test.ts
+++ b/src/test/unit/ghClient.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 
 import { GitHubClient } from '../../common/api/ghClient';
 import { GitExecutor } from '../../common/git/gitExecutor';
+import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
 import { PrCloneTempWorktreeService } from '../../services/prCloneTempWorktreeService';
 import { GitHubCommit, GitHubLabel, GitHubPR } from '../../types/dataTypes';
 import { mockLogService } from '../e2e/helpers/mockLogService';
@@ -41,6 +42,14 @@ function createPullRequest(number = 42): GitHubPR {
         avatar_url: 'https://github.com/octocat.png',
       },
     ],
+    requested_reviewers: [
+      {
+        id: 3,
+        login: 'reviewer-one',
+        avatar_url: 'https://github.com/reviewer-one.png',
+      },
+    ],
+    requested_teams: [{ slug: 'core-team' }],
   };
 }
 
@@ -141,10 +150,140 @@ describe('GitHubClient.createPullRequest', () => {
     assert.match(warnings[0].message, /Failed to copy labels to PR #42/);
     assert.match(warnings[1].message, /Failed to copy assignees to PR #42/);
   });
+
+  it('copies reviewers and team reviewers through the requested_reviewers API', async () => {
+    const client = new GitHubClient('owner', 'repo');
+    const newPr = createPullRequest();
+    const requests: RequestCall[] = [];
+
+    (client as any).makeRequest = async (
+      endpoint: string,
+      method?: string,
+      body?: unknown
+    ) => {
+      requests.push({ endpoint, method, body });
+      return newPr;
+    };
+
+    const result = await client.createPullRequest(
+      'Cloned PR',
+      'Description',
+      'feature/cloned',
+      'main',
+      true,
+      [],
+      [],
+      ['reviewer-one'],
+      ['core-team']
+    );
+
+    assert.strictEqual(result, newPr);
+    const reviewerRequest = requests.find((request) =>
+      request.endpoint.endsWith('/requested_reviewers')
+    );
+    assert.deepStrictEqual(reviewerRequest, {
+      endpoint: '/repos/owner/repo/pulls/42/requested_reviewers',
+      method: 'POST',
+      body: { reviewers: ['reviewer-one'], team_reviewers: ['core-team'] },
+    });
+  });
+
+  it('does not call the requested_reviewers API when no reviewers are provided', async () => {
+    const client = new GitHubClient('owner', 'repo');
+    const newPr = createPullRequest();
+    const requests: RequestCall[] = [];
+
+    (client as any).makeRequest = async (
+      endpoint: string,
+      method?: string,
+      body?: unknown
+    ) => {
+      requests.push({ endpoint, method, body });
+      return newPr;
+    };
+
+    await client.createPullRequest(
+      'Cloned PR',
+      'Description',
+      'feature/cloned',
+      'main',
+      true,
+      [],
+      []
+    );
+
+    assert.ok(
+      !requests.some((request) => request.endpoint.endsWith('/requested_reviewers')),
+      'should not call the requested_reviewers endpoint'
+    );
+  });
+
+  it('warns on a reviewer-copy failure and still returns the created PR', async () => {
+    const newPr = createPullRequest();
+    const warnings: Array<{ message: string; error: unknown }> = [];
+    const client = new GitHubClient('owner', 'repo', (message, error) => {
+      warnings.push({ message, error });
+    });
+
+    (client as any).makeRequest = async (endpoint: string) => {
+      if (endpoint.endsWith('/requested_reviewers')) {
+        throw new Error('reviewers forbidden');
+      }
+      return newPr;
+    };
+
+    const result = await client.createPullRequest(
+      'Cloned PR',
+      'Description',
+      'feature/cloned',
+      'main',
+      false,
+      [],
+      [],
+      ['reviewer-one']
+    );
+
+    assert.strictEqual(result, newPr);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0].message, /Failed to copy reviewers to PR #42/);
+  });
+});
+
+describe('GitHubClient.getCurrentUserLogin', () => {
+  it('fetches and caches the authenticated user login', async () => {
+    const client = new GitHubClient('owner', 'repo');
+    let callCount = 0;
+    (client as any).makeRequest = async () => {
+      callCount++;
+      return { login: 'octocat' };
+    };
+
+    const first = await client.getCurrentUserLogin();
+    const second = await client.getCurrentUserLogin();
+
+    assert.strictEqual(first, 'octocat');
+    assert.strictEqual(second, 'octocat');
+    assert.strictEqual(callCount, 1, 'should only fetch the current user once (cached)');
+  });
+
+  it('returns undefined and warns when the current-user request fails', async () => {
+    const warnings: Array<{ message: string; error: unknown }> = [];
+    const client = new GitHubClient('owner', 'repo', (message, error) => {
+      warnings.push({ message, error });
+    });
+    (client as any).makeRequest = async () => {
+      throw new Error('unauthorized');
+    };
+
+    const result = await client.getCurrentUserLogin();
+
+    assert.strictEqual(result, undefined);
+    assert.strictEqual(warnings.length, 1);
+  });
 });
 
 describe('PrCloneTempWorktreeService metadata parity', () => {
-  it('passes original labels and assignees when creating the cloned PR', async () => {
+  it('passes original labels, assignees, and reviewers when creating the cloned PR', async () => {
     const calls: unknown[][] = [];
     const newPr = createPullRequest(84);
     const ghClient = {
@@ -152,6 +291,7 @@ describe('PrCloneTempWorktreeService metadata parity', () => {
         calls.push(args);
         return newPr;
       },
+      getCurrentUserLogin: async () => 'someone-else',
     } as unknown as GitHubClient;
     const service = new PrCloneTempWorktreeService(
       {} as GitExecutor,
@@ -177,8 +317,100 @@ describe('PrCloneTempWorktreeService metadata parity', () => {
         true,
         ['bug'],
         ['octocat'],
+        ['reviewer-one'],
+        ['core-team'],
       ],
     ]);
+  });
+
+  it('excludes the authenticated user from the requested reviewers (self-review is rejected by GitHub)', async () => {
+    const calls: unknown[][] = [];
+    const newPr = createPullRequest(84);
+    const ghClient = {
+      createPullRequest: async (...args: unknown[]) => {
+        calls.push(args);
+        return newPr;
+      },
+      getCurrentUserLogin: async () => 'reviewer-one',
+    } as unknown as GitHubClient;
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      ghClient,
+      mockLogService
+    );
+
+    await (service as any).createGitHubPR(
+      createPullRequest(),
+      'feature/cloned',
+      'release',
+      'Description',
+      true
+    );
+
+    const reviewers = calls[0][7] as string[];
+    assert.deepStrictEqual(reviewers, []);
+  });
+});
+
+describe('PrCloneInPlaceService metadata parity', () => {
+  it('passes original labels, assignees, and reviewers when creating the cloned PR', async () => {
+    const calls: unknown[][] = [];
+    const newPr = createPullRequest(84);
+    const ghClient = {
+      createPullRequest: async (...args: unknown[]) => {
+        calls.push(args);
+        return newPr;
+      },
+      getCurrentUserLogin: async () => 'someone-else',
+    } as unknown as GitHubClient;
+    const service = new PrCloneInPlaceService({} as GitExecutor, ghClient, mockLogService);
+
+    const result = await (service as any).createGitHubPR(
+      createPullRequest(),
+      'feature/cloned',
+      'release',
+      'Description',
+      true
+    );
+
+    assert.strictEqual(result, newPr);
+    assert.deepStrictEqual(calls, [
+      [
+        'Original PR',
+        'Description',
+        'feature/cloned',
+        'release',
+        true,
+        ['bug'],
+        ['octocat'],
+        ['reviewer-one'],
+        ['core-team'],
+      ],
+    ]);
+  });
+
+  it('excludes the authenticated user from the requested reviewers (self-review is rejected by GitHub)', async () => {
+    const calls: unknown[][] = [];
+    const newPr = createPullRequest(84);
+    const ghClient = {
+      createPullRequest: async (...args: unknown[]) => {
+        calls.push(args);
+        return newPr;
+      },
+      getCurrentUserLogin: async () => 'reviewer-one',
+    } as unknown as GitHubClient;
+    const service = new PrCloneInPlaceService({} as GitExecutor, ghClient, mockLogService);
+
+    await (service as any).createGitHubPR(
+      createPullRequest(),
+      'feature/cloned',
+      'release',
+      'Description',
+      true
+    );
+
+    const reviewers = calls[0][7] as string[];
+    assert.deepStrictEqual(reviewers, []);
   });
 });
 

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -25,6 +25,8 @@ export interface GitHubPR {
   html_url: string;
   labels: GitHubLabel[];
   assignees: GitHubUser[];
+  requested_reviewers?: GitHubUser[];
+  requested_teams?: Array<{ slug: string }>;
   /** Total number of commits on the PR (as reported by GitHub). */
   commits?: number;
 }


### PR DESCRIPTION
## Summary
- Cloned PRs only copied labels and assignees to the newly created PR, silently dropping requested reviewers/team reviewers even though closed issue #28 ("clone labels, reviewers and other attributes") promised reviewers would carry over.
- Extends `GitHubClient.createPullRequest` with optional `reviewers`/`teamReviewers` params that, after PR/labels/assignees creation, POST to `/pulls/:number/requested_reviewers` as a best-effort step (failures are caught and logged as warnings, mirroring the existing labels/assignees behavior — never fails the overall clone).
- Both `PrCloneInPlaceService` and `PrCloneTempWorktreeService`'s `createGitHubPR` helpers now extract `requested_reviewers`/`requested_teams` from the original PR and pass them through, excluding the authenticated user from the reviewers list (GitHub rejects self-review requests) via a new cached `GitHubClient.getCurrentUserLogin()`.
- Added `requested_reviewers`/`requested_teams` fields to the `GitHubPR` type.
- Does not implement milestone-copying (out of scope per review) and adds no UI indication — consistent with how labels/assignees already work silently.

## Test plan
- [x] Unit tests pass (`yarn test:unit`) — added cases for: reviewers/team reviewers API call with correct body, no call when reviewers empty/undefined, failure caught and logged as warning without throwing, and both clone services' self-author-filtering logic.
- [x] Type check passes (`yarn compile`)
- Manual verification: clone a PR that has requested reviewers/team reviewers (and is not authored by you) into a new branch; confirm the new PR has the same reviewers requested (minus yourself if you happen to be one of them).