### PR TITLE
fix(pr-clone): recover interrupted in-place clone on restart

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,12 @@ import { PrCommitsWebViewProvider } from './view/PrCommitsWebViewProvider';
 import { commands } from 'vscode';
 import { setContextShowPRClone, setContextShowPRCommits } from './utils/setContext';
 import { PrCloneService } from './services/prCloneService';
-import { getGitExecutor } from './utils/getGitExecutor';
+import {
+  IPersistedCloneOperation,
+  PR_CLONE_IN_PLACE_STATE_KEY,
+} from './services/prCloneInPlaceService';
+import { getGitExecutor, resolveGitRepositoryRoot } from './utils/getGitExecutor';
+import { GitExecutor } from './common/git/gitExecutor';
 import { GitHubClient } from './common/api/ghClient';
 import { AutoStashService } from './services/autoStashService';
 import { CheckoutByPRCommand } from './commands/checkoutByPRCommand';
@@ -104,6 +109,18 @@ export function activate(context: vscode.ExtensionContext) {
   const refDetailsCache = new RefDetailsCache(context.globalState, logService);
 
   logService.info(`Extension "${EXTENSION_NAME}" is now active!`);
+
+  // Check for a PR clone that was left mid-cherry-pick if the window closed/crashed while
+  // paused on conflicts, before unconditionally resetting the PR-clone contexts below. This
+  // check is async (spawns git) and cannot block synchronous activation; if it finds a
+  // resumable operation it re-sets the contexts, which simply lands a moment after the
+  // unconditional reset below (no repository/persisted state is at risk in the interim).
+  void checkForInterruptedPrClone(
+    context,
+    logService,
+    vscodeGitProvider,
+    prCloneService
+  );
 
   // Set initial context to hide PR Clone view and commits view
   setContextShowPRClone(false);
@@ -388,6 +405,99 @@ export function activate(context: vscode.ExtensionContext) {
   statusBarManager.show();
 
   return { commandManager };
+}
+
+/**
+ * On activation, check whether an in-place PR clone was left mid-cherry-pick by a window
+ * close/crash/reload while paused on conflicts (issue: "No recovery path if VS Code closes
+ * mid in-place clone"). If so, offer the user a Resume/Abort-and-restore choice instead of
+ * silently stranding the repo on the `<feature>_clone` branch with the original work stashed.
+ */
+/**
+ * Resolve a `GitExecutor` for the repository a persisted clone record belongs to, by matching
+ * it against the currently-open workspace folders. Exported separately so tests can stub the
+ * resolution without needing a real multi-root workspace.
+ */
+export async function resolveGitExecutorForRepoPath(
+  repoPath: string,
+  logService: LoggingService,
+  vscodeGitProvider: VscodeGitProvider | undefined
+): Promise<GitExecutor | undefined> {
+  const wsFolders = vscode.workspace.workspaceFolders ?? [];
+  for (const folder of wsFolders) {
+    try {
+      const repoRoot = await resolveGitRepositoryRoot(folder.uri.fsPath, logService);
+      if (repoRoot === repoPath) {
+        return new GitExecutor(repoRoot, logService, vscodeGitProvider);
+      }
+    } catch {
+      // Folder isn't a git repository (or isn't resolvable yet); keep looking.
+    }
+  }
+
+  return undefined;
+}
+
+export async function checkForInterruptedPrClone(
+  context: vscode.ExtensionContext,
+  logService: LoggingService,
+  vscodeGitProvider: VscodeGitProvider | undefined,
+  prCloneService: PrCloneService,
+  resolveGitForRecord: (
+    record: IPersistedCloneOperation
+  ) => Promise<GitExecutor | undefined> = (record) =>
+    resolveGitExecutorForRepoPath(record.repoPath, logService, vscodeGitProvider)
+): Promise<void> {
+  const record = context.workspaceState.get<IPersistedCloneOperation>(
+    PR_CLONE_IN_PLACE_STATE_KEY
+  );
+  if (!record) {
+    return;
+  }
+
+  const matchedGit = await resolveGitForRecord(record);
+
+  if (!matchedGit) {
+    // The repo this record belongs to isn't open in this workspace right now; leave the
+    // record in place in case it's opened in a future activation.
+    return;
+  }
+
+  const cherryPickInProgress = await matchedGit.isCherryPickInProgress();
+  if (!cherryPickInProgress) {
+    // The user must have resolved (or aborted) this manually via the git CLI before
+    // reopening. There's nothing to recover, so just clear the stale record silently.
+    await context.workspaceState.update(PR_CLONE_IN_PLACE_STATE_KEY, undefined);
+    return;
+  }
+
+  const choice = await vscode.window.showWarningMessage(
+    `A PR clone of #${record.prNumber} was interrupted. Resume or abort and restore your original state?`,
+    'Resume',
+    'Abort and restore'
+  );
+
+  if (choice !== 'Resume' && choice !== 'Abort and restore') {
+    return;
+  }
+
+  const repoInfo = await matchedGit.getRepoInfo();
+  if (!repoInfo) {
+    logService.warn(
+      'Could not determine GitHub repository information while recovering an interrupted PR clone.'
+    );
+    return;
+  }
+
+  const ghClient = new GitHubClient(repoInfo.owner, repoInfo.repo);
+  prCloneService.init(matchedGit, ghClient);
+
+  if (choice === 'Resume') {
+    await prCloneService.InPlaceService.resumeOperation(record);
+    await commands.executeCommand(`workbench.view.extension.${EXTENSION_NAME}`);
+  } else {
+    await prCloneService.InPlaceService.abortFromPersistedState(record);
+  }
 }
 
 export async function deactivate() {

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -1,4 +1,4 @@
-import { commands, env, Progress, Uri, window } from 'vscode';
+import { commands, env, Memento, Progress, Uri, window } from 'vscode';
 
 import { GitExecutor } from '../common/git/gitExecutor';
 import { GitHubClient } from '../common/api/ghClient';
@@ -25,12 +25,41 @@ interface IServiceStore {
   originalPrData?: PrCloneData;
 }
 
+/** Key used to persist an in-progress in-place clone operation so it can survive a window reload/crash. */
+export const PR_CLONE_IN_PLACE_STATE_KEY = 'gitSmartCheckout.prCloneInPlaceOperation';
+
+/**
+ * Snapshot of an in-place PR clone operation, persisted to `workspaceState` so it can be
+ * recovered on the next activation if VS Code closes/crashes while paused on a cherry-pick
+ * conflict (see issue: "No recovery path if VS Code closes mid in-place clone").
+ */
+export interface IPersistedCloneOperation {
+  repoPath: string;
+  originalBranch: string;
+  createdBranchName: string;
+  stashMessage?: string;
+  /** Shas that still need to land, including the one that may currently be mid-conflict. */
+  remainingShas: string[];
+  prNumber: number;
+  ts: number;
+  targetBranch: string;
+  description: string;
+  isDraft: boolean;
+  prData: GitHubPR;
+}
+
 export class PrCloneInPlaceService extends PrCloneServiceBase {
   private updateProgress?: Progress<{ message?: string; increment?: number }>;
   private commitGenerator: AsyncGenerator<CommitGeneratorItem, void, unknown> | undefined;
   private serviceStore: IServiceStore = {};
+  private remainingShas: string[] = [];
 
-  constructor(git: GitExecutor, ghClient: GitHubClient, loggingService: LoggingService) {
+  constructor(
+    git: GitExecutor,
+    ghClient: GitHubClient,
+    loggingService: LoggingService,
+    private workspaceState?: Memento
+  ) {
     super(git, ghClient, loggingService);
   }
 
@@ -122,6 +151,10 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
           await commands.executeCommand('workbench.view.scm');
           return;
         } else {
+          // Commit landed successfully; shrink the persisted remaining-commits list so a
+          // reload/crash recovery resumes from the right place instead of re-applying it.
+          this.remainingShas = this.remainingShas.filter((sha) => sha !== nextCommit.value.sha);
+          this.persistState();
           await this.cherryPickNext();
         }
       } catch (error) {
@@ -303,6 +336,8 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
       // create commits generator
       this.commitGenerator = new CommitsGenerator(data.selectedCommits)[Symbol.asyncIterator]();
+      this.remainingShas = [...data.selectedCommits];
+      this.persistState();
 
       // start cherry picking
       await this.cherryPickNext();
@@ -343,9 +378,100 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
   private resetOperationState(): void {
     this.serviceStore = {};
     this.commitGenerator = undefined;
+    this.remainingShas = [];
     this.updateProgress = undefined;
     this.finishProgress = undefined;
     this.cancelProgress = undefined;
+    this.clearPersistedState();
+  }
+
+  /**
+   * Persist the current operation (start of clone, and after every commit successfully lands)
+   * so it can be recovered on the next activation if the window closes/crashes mid-operation.
+   */
+  private persistState(): void {
+    if (!this.workspaceState) {
+      return;
+    }
+
+    const { originalBranch, createdBranchName, stashMessage, originalPrData } = this.serviceStore;
+    if (!originalBranch || !createdBranchName || !originalPrData) {
+      return;
+    }
+
+    const record: IPersistedCloneOperation = {
+      repoPath: this.git.repositoryPath,
+      originalBranch,
+      createdBranchName,
+      stashMessage,
+      remainingShas: [...this.remainingShas],
+      prNumber: originalPrData.prData.number,
+      ts: Date.now(),
+      targetBranch: originalPrData.targetBranch,
+      description: originalPrData.description,
+      isDraft: originalPrData.isDraft,
+      prData: originalPrData.prData,
+    };
+
+    void this.workspaceState.update(PR_CLONE_IN_PLACE_STATE_KEY, record);
+  }
+
+  private clearPersistedState(): void {
+    if (!this.workspaceState) {
+      return;
+    }
+
+    void this.workspaceState.update(PR_CLONE_IN_PLACE_STATE_KEY, undefined);
+  }
+
+  private restoreServiceStoreFromRecord(record: IPersistedCloneOperation): void {
+    this.serviceStore = {
+      originalBranch: record.originalBranch,
+      createdBranchName: record.createdBranchName,
+      stashMessage: record.stashMessage,
+      originalPrData: {
+        prData: record.prData,
+        targetBranch: record.targetBranch,
+        featureBranch: record.createdBranchName,
+        description: record.description,
+        selectedCommits: record.remainingShas,
+        isDraft: record.isDraft,
+      },
+    };
+    this.remainingShas = [...record.remainingShas];
+  }
+
+  /**
+   * Rebuild in-memory state from a persisted record (found on activation) and re-set the
+   * contexts so the UI picks back up at the paused conflict, without touching the repository.
+   */
+  async resumeOperation(record: IPersistedCloneOperation): Promise<void> {
+    this.restoreServiceStoreFromRecord(record);
+
+    this.commitGenerator = new CommitsGenerator(record.remainingShas)[Symbol.asyncIterator]();
+    if (record.remainingShas.length > 0) {
+      // The head of remainingShas is the commit that was mid-cherry-pick (still conflicted in
+      // git) when the window closed. Advance the generator past it so that the next
+      // "Conflicts resolved" click resumes with the following commit, matching the position
+      // cherryPickNext would have been in right before the interruption.
+      await this.commitGenerator.next();
+    }
+
+    this.persistState();
+
+    await setContextIsCloning(true);
+    await setContextIsCherryPickConflict(true);
+    await setContextShowPRClone(true);
+    await setContextShowPRCommits(true);
+  }
+
+  /**
+   * Rebuild just enough in-memory state from a persisted record to run the existing
+   * abort/cleanup path, restoring the pre-clone repository state (original branch + stash).
+   */
+  async abortFromPersistedState(record: IPersistedCloneOperation): Promise<void> {
+    this.restoreServiceStoreFromRecord(record);
+    await this.abortClonePR();
   }
 
   private async createGitHubPR(

--- a/src/services/prCloneService.ts
+++ b/src/services/prCloneService.ts
@@ -104,7 +104,12 @@ export class PrCloneService {
       ghClient,
       this.loggingService
     );
-    this._inPlaceService = new PrCloneInPlaceService(git, ghClient, this.loggingService);
+    this._inPlaceService = new PrCloneInPlaceService(
+      git,
+      ghClient,
+      this.loggingService,
+      this.context.workspaceState
+    );
 
     for (const cleanUpActions of this.cleanUpActions) {
       this._tempWorktreeService.addCleanUpActions(cleanUpActions);

--- a/src/test/unit/prCloneInterruptedRecovery.test.ts
+++ b/src/test/unit/prCloneInterruptedRecovery.test.ts
@@ -1,0 +1,303 @@
+import * as assert from 'assert';
+import { ExtensionContext, ExtensionMode, Memento, window as vscodeWindow } from 'vscode';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import {
+  checkForInterruptedPrClone,
+  resolveGitExecutorForRepoPath,
+} from '../../extension';
+import {
+  IPersistedCloneOperation,
+  PR_CLONE_IN_PLACE_STATE_KEY,
+  PrCloneInPlaceService,
+} from '../../services/prCloneInPlaceService';
+import { PrCloneData, PrCloneService } from '../../services/prCloneService';
+import { GitHubPR } from '../../types/dataTypes';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Regression tests for issue 20: "No recovery path if VS Code closes mid in-place clone
+ * (paused on conflicts)". These cover persisting/clearing the recovery record and the
+ * activation-time Resume / Abort-and-restore flow.
+ */
+
+function createFakeMemento(): Memento & { updates: unknown[] } {
+  const store = new Map<string, unknown>();
+  const updates: unknown[] = [];
+
+  return {
+    updates,
+    get: ((key: string, defaultValue?: unknown) =>
+      store.has(key) ? store.get(key) : defaultValue) as Memento['get'],
+    update: async (key: string, value: unknown) => {
+      if (value === undefined) {
+        store.delete(key);
+      } else {
+        store.set(key, value);
+      }
+      updates.push(value);
+    },
+    keys: () => [...store.keys()],
+  };
+}
+
+const prData = {
+  number: 99,
+  title: 'Recovery PR',
+  body: 'desc',
+  head: { ref: 'feature/source' },
+  base: { ref: 'main' },
+  labels: [],
+  assignees: [],
+} as unknown as GitHubPR;
+
+const cloneData: PrCloneData = {
+  prData,
+  targetBranch: 'main',
+  featureBranch: 'feature/clone',
+  description: 'desc',
+  selectedCommits: ['c1', 'c2'],
+  isDraft: false,
+};
+
+/** Builds a git stub that lands `c1` cleanly, then reports a conflict on `c2` and stalls there. */
+function createStallingGitStub(repositoryPath = '/repo') {
+  const calls = {
+    reset: 0,
+    checkout: [] as string[],
+    popStash: [] as string[],
+    deleteLocalBranch: [] as string[],
+    cherryPickAbort: 0,
+    isCherryPickInProgress: 0,
+  };
+
+  const git = {
+    repositoryPath,
+    getCurrentBranch: async () => 'original',
+    isWorkdirHasChanges: async () => false,
+    fetchPullRequestHead: async () => {},
+    checkout: async (branch: string) => {
+      calls.checkout.push(branch);
+    },
+    pullCurrentBranch: async () => {},
+    createUniqueFeatureBranch: async () => 'feature/clone',
+    commitExists: async () => true,
+    hasConflicts: async () => false,
+    cherryPick: async (sha: string) => ({ conflicts: sha === 'c2' }),
+    isCherryPickInProgress: async () => {
+      calls.isCherryPickInProgress += 1;
+      return false;
+    },
+    reset: async () => {
+      calls.reset += 1;
+    },
+    popStash: async (message: string) => {
+      calls.popStash.push(message);
+    },
+    deleteLocalBranch: async (branch: string) => {
+      calls.deleteLocalBranch.push(branch);
+    },
+    cherryPickAbort: async () => {
+      calls.cherryPickAbort += 1;
+    },
+  } as unknown as GitExecutor;
+
+  return { git, calls };
+}
+
+describe('PrCloneInPlaceService interrupted-clone recovery persistence', () => {
+  it('persists the record on start and shrinks remainingShas as commits land', async () => {
+    const memento = createFakeMemento();
+    const { git } = createStallingGitStub();
+    const service = new PrCloneInPlaceService(git, {} as GitHubClient, mockLogService, memento);
+
+    await service.clonePR(cloneData);
+
+    // c2 is left mid-conflict; clonePR() resolves (cherryPickNext returns early) rather than throwing.
+    const persisted = memento.get<IPersistedCloneOperation>(PR_CLONE_IN_PLACE_STATE_KEY);
+    assert.ok(persisted, 'a record should be persisted while paused on a conflict');
+    assert.deepStrictEqual(persisted!.remainingShas, ['c2']);
+    assert.strictEqual(persisted!.prNumber, 99);
+    assert.strictEqual(persisted!.repoPath, '/repo');
+    assert.strictEqual(persisted!.originalBranch, 'original');
+    assert.strictEqual(persisted!.createdBranchName, 'feature/clone');
+
+    // Verify the sequence of writes: full list at start, then shrunk after c1 landed.
+    const recordedRemaining = memento.updates
+      .filter((update): update is IPersistedCloneOperation => !!update)
+      .map((update) => update.remainingShas);
+    assert.deepStrictEqual(recordedRemaining, [
+      ['c1', 'c2'],
+      ['c2'],
+    ]);
+  });
+
+  it('clears the record when cleanUp runs (abort path)', async () => {
+    const memento = createFakeMemento();
+    const { git } = createStallingGitStub();
+    const service = new PrCloneInPlaceService(git, {} as GitHubClient, mockLogService, memento);
+
+    await service.clonePR(cloneData);
+    assert.ok(memento.get(PR_CLONE_IN_PLACE_STATE_KEY), 'sanity check: record exists before abort');
+
+    await service.abortClonePR();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(
+      memento.get(PR_CLONE_IN_PLACE_STATE_KEY),
+      undefined,
+      'cleanUp must clear the persisted record'
+    );
+  });
+});
+
+describe('checkForInterruptedPrClone activation flow', () => {
+  const context = { extensionMode: ExtensionMode.Test } as ExtensionContext;
+
+  function createRecord(overrides: Partial<IPersistedCloneOperation> = {}): IPersistedCloneOperation {
+    return {
+      repoPath: '/repo',
+      originalBranch: 'original',
+      createdBranchName: 'feature/clone',
+      stashMessage: undefined,
+      remainingShas: ['c2'],
+      prNumber: 99,
+      ts: Date.now(),
+      targetBranch: 'main',
+      description: 'desc',
+      isDraft: false,
+      prData,
+      ...overrides,
+    };
+  }
+
+  it('silently clears a stale record when no cherry-pick is in progress (no prompt)', async () => {
+    const memento = createFakeMemento();
+    await memento.update(PR_CLONE_IN_PLACE_STATE_KEY, createRecord());
+    const fakeContext = { ...context, workspaceState: memento } as unknown as ExtensionContext;
+
+    const { git } = createStallingGitStub();
+    // isCherryPickInProgress stub above returns false.
+    let prompted = false;
+    const originalShowWarningMessage = vscodeWindow.showWarningMessage;
+    (vscodeWindow as any).showWarningMessage = async () => {
+      prompted = true;
+      return undefined;
+    };
+
+    const prCloneService = new PrCloneService(fakeContext, mockLogService, {} as any);
+
+    try {
+      await checkForInterruptedPrClone(
+        fakeContext,
+        mockLogService,
+        undefined,
+        prCloneService,
+        async () => git
+      );
+    } finally {
+      (vscodeWindow as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(prompted, false, 'must not prompt when there is nothing to recover');
+    assert.strictEqual(
+      memento.get(PR_CLONE_IN_PLACE_STATE_KEY),
+      undefined,
+      'the stale record must be cleared silently'
+    );
+  });
+
+  it('Resume rebuilds state and contexts without touching the repository', async () => {
+    const memento = createFakeMemento();
+    const record = createRecord();
+    await memento.update(PR_CLONE_IN_PLACE_STATE_KEY, record);
+    const fakeContext = { ...context, workspaceState: memento } as unknown as ExtensionContext;
+
+    const { git, calls } = createStallingGitStub();
+    (git as any).isCherryPickInProgress = async () => true;
+    (git as any).getRepoInfo = async () => ({ owner: 'o', repo: 'r' });
+
+    const originalShowWarningMessage = vscodeWindow.showWarningMessage;
+    (vscodeWindow as any).showWarningMessage = async () => 'Resume';
+
+    const prCloneService = new PrCloneService(fakeContext, mockLogService, {} as any);
+
+    try {
+      await checkForInterruptedPrClone(
+        fakeContext,
+        mockLogService,
+        undefined,
+        prCloneService,
+        async () => git
+      );
+    } finally {
+      (vscodeWindow as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(calls.reset, 0, 'Resume must not touch the working directory');
+    assert.deepStrictEqual(calls.checkout, [], 'Resume must not checkout any branch');
+    assert.deepStrictEqual(calls.deleteLocalBranch, [], 'Resume must not delete any branch');
+
+    const inPlaceService = prCloneService.InPlaceService as unknown as {
+      serviceStore: { originalBranch?: string; createdBranchName?: string };
+      commitGenerator: unknown;
+    };
+    assert.strictEqual(inPlaceService.serviceStore.originalBranch, 'original');
+    assert.strictEqual(inPlaceService.serviceStore.createdBranchName, 'feature/clone');
+    assert.ok(inPlaceService.commitGenerator, 'the commit generator should be rebuilt');
+  });
+
+  it('Abort and restore calls the existing cleanup/restore path', async () => {
+    const memento = createFakeMemento();
+    const record = createRecord({ stashMessage: 'gsc-stash: original' });
+    await memento.update(PR_CLONE_IN_PLACE_STATE_KEY, record);
+    const fakeContext = { ...context, workspaceState: memento } as unknown as ExtensionContext;
+
+    const { git, calls } = createStallingGitStub();
+    (git as any).isCherryPickInProgress = async () => true;
+    (git as any).getRepoInfo = async () => ({ owner: 'o', repo: 'r' });
+
+    const originalShowWarningMessage = vscodeWindow.showWarningMessage;
+    (vscodeWindow as any).showWarningMessage = async () => 'Abort and restore';
+
+    const prCloneService = new PrCloneService(fakeContext, mockLogService, {} as any);
+
+    try {
+      await checkForInterruptedPrClone(
+        fakeContext,
+        mockLogService,
+        undefined,
+        prCloneService,
+        async () => git
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      (vscodeWindow as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(calls.reset, 1, 'Abort must reset the working directory');
+    assert.deepStrictEqual(calls.checkout, ['original'], 'Abort must restore the original branch');
+    assert.deepStrictEqual(
+      calls.popStash,
+      ['gsc-stash: original'],
+      'Abort must restore the stashed changes'
+    );
+    assert.deepStrictEqual(
+      calls.deleteLocalBranch,
+      ['feature/clone'],
+      'Abort must delete the created clone branch'
+    );
+    assert.strictEqual(
+      memento.get(PR_CLONE_IN_PLACE_STATE_KEY),
+      undefined,
+      'the persisted record must be cleared after abort'
+    );
+  });
+});
+
+describe('resolveGitExecutorForRepoPath', () => {
+  it('is exported and callable (smoke test; workspace-folder matching is exercised via injected resolvers above)', () => {
+    assert.strictEqual(typeof resolveGitExecutorForRepoPath, 'function');
+  });
+});


### PR DESCRIPTION
## Summary
- The in-place PR-clone cherry-pick flow can legitimately pause for a long time while the user resolves conflicts. Previously all clone state lived only in memory, and the PR-clone contexts were unconditionally reset on activation, so a window close/crash/reload while paused left the repo mid-cherry-pick on a `<feature>_clone` branch with the user's prior work stashed and no way back except manual git surgery.
- Persist an operation record (`repoPath`, `originalBranch`, `createdBranchName`, `stashMessage`, `remainingShas`, `prNumber`, PR metadata) to `workspaceState` when a clone starts and as each commit lands; clear it in `cleanUp` on both normal completion and abort.
- On activation, if a persisted record exists for a repo currently open in the workspace and `git.isCherryPickInProgress()` confirms it's still mid-conflict, prompt "Resume" (rebuild service state + re-set contexts so the UI picks back up where it left off, no repo changes) or "Abort and restore" (run the existing cleanup path: checkout original branch, pop stash, delete the clone branch). If the record is stale (cherry-pick no longer in progress, e.g. resolved manually via CLI), it's cleared silently with no prompt.
- Manual test: start an in-place PR clone with a commit set up to conflict, let it pause on the conflict, force-quit VS Code, reopen the same workspace — you should see the interruption prompt; choosing Resume re-shows the PR-clone panel in the conflicted state, choosing Abort and restore returns you to the original branch with your stash restored.

## Test plan
- [x] Unit tests pass (`yarn test`, 430 passing)
- [x] Type check passes (`yarn compile`)
- [x] New tests added in `src/test/unit/prCloneInterruptedRecovery.test.ts` covering: record persisted on start and shrinks as commits land; `cleanUp` clears the record; activation Resume flow rebuilds state without touching the repo; activation Abort flow runs the existing restore path; stale record with no in-progress cherry-pick is cleared silently without a prompt