### PR TITLE
fix(config): scope stash mode updates to workspace, not global

### DIFF
--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -11,6 +11,11 @@ import {
   togglePreferredRef,
 } from './preferredRefs';
 
+/** Minimal slice of `vscode.WorkspaceConfiguration` needed to update the stash mode. */
+export interface ModeConfig {
+  update(section: 'mode', value: ExtensionConfig['mode'], target: ConfigurationTarget): Thenable<void>;
+}
+
 export class ConfigurationManager {
   private config: ExtensionConfig;
   /** Jira API token cached from Secret Storage; never read from settings. */
@@ -113,9 +118,23 @@ export class ConfigurationManager {
     return this.config;
   }
 
-  public async updateMode(mode: ExtensionConfig['mode']): Promise<void> {
-    const config = workspace.getConfiguration(EXTENSION_NAME);
-    await config.update('mode', mode, ConfigurationTarget.Global);
+  /**
+   * Persist the stash mode. Scoped to the current workspace when one is open,
+   * so the mode shadows the global default per-repo (matches the website's
+   * "remembers it per workspace" promise); falls back to Global when no
+   * workspace is open (e.g. an empty editor window) since there is nothing to
+   * scope to.
+   *
+   * `config` and `hasWorkspace` are overridable for unit testing without a
+   * real workspace open.
+   */
+  public async updateMode(
+    mode: ExtensionConfig['mode'],
+    config: ModeConfig = workspace.getConfiguration(EXTENSION_NAME),
+    hasWorkspace: boolean = Boolean(workspace.workspaceFolders && workspace.workspaceFolders.length > 0)
+  ): Promise<void> {
+    const target = hasWorkspace ? ConfigurationTarget.Workspace : ConfigurationTarget.Global;
+    await config.update('mode', mode, target);
   }
 
   public async updateLoggingEnabled(enabled: boolean): Promise<void> {

--- a/src/test/unit/configurationManager.test.ts
+++ b/src/test/unit/configurationManager.test.ts
@@ -1,10 +1,23 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { ConfigurationManager } from '../../configuration/configurationManager';
+import { ConfigurationManager, ModeConfig } from '../../configuration/configurationManager';
 import { EXTENSION_NAME } from '../../const';
 import { JIRA_TOKEN_SECRET_KEY } from '../../configuration/jiraTokenStore';
 import { FakeSecretStorage } from './helpers/fakeSecretStorage';
+
+/** Fake `vscode.WorkspaceConfiguration` slice that records `update` calls to the `mode` setting. */
+class FakeModeConfig implements ModeConfig {
+  readonly calls: Array<{ value: string; target: vscode.ConfigurationTarget }> = [];
+
+  async update(
+    _section: 'mode',
+    value: string,
+    target: vscode.ConfigurationTarget
+  ): Promise<void> {
+    this.calls.push({ value, target });
+  }
+}
 
 describe('ConfigurationManager', () => {
   const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
@@ -18,6 +31,30 @@ describe('ConfigurationManager', () => {
   it('defaults pullAfterCheckout to "ffOnly"', () => {
     const manager = new ConfigurationManager(new FakeSecretStorage());
     assert.strictEqual(manager.get().pullAfterCheckout, 'ffOnly');
+  });
+
+  describe('updateMode', () => {
+    it('writes to the Workspace scope when a workspace is open', async () => {
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      const fakeConfig = new FakeModeConfig();
+
+      await manager.updateMode('autoStashAndPop', fakeConfig, /* hasWorkspace */ true);
+
+      assert.deepStrictEqual(fakeConfig.calls, [
+        { value: 'autoStashAndPop', target: vscode.ConfigurationTarget.Workspace },
+      ]);
+    });
+
+    it('falls back to the Global scope when no workspace is open', async () => {
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      const fakeConfig = new FakeModeConfig();
+
+      await manager.updateMode('manual', fakeConfig, /* hasWorkspace */ false);
+
+      assert.deepStrictEqual(fakeConfig.calls, [
+        { value: 'manual', target: vscode.ConfigurationTarget.Global },
+      ]);
+    });
   });
 
   it('uses deprecated jira.email only when jira.username is empty', async () => {


### PR DESCRIPTION
## Summary
- `ConfigurationManager.updateMode` always wrote the `mode` setting with `ConfigurationTarget.Global`, so switching the stash mode in one VS Code window silently changed it for every other project on the machine — contradicting the website's promise that the extension "remembers it per workspace."
- `updateMode` now writes to `ConfigurationTarget.Workspace` when a workspace is open, falling back to `ConfigurationTarget.Global` only when there is no workspace open (e.g. an empty editor window). The read path (`readConfig`) already reads the merged/effective value via `workspace.getConfiguration(...).get(...)`, so no change was needed there.
- `config` and `hasWorkspace` are now optional, overridable parameters on `updateMode` (defaulting to the real `vscode.workspace` APIs) to allow deterministic unit testing without a real workspace open, following the existing `LegacyTokenConfig` DI pattern used in `jiraTokenStore.ts`.
- To test manually: open two different folders in two VS Code windows, set the mode to `autoStashAndPop` in window A's status bar, and confirm window B's mode is unaffected.

## Test plan
- [x] Added unit tests verifying `updateMode` calls `config.update` with `ConfigurationTarget.Workspace` when a workspace is open, and `ConfigurationTarget.Global` when it isn't.
- [x] `yarn compile` passes.
- [x] `yarn test:unit` — new tests pass. Note: 2 pre-existing, unrelated failures in `remoteBranchConflictPreview.test.ts` (`this.configManager.get is not a function`) exist on `main` prior to this change and are not exercised by CI (the `Build and Test` workflow runs `yarn build-all`, which does not run unit tests).