### PR TITLE
fix(pr-clone): replace setTimeout webview reset with WEBVIEW_READY handshake

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,8 +51,6 @@ import { AnalyticsEvent, capture, initAnalytics, setAnalyticsEnabled, shutdownAn
 import { randomUUID } from 'crypto';
 import { showErrorMessageWithIssueAction } from './utils/errorIssueNotification';
 
-const EXTENSION_LOADING_TIMEOUT = 250;
-
 export function activate(context: vscode.ExtensionContext) {
   const anonymousId = context.globalState.get<string>('analytics.anonymousId') ?? (() => {
     const id = randomUUID();
@@ -278,11 +276,9 @@ export function activate(context: vscode.ExtensionContext) {
       setContextShowPRClone(true);
       // Show the Git Smart Checkout activity bar
       commands.executeCommand(`workbench.view.extension.${EXTENSION_NAME}`);
-      // TODO: change this to clear state at the moment of the first mount of App.tsx
-      setTimeout(() => {
-        // Wait until app fully initialized and clear webview state to start fresh
-        prCloneWebViewProvider.clearState();
-      }, EXTENSION_LOADING_TIMEOUT);
+      // Reset the webview to a fresh state: immediately if it's already
+      // visible, or as soon as it finishes mounting (WEBVIEW_READY handshake).
+      prCloneWebViewProvider.requestFreshStart();
     }
   );
 

--- a/src/test/unit/prCloneWebViewProvider.test.ts
+++ b/src/test/unit/prCloneWebViewProvider.test.ts
@@ -305,6 +305,89 @@ describe('PrCloneWebViewProvider fetch error handling', () => {
   });
 });
 
+describe('PrCloneWebViewProvider requestFreshStart / WEBVIEW_READY handshake', () => {
+  function createProvider(): PrCloneWebViewProvider {
+    const ghClient = new GitHubClient('owner', 'repo');
+    return new PrCloneWebViewProvider(
+      {} as vscode.ExtensionContext,
+      mockLogService,
+      {} as ConfigurationManager,
+      createPrCloneService(ghClient)
+    );
+  }
+
+  it('clears state immediately when the webview is already resolved and visible', () => {
+    const provider = createProvider();
+    let clearStateCalls = 0;
+    (provider as any).clearState = () => {
+      clearStateCalls++;
+    };
+    (provider as any).webviewView = { visible: true };
+
+    provider.requestFreshStart();
+
+    assert.strictEqual(clearStateCalls, 1);
+    assert.strictEqual((provider as any).pendingReset, false);
+  });
+
+  it('sets a pending-reset flag (without clearing state) when the webview is not yet resolved', () => {
+    const provider = createProvider();
+    let clearStateCalls = 0;
+    (provider as any).clearState = () => {
+      clearStateCalls++;
+    };
+
+    provider.requestFreshStart();
+
+    assert.strictEqual(clearStateCalls, 0);
+    assert.strictEqual((provider as any).pendingReset, true);
+  });
+
+  it('sets a pending-reset flag when the webview is resolved but not visible', () => {
+    const provider = createProvider();
+    let clearStateCalls = 0;
+    (provider as any).clearState = () => {
+      clearStateCalls++;
+    };
+    (provider as any).webviewView = { visible: false };
+
+    provider.requestFreshStart();
+
+    assert.strictEqual(clearStateCalls, 0);
+    assert.strictEqual((provider as any).pendingReset, true);
+  });
+
+  it('clears state and resets the pending flag once WEBVIEW_READY fires with a pending reset', async () => {
+    const provider = createProvider();
+    let clearStateCalls = 0;
+    (provider as any).clearState = () => {
+      clearStateCalls++;
+    };
+    (provider as any).webviewView = undefined;
+
+    provider.requestFreshStart();
+    assert.strictEqual((provider as any).pendingReset, true);
+
+    await (provider as any).handleWebViewReady();
+
+    assert.strictEqual(clearStateCalls, 1);
+    assert.strictEqual((provider as any).pendingReset, false);
+  });
+
+  it('does not clear state on a normal WEBVIEW_READY when no reset was requested', async () => {
+    const provider = createProvider();
+    let clearStateCalls = 0;
+    (provider as any).clearState = () => {
+      clearStateCalls++;
+    };
+
+    await (provider as any).handleWebViewReady();
+
+    assert.strictEqual(clearStateCalls, 0);
+    assert.strictEqual((provider as any).pendingReset, false);
+  });
+});
+
 describe('PrCloneWebViewProvider default target branch resolution', () => {
   async function runFetchPR(options: {
     defaultTargetBranch: string;

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -120,6 +120,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   private commitsProvider?: PrCommitsWebViewProvider;
   private currentPrData?: GitHubPR;
   private currentCommits: GitHubCommit[] = [];
+  private pendingReset = false;
 
   private cloneServiceCleanUpAssigned = false;
   private readonly repositoryChangeSubscription: Disposable;
@@ -207,7 +208,29 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async handleWebViewReady() {
+    if (this.pendingReset) {
+      this.pendingReset = false;
+      this.clearState();
+    }
+
     this.updateRepoInfo();
+  }
+
+  /**
+   * Requests a fresh start for the PR Clone webview (e.g. when the
+   * "clone pull request" command is invoked). If the webview is already
+   * resolved and visible, the state is cleared immediately. Otherwise, a
+   * pending-reset flag is set and honored once the webview finishes
+   * mounting and sends the WEBVIEW_READY handshake (see `handleWebViewReady`).
+   */
+  public requestFreshStart(): void {
+    if (this.webviewView?.visible) {
+      this.clearState();
+      this.pendingReset = false;
+      return;
+    }
+
+    this.pendingReset = true;
   }
 
   private updateRepoInfo() {


### PR DESCRIPTION
## Summary
- The clone-PR command reset the webview state via a fixed 250ms `setTimeout`, racing against the `WEBVIEW_READY` handshake the React app already sends once mounted. On slow machines the reset could fire before the webview finished mounting, leaving stale PR data visible; when the webview was already open, the user saw the old data flash before the delayed reset applied.
- Replaced the timeout hack with `PrCloneWebViewProvider.requestFreshStart()`: clears state immediately if the webview is already resolved and visible, otherwise sets a `pendingReset` flag that `handleWebViewReady()` honors once `WEBVIEW_READY` actually arrives. Removed the now-unused `EXTENSION_LOADING_TIMEOUT` constant and `setTimeout` call from `extension.ts`.
- To test manually: open the PR Clone view, submit a clone, then immediately reopen "Clone Pull Request" — the form should reset instantly (no stale data, no flash) regardless of whether the view was already visible or not yet mounted.

## Test plan
- [x] Unit tests pass (`yarn test:unit`) for the new/changed code paths (5 new tests covering `requestFreshStart` + `handleWebViewReady` pending-reset handshake)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host

Note: `yarn test:unit` has 2 pre-existing failures in `AutoStashService conflict preview ref resolution` (unrelated to this change — reproducible on a clean `origin/main` checkout, caused by a test/config mismatch from PR #133). CI's `Build and Test` workflow only runs `yarn build-all` (compile + lint), not the unit test suite, so this pre-existing issue does not affect PR checks.