### PR TITLE
fix: resolve ten assorted small defects (issue 21 a-j)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,24 +28,24 @@ All commands are grouped under the `GSC:` prefix in the Command Palette.
 | Feature | Command | Details |
 | --- | --- | --- |
 | Checkout to a branch, tag, or remote ref with configurable stash behavior | `GSC: Checkout to ... (With Stash)` | [Checkout with stash](docs/checkout-with-stash.md) |
-| Checkout the previous branch with the same stash behavior | `GSC: Checkout previous branch (With Stash)` | [Checkout previous branch with stash](docs/checkout-previous-branch-with-stash.md) |
-| Copy the current branch name to the clipboard | `GSC: Copy current branch name to clipboard` | [Copy current branch name](docs/copy-current-branch-name.md) |
-| Checkout a GitHub pull request branch by PR number or URL | `GSC: Checkout by PR number... (With Stash)` | [Checkout by PR number with stash](docs/checkout-by-pr-number-with-stash.md) |
-| Review a GitHub pull request in a linked worktree and remove tracked review worktrees | `GSC: PR Review in Worktree`, `GSC: Remove PR review in Worktree` | [PR review in worktree](docs/pr-review-in-worktree.md) |
+| Checkout the previous branch with the same stash behavior | `GSC: Checkout Previous Branch (With Stash)` | [Checkout previous branch with stash](docs/checkout-previous-branch-with-stash.md) |
+| Copy the current branch name to the clipboard | `GSC: Copy Current Branch Name to Clipboard` | [Copy current branch name](docs/copy-current-branch-name.md) |
+| Checkout a GitHub pull request branch by PR number or URL | `GSC: Checkout by PR Number... (With Stash)` | [Checkout by PR number with stash](docs/checkout-by-pr-number-with-stash.md) |
+| Review a GitHub pull request in a linked worktree and remove tracked review worktrees | `GSC: PR Review in Worktree...`, `GSC: Remove PR Review in Worktree...` | [PR review in worktree](docs/pr-review-in-worktree.md) |
 | Pull the current branch while preserving local changes | `GSC: Pull (With Stash)` | [Pull with stash](docs/pull-with-stash.md) |
 | Pull with rebase while preserving local changes | `GSC: Pull (Rebase With Stash)` | [Pull rebase with stash](docs/pull-rebase-with-stash.md) |
 | Rebase the current branch onto another ref while preserving local changes | `GSC: Rebase (With Stash)` | [Rebase with stash](docs/rebase-with-stash.md) |
-| Inspect, recover, or remove stashes created by Git Smart Checkout | `GSC: Manage auto-stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
-| Copy staged or WIP changes between existing worktrees | `GSC: Copy staged changes to worktree ...`, `GSC: Copy WIP changes to worktree ...`, `GSC: Copy WIP from Worktree`, `GSC: Move WIP from Worktree` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
+| Inspect, recover, or remove stashes created by Git Smart Checkout | `GSC: Manage Auto-Stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
+| Copy staged or WIP changes between existing worktrees | `GSC: Copy Staged Changes to Worktree...`, `GSC: Copy WIP Changes to Worktree...`, `GSC: Copy WIP from Worktree...`, `GSC: Move WIP from Worktree...` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
 | Open a terminal in a selected worktree's directory | `GSC: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
 | Remove several Git worktrees at once with a single confirmation | `GSC: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
-| Create a new PR from selected commits in another GitHub PR | `GSC: Clone pull request...` | [GitHub PR clone](docs/github-pr-clone.md) |
+| Create a new PR from selected commits in another GitHub PR | `GSC: Clone Pull Request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `GSC: Create Tag from Template...` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `GSC: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |
-| Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `GSC: Init Jira` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
-| Store the Jira API token securely in VS Code Secret Storage | `GSC: Set Jira token` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
-| Change the default stash mode used by checkout-style commands | `GSC: Switch Mode` | [Switch mode](docs/switch-mode.md) |
-| Open a quick-actions menu of common commands (checkout, pull/rebase, all worktree commands, clone PR, open settings) from the status bar item | `GSC: Quick Actions` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
+| Set up Jira credentials (domain, username, and securely stored API token) in one guided flow | `GSC: Init Jira...` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
+| Store the Jira API token securely in VS Code Secret Storage | `GSC: Set Jira Token...` | [Create branch from template](docs/create-branch-from-template.md#jira-configuration) |
+| Change the default stash mode used by checkout-style commands | `GSC: Switch Mode...` | [Switch mode](docs/switch-mode.md) |
+| Open a quick-actions menu of common commands (checkout, pull/rebase, all worktree commands, clone PR, open settings) from the status bar item | `GSC: Quick Actions...` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
 | Open this extension's settings | `GSC: Open Settings` | [Status bar quick actions](docs/status-bar-quick-actions.md) |
 
 ## Extension Settings
@@ -69,7 +69,7 @@ Click a setting ID to open that setting in VS Code.
 | ⚙️ [`git-smart-checkout.jira.domain`](vscode://settings/git-smart-checkout.jira.domain) (Jira domain) | `string` | Jira Cloud host (e.g. `your-company.atlassian.net`). Required when the branch template uses Jira tokens. |
 | ⚙️ [`git-smart-checkout.jira.username`](vscode://settings/git-smart-checkout.jira.username) (Jira username) | `string` | Atlassian account username for Jira API authentication (usually your Atlassian account email). |
 | ⚙️ [`git-smart-checkout.jira.email`](vscode://settings/git-smart-checkout.jira.email) (Deprecated Jira email) | `string` | Deprecated compatibility fallback used only when `jira.username` is empty. Migrate to `git-smart-checkout.jira.username`. |
-| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | **Deprecated — stored in plaintext.** Use the `GSC: Set Jira token` command, which keeps the token in VS Code Secret Storage. Any value set here is migrated into Secret Storage and cleared on the next activation. |
+| ⚙️ [`git-smart-checkout.jira.token`](vscode://settings/git-smart-checkout.jira.token) (Jira API token) | `string` | **Deprecated — stored in plaintext.** Use the `GSC: Set Jira Token...` command, which keeps the token in VS Code Secret Storage. Any value set here is migrated into Secret Storage and cleared on the next activation. |
 | ⚙️ [`git-smart-checkout.jira.projectKeys`](vscode://settings/git-smart-checkout.jira.projectKeys) (Jira project keys) | `array` | Optional list of project keys that limit the Jira issue picker, e.g. `["KEY", "HOME"]`. Empty (default) shows all issues assigned to you. |
 | ⚙️ [`git-smart-checkout.pushTagWithoutConfirmation`](vscode://settings/git-smart-checkout.pushTagWithoutConfirmation) (Push tag without confirmation) | `boolean` | Pushes the created Git tag to the remote without asking for confirmation. |
 | ⚙️ [`git-smart-checkout.tagRemote`](vscode://settings/git-smart-checkout.tagRemote) (Tag remote) | `string` | Git remote used when pushing created tags. |

--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
       },
       {
         "command": "git-smart-checkout.checkoutPrevious",
-        "title": "Checkout previous branch (With Stash)",
+        "title": "Checkout Previous Branch (With Stash)",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.copyBranchName",
-        "title": "Copy current branch name to clipboard",
+        "title": "Copy Current Branch Name to Clipboard",
         "category": "GSC"
       },
       {
@@ -93,12 +93,12 @@
       },
       {
         "command": "git-smart-checkout.switchMode",
-        "title": "Switch Mode",
+        "title": "Switch Mode...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.showStatusBarMenu",
-        "title": "Quick Actions",
+        "title": "Quick Actions...",
         "category": "GSC"
       },
       {
@@ -108,7 +108,7 @@
       },
       {
         "command": "git-smart-checkout.clonePullRequest",
-        "title": "Clone pull request...",
+        "title": "Clone Pull Request...",
         "category": "GSC",
         "icon": {
           "light": "resources/light/clone.svg",
@@ -117,7 +117,7 @@
       },
       {
         "command": "git-smart-checkout.prCancelCloneMenu",
-        "title": "Cancel PR clone",
+        "title": "Cancel PR Clone",
         "category": "GSC",
         "icon": {
           "light": "resources/light/revert.svg",
@@ -126,7 +126,7 @@
       },
       {
         "command": "git-smart-checkout.prConflictsResolvedMenu",
-        "title": "Conflicts resolved",
+        "title": "Conflicts Resolved",
         "category": "GSC",
         "icon": {
           "light": "resources/light/forward.svg",
@@ -150,52 +150,52 @@
       },
       {
         "command": "git-smart-checkout.initJira",
-        "title": "Init Jira",
+        "title": "Init Jira...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.setJiraToken",
-        "title": "Set Jira token",
+        "title": "Set Jira Token...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.checkoutByPR",
-        "title": "Checkout by PR number... (With Stash)",
+        "title": "Checkout by PR Number... (With Stash)",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.prReviewInWorktree",
-        "title": "PR Review in Worktree",
+        "title": "PR Review in Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.removePRReviewInWorktree",
-        "title": "Remove PR review in Worktree",
+        "title": "Remove PR Review in Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.moveToNewWorktree",
-        "title": "Move to new worktree",
+        "title": "Move to New Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.copyStagedChangesToWorktree",
-        "title": "Copy staged changes to worktree...",
+        "title": "Copy Staged Changes to Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.copyWipChangesToWorktree",
-        "title": "Copy WIP changes to worktree...",
+        "title": "Copy WIP Changes to Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.copyWipChangesFromWorktree",
-        "title": "Copy WIP from Worktree",
+        "title": "Copy WIP from Worktree...",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.moveWipChangesFromWorktree",
-        "title": "Move WIP from Worktree",
+        "title": "Move WIP from Worktree...",
         "category": "GSC"
       },
       {
@@ -215,7 +215,7 @@
       },
       {
         "command": "git-smart-checkout.manageAutoStashes",
-        "title": "Manage auto-stashes...",
+        "title": "Manage Auto-Stashes...",
         "category": "GSC"
       }
     ],

--- a/src/commands/copyChangesToWorktreeCommand/index.ts
+++ b/src/commands/copyChangesToWorktreeCommand/index.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -8,11 +7,14 @@ import { IGitWorktree } from '../../common/git/types';
 import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
 import { LoggingService } from '../../logging/loggingService';
 import { BaseCommand } from '../command';
+import { normalizePathForComparison } from '../utils/worktreeRemoval';
+import { showWorktreeCompletionActions } from '../utils/worktreeCompletionActions';
 
-const ACTION_ADD_TO_WORKSPACE = 'Add to Workspace';
-const ACTION_OPEN_FOLDER = 'Open in Current Window';
-const ACTION_OPEN_IN_NEW_WINDOW = 'Open in New Window';
 const ACTION_OK = 'OK';
+
+function isSamePath(left: string, right: string): boolean {
+  return normalizePathForComparison(left) === normalizePathForComparison(right);
+}
 
 type CopyMode = 'staged' | 'wip';
 type WorktreeQuickPickItem = vscode.QuickPickItem & {
@@ -71,7 +73,12 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
         untracked_file_count: result.untrackedFileCount,
       });
 
-      await this.showCompletionActions(worktree.path, result.hadChanges);
+      await showWorktreeCompletionActions(
+        worktree.path,
+        result.hadChanges
+          ? `Changes copied to ${worktree.path}`
+          : `No changes to copy. Worktree selected: ${worktree.path}`
+      );
     } catch (error) {
       captureException(error);
       const message = error instanceof Error ? error.message : String(error);
@@ -85,7 +92,7 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
       (worktree) =>
         !worktree.bare &&
         !worktree.prunable &&
-        !this.isSamePath(worktree.path, git.repositoryPath)
+        !isSamePath(worktree.path, git.repositoryPath)
     );
 
     if (selectableWorktrees.length === 0) {
@@ -200,68 +207,6 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
 
   private getShortHead(worktree: IGitWorktree): string {
     return worktree.head?.slice(0, 7) ?? 'unknown';
-  }
-
-  private async showCompletionActions(worktreePath: string, hadChanges: boolean): Promise<void> {
-    const action = await vscode.window.showInformationMessage(
-      hadChanges ? `Changes copied to ${worktreePath}` : `No changes to copy. Worktree selected: ${worktreePath}`,
-      ...this.getCompletionActions(worktreePath)
-    );
-
-    switch (action) {
-      case ACTION_ADD_TO_WORKSPACE:
-        this.addToWorkspace(worktreePath);
-        break;
-      case ACTION_OPEN_FOLDER:
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(worktreePath), false);
-        break;
-      case ACTION_OPEN_IN_NEW_WINDOW:
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(worktreePath), true);
-        break;
-    }
-  }
-
-  private addToWorkspace(worktreePath: string): void {
-    const folders = vscode.workspace.workspaceFolders ?? [];
-    vscode.workspace.updateWorkspaceFolders(folders.length, null, {
-      uri: vscode.Uri.file(worktreePath),
-      name: path.basename(worktreePath),
-    });
-  }
-
-  private getCompletionActions(worktreePath: string): string[] {
-    const actions = [ACTION_OPEN_FOLDER, ACTION_OPEN_IN_NEW_WINDOW];
-
-    if (!this.isWorktreeInWorkspace(worktreePath)) {
-      actions.unshift(ACTION_ADD_TO_WORKSPACE);
-    }
-
-    return actions;
-  }
-
-  private isWorktreeInWorkspace(worktreePath: string): boolean {
-    return (vscode.workspace.workspaceFolders ?? []).some((folder) =>
-      this.isSamePath(folder.uri.fsPath, worktreePath)
-    );
-  }
-
-  private isSamePath(left: string, right: string): boolean {
-    return this.normalizePathForComparison(left) === this.normalizePathForComparison(right);
-  }
-
-  private normalizePathForComparison(targetPath: string): string {
-    try {
-      return fs.realpathSync.native(targetPath);
-    } catch {
-      try {
-        return path.join(
-          fs.realpathSync.native(path.dirname(targetPath)),
-          path.basename(targetPath)
-        );
-      } catch {
-        return path.resolve(targetPath);
-      }
-    }
   }
 }
 

--- a/src/commands/createBranchFromTemplateCommand/index.ts
+++ b/src/commands/createBranchFromTemplateCommand/index.ts
@@ -65,7 +65,7 @@ export class CreateBranchFromTemplateCommand extends BaseCommand {
     if (branchTemplateNeedsJira(template)) {
       if (!isJiraConfigured(cfg.jira)) {
         await this.showErrorMessage(
-          'Branch template requires Jira. Set git-smart-checkout.jira.domain and jira.username, then run "GSC: Set Jira token".'
+          'Branch template requires Jira. Set git-smart-checkout.jira.domain and jira.username, then run "GSC: Set Jira Token...".'
         );
         return;
       }

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -25,6 +25,17 @@ export function supportsMergeTreeWriteTree(output: string): boolean {
   return major > 2 || (major === 2 && minor >= 38);
 }
 
+// `git stash show --include-untracked` requires Git >= 2.32; older Git errors
+// out on the flag entirely.
+export function supportsStashShowIncludeUntracked(output: string): boolean {
+  const version = parseGitVersion(output);
+  if (!version) {
+    return false;
+  }
+  const [major, minor] = version;
+  return major > 2 || (major === 2 && minor >= 32);
+}
+
 type StashConflictPreviewError = ExecException & {
   stdout?: string;
   stderr?: string;
@@ -219,6 +230,7 @@ export class GitExecutor {
   #vscodeGitProvider: VscodeGitProvider | undefined;
   #mergeTreeSupport?: Promise<boolean>;
   #mergeTreeFallbackLogged = false;
+  #stashShowIncludeUntrackedSupport?: Promise<boolean>;
 
   constructor(repositoryPath: string, logService: LoggingService, vscodeGitProvider?: VscodeGitProvider) {
     this.#repositoryPath = repositoryPath;
@@ -569,16 +581,26 @@ export class GitExecutor {
   }
 
   async getStashPatch(selector: string): Promise<string> {
-    const { stdout } = await this.#execGitCommand([
-      'stash',
-      'show',
-      '--patch',
-      '--binary',
-      '--include-untracked',
-      '--format=',
-      selector,
-    ]);
-    return stdout;
+    const includeUntrackedSupported = await this.#supportsStashShowIncludeUntracked();
+
+    const args = ['stash', 'show', '--patch', '--binary'];
+    if (includeUntrackedSupported) {
+      args.push('--include-untracked');
+    }
+    args.push('--format=', selector);
+
+    const { stdout } = await this.#execGitCommand(args);
+
+    return includeUntrackedSupported
+      ? stdout
+      : `${stdout}\n(untracked files not shown: Git 2.32 or newer is required)`;
+  }
+
+  async #supportsStashShowIncludeUntracked(): Promise<boolean> {
+    this.#stashShowIncludeUntrackedSupport ??= this.#execGitCommand(['--version'])
+      .then(({ stdout }) => supportsStashShowIncludeUntracked(stdout))
+      .catch(() => false);
+    return this.#stashShowIncludeUntrackedSupport;
   }
 
   async isWorkdirHasChanges() {

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -11,6 +11,21 @@ import {
   togglePreferredRef,
 } from './preferredRefs';
 
+/** globalState key tracking whether the one-time jira.email migration notice has been shown. */
+export const JIRA_EMAIL_MIGRATION_NOTICE_SHOWN_KEY = 'jira.emailMigrationNoticeShown';
+
+/**
+ * Whether the one-time "please migrate to jira.username" notice should be
+ * shown: the user is still relying on the deprecated `jira.email` setting and
+ * hasn't already been notified.
+ */
+export function shouldShowJiraEmailMigrationNotice(
+  isUsingDeprecatedJiraEmail: boolean,
+  noticeAlreadyShown: boolean
+): boolean {
+  return isUsingDeprecatedJiraEmail && !noticeAlreadyShown;
+}
+
 export class ConfigurationManager {
   private config: ExtensionConfig;
   /** Jira API token cached from Secret Storage; never read from settings. */
@@ -107,6 +122,18 @@ export class ConfigurationManager {
       token: this.jiraToken,
       projectKeys: vscodeConfig.get<string[]>('jira.projectKeys', []),
     };
+  }
+
+  /**
+   * True when the user still relies on the deprecated `jira.email` setting
+   * (i.e. the replacement `jira.username` is unset) — used to decide whether
+   * to nudge them toward migrating, once per install.
+   */
+  public isUsingDeprecatedJiraEmailSetting(): boolean {
+    const vscodeConfig = workspace.getConfiguration(EXTENSION_NAME);
+    const username = vscodeConfig.get<string>('jira.username', '').trim();
+    const email = vscodeConfig.get<string>('jira.email', '').trim();
+    return username === '' && email !== '';
   }
 
   public get(): ExtensionConfig {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,11 @@ import { SwitchModeCommand } from './commands/switchModeCommand';
 import { StatusBarMenuCommand } from './commands/statusBarMenuCommand';
 import { OpenSettingsCommand } from './commands/openSettingsCommand';
 import { VscodeGitProvider } from './common/git/vscodeGitProvider';
-import { ConfigurationManager } from './configuration/configurationManager';
+import {
+  ConfigurationManager,
+  JIRA_EMAIL_MIGRATION_NOTICE_SHOWN_KEY,
+  shouldShowJiraEmailMigrationNotice,
+} from './configuration/configurationManager';
 import { EXTENSION_NAME } from './const';
 import { LoggingService } from './logging/loggingService';
 import { StatusBarManager } from './statusBar/statusBarManager';
@@ -50,6 +54,7 @@ import { RefDetailsCache } from './services/refDetailsCache';
 import { AnalyticsEvent, capture, initAnalytics, setAnalyticsEnabled, shutdownAnalytics } from './analytics/analytics';
 import { randomUUID } from 'crypto';
 import { showErrorMessageWithIssueAction } from './utils/errorIssueNotification';
+import { UserCancelledError } from './utils/userCancelledError';
 
 const EXTENSION_LOADING_TIMEOUT = 250;
 
@@ -78,6 +83,29 @@ export function activate(context: vscode.ExtensionContext) {
 
   updateTelemetryState();
   capture(AnalyticsEvent.ExtensionActivated);
+
+  const jiraEmailMigrationNoticeShown = context.globalState.get<boolean>(
+    JIRA_EMAIL_MIGRATION_NOTICE_SHOWN_KEY,
+    false
+  );
+  if (
+    shouldShowJiraEmailMigrationNotice(
+      configManager.isUsingDeprecatedJiraEmailSetting(),
+      jiraEmailMigrationNoticeShown
+    )
+  ) {
+    context.globalState.update(JIRA_EMAIL_MIGRATION_NOTICE_SHOWN_KEY, true);
+    vscode.window
+      .showInformationMessage(
+        'Git Smart Checkout: the "jira.email" setting is deprecated. Please migrate to "jira.username".',
+        'Open Settings'
+      )
+      .then((selection) => {
+        if (selection === 'Open Settings') {
+          commands.executeCommand(`${EXTENSION_NAME}.openSettings`);
+        }
+      });
+  }
 
   const logService = new LoggingService(configManager);
   const vscodeGitProvider = VscodeGitProvider.tryCreate(logService);
@@ -260,29 +288,38 @@ export function activate(context: vscode.ExtensionContext) {
   const clonePullRequestCommand = commands.registerCommand(
     `${EXTENSION_NAME}.clonePullRequest`,
     async () => {
-      capture(AnalyticsEvent.PrCloneOpened);
+      try {
+        capture(AnalyticsEvent.PrCloneOpened);
 
-      // get exact repository
-      const git = await getGitExecutor(logService);
+        // get exact repository
+        const git = await getGitExecutor(logService);
 
-      const repoInfo = await git.getRepoInfo();
-      if (!repoInfo) {
-        throw new Error('Could not determine GitHub repository information');
+        const repoInfo = await git.getRepoInfo();
+        if (!repoInfo) {
+          throw new Error('Could not determine GitHub repository information');
+        }
+
+        const ghClient = new GitHubClient(repoInfo.owner, repoInfo.repo);
+
+        prCloneService.init(git, ghClient);
+
+        // Show the PR Clone view by setting the context
+        setContextShowPRClone(true);
+        // Show the Git Smart Checkout activity bar
+        commands.executeCommand(`workbench.view.extension.${EXTENSION_NAME}`);
+        // TODO: change this to clear state at the moment of the first mount of App.tsx
+        setTimeout(() => {
+          // Wait until app fully initialized and clear webview state to start fresh
+          prCloneWebViewProvider.clearState();
+        }, EXTENSION_LOADING_TIMEOUT);
+      } catch (error) {
+        if (error instanceof UserCancelledError) {
+          return;
+        }
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await showErrorMessageWithIssueAction(`Command failed: ${errorMessage}`, 'OK');
+        console.error(`Error executing command ${EXTENSION_NAME}.clonePullRequest:`, error);
       }
-
-      const ghClient = new GitHubClient(repoInfo.owner, repoInfo.repo);
-
-      prCloneService.init(git, ghClient);
-
-      // Show the PR Clone view by setting the context
-      setContextShowPRClone(true);
-      // Show the Git Smart Checkout activity bar
-      commands.executeCommand(`workbench.view.extension.${EXTENSION_NAME}`);
-      // TODO: change this to clear state at the moment of the first mount of App.tsx
-      setTimeout(() => {
-        // Wait until app fully initialized and clear webview state to start fresh
-        prCloneWebViewProvider.clearState();
-      }, EXTENSION_LOADING_TIMEOUT);
     }
   );
 

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -312,7 +312,7 @@ export class AutoStashService {
         await git.createStash(stashMessage);
       }
     } catch (e) {
-      handleErrorMessage(e);
+      handleErrorMessage(e, undefined, undefined, undefined, this.logService);
     }
 
     try {
@@ -334,7 +334,13 @@ export class AutoStashService {
         await git.popStash(message);
       }
     } catch (e) {
-      handleErrorMessage(e, 'No stash found', 'No stash to pop on the new branch.', 'Failed to pop the stash on the new branch.');
+      handleErrorMessage(
+        e,
+        'No stash found',
+        'No stash to pop on the new branch.',
+        'Failed to pop the stash on the new branch.',
+        this.logService
+      );
     }
 
     return 'completed';
@@ -375,7 +381,7 @@ export class AutoStashService {
         await git.createStash(stashMessage);
       }
     } catch (e) {
-      handleErrorMessage(e);
+      handleErrorMessage(e, undefined, undefined, undefined, this.logService);
     }
 
     try {

--- a/src/services/prCloneTempWorktreeService.ts
+++ b/src/services/prCloneTempWorktreeService.ts
@@ -74,7 +74,7 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
 
             // Step 2: Fetch the target branch and the PR's commits (works for forks too)
             progress.report({ message: `Fetching PR #${data.prData.number} commits...` });
-            await this.fetchAllBranches(data.prData.number);
+            await this.fetchAllBranches(data.targetBranch, data.prData.number);
 
             throwIfCancellationRequested(token);
 
@@ -193,12 +193,16 @@ export class PrCloneTempWorktreeService extends PrCloneServiceBase {
     return tempPath;
   }
 
-  private async fetchAllBranches(prNumber: number): Promise<void> {
+  private async fetchAllBranches(targetBranch: string, prNumber: number): Promise<void> {
     if (!this.tempGit) {
       throw new Error('Temporary git workspace not initialized');
     }
 
-    await this.tempGit.fetchAllRemoteBranchesAndTags();
+    // Fetch only the target branch here — force-fetching all tags as a side
+    // effect of cloning a PR can silently overwrite local tags that diverged
+    // from the remote. The PR head fetch below is sufficient to get the
+    // commits we need (works for forks too).
+    await this.tempGit.fetchSpecificBranch(targetBranch);
 
     try {
       await this.tempGit.fetchPullRequestHead(prNumber);

--- a/src/statusBar/quickActionsState.ts
+++ b/src/statusBar/quickActionsState.ts
@@ -25,6 +25,8 @@ export interface WorktreeQuickActionsState {
   canCopyWipToWorktree: boolean;
   /** At least one tracked PR-review worktree still exists on disk. */
   hasPRReviewWorktree: boolean;
+  /** The repository's remote resolves to a GitHub repository. */
+  isGitHubRepo: boolean;
 }
 
 const EMPTY_STATE: WorktreeQuickActionsState = {
@@ -34,6 +36,7 @@ const EMPTY_STATE: WorktreeQuickActionsState = {
   canCopyStagedToWorktree: false,
   canCopyWipToWorktree: false,
   hasPRReviewWorktree: false,
+  isGitHubRepo: false,
 };
 
 function isSamePath(left: string, right: string): boolean {
@@ -86,6 +89,7 @@ async function gatherForFolder(
     canCopyStagedToWorktree: hasStagedChanges && hasOtherWorktree,
     canCopyWipToWorktree: hasWipChanges && hasOtherWorktree,
     hasPRReviewWorktree,
+    isGitHubRepo: repoInfo !== null,
   };
 }
 
@@ -115,6 +119,7 @@ export async function gatherWorktreeQuickActionsState(
         state.canCopyStagedToWorktree ||= folderState.canCopyStagedToWorktree;
         state.canCopyWipToWorktree ||= folderState.canCopyWipToWorktree;
         state.hasPRReviewWorktree ||= folderState.hasPRReviewWorktree;
+        state.isGitHubRepo ||= folderState.isGitHubRepo;
       } catch (error) {
         logService.warn(
           `[Quick Actions] Failed to gather worktree state for ${folder.path}: ${

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -31,12 +31,35 @@ interface QuickActionItem extends QuickPickItem {
   visible?: boolean;
 }
 
+interface ModeQuickPickItem extends QuickPickItem {
+  mode: TAutoStashModeConfig;
+}
+
 export function getStatusBarBackgroundColor(
   mode: TAutoStashModeConfig
 ): ThemeColor | undefined {
   return mode === AUTO_STASH_MODE_MANUAL
     ? undefined
     : new ThemeColor('statusBarItem.warningBackground');
+}
+
+/**
+ * Builds the Mode QuickPick item list. Each item carries the actual `mode`
+ * value so the selection handler can read it directly instead of re-parsing
+ * the display label. Pure (no VS Code interaction) so it can be unit-tested.
+ */
+export function buildModeQuickPickItems(
+  currentMode: TAutoStashModeConfig
+): ModeQuickPickItem[] {
+  return AUTO_STASH_MODES.map((mode) => {
+    const modeDetails = AUTO_STASH_MODES_DETAILS[mode];
+    return {
+      label: `${modeDetails.icon} ${modeDetails.label}`,
+      description: modeDetails.description,
+      detail: currentMode === mode ? 'Currently active' : undefined,
+      mode,
+    };
+  });
 }
 
 /**
@@ -60,7 +83,11 @@ export function buildQuickActionItems(
     { label: 'Checkout', kind: QuickPickItemKind.Separator },
     { label: '$(arrow-swap) Checkout to…', commandId: command('checkoutTo') },
     { label: '$(history) Checkout previous branch', commandId: command('checkoutPrevious') },
-    { label: '$(git-pull-request) Checkout by PR number…', commandId: command('checkoutByPR') },
+    {
+      label: '$(git-pull-request) Checkout by PR number…',
+      commandId: command('checkoutByPR'),
+      visible: state.isGitHubRepo,
+    },
     { label: '$(git-branch) Create branch from template…', commandId: command('createBranchFromTemplate') },
     { label: '$(tag) Create tag from template…', commandId: command('createTagFromTemplate') },
     { label: 'Update branch', kind: QuickPickItemKind.Separator },
@@ -112,7 +139,11 @@ export function buildQuickActionItems(
       visible: state.hasPRReviewWorktree,
     },
     { label: 'GitHub', kind: QuickPickItemKind.Separator },
-    { label: '$(repo-clone) Clone pull request…', commandId: command('clonePullRequest') },
+    {
+      label: '$(repo-clone) Clone pull request…',
+      commandId: command('clonePullRequest'),
+      visible: state.isGitHubRepo,
+    },
     { label: 'Settings', kind: QuickPickItemKind.Separator },
     { label: '$(settings-gear) Open settings', commandId: command('openSettings') },
   ];
@@ -188,14 +219,7 @@ export class StatusBarManager implements Disposable {
     const config = this.configManager.get();
     const currentMode = config.mode;
 
-    const items: QuickPickItem[] = AUTO_STASH_MODES.map((mode) => {
-      const modeDetails = AUTO_STASH_MODES_DETAILS[mode];
-      return {
-        label: `${modeDetails.icon} ${modeDetails.label}`,
-        description: modeDetails.description,
-        detail: currentMode === mode ? 'Currently active' : undefined,
-      } as QuickPickItem;
-    });
+    const items: ModeQuickPickItem[] = buildModeQuickPickItems(currentMode);
 
     const selection = await window.showQuickPick(items, {
       title: 'Select Auto Stash Checkout Mode',
@@ -208,13 +232,9 @@ export class StatusBarManager implements Disposable {
 
     this.loggingService.info(`Auto Stash Checkout Mode: ${selection?.label}`);
 
-    const [_, ...rest] = selection.label.split(' ');
-    const newModeLabel = rest.join(' ');
-    const newMode = AUTO_STASH_MODES.find(
-      (mode) => AUTO_STASH_MODES_DETAILS[mode].label === newModeLabel
-    );
+    const newMode = selection.mode;
 
-    this.loggingService.info(`New mode: ${newMode}, newModeLabel: ${newModeLabel}`);
+    this.loggingService.info(`New mode: ${newMode}`);
 
     if (newMode && newMode !== currentMode) {
       // const modeDetails = AUTO_STASH_MODES_DETAILS[newMode];

--- a/src/test/e2e/statusBarMenu.test.ts
+++ b/src/test/e2e/statusBarMenu.test.ts
@@ -19,21 +19,20 @@ const EXPECTED_ACTIONS = [
   'switchMode',
   'checkoutTo',
   'checkoutPrevious',
-  'checkoutByPR',
   'pullWithStash',
   'pullRebaseWithStash',
   'rebaseWithStash',
   'moveToNewWorktree',
   'prReviewInWorktree',
   'openWorktreeDevTerminal',
-  'clonePullRequest',
   'openSettings',
 ];
 
-// Actions gated on repository state (worktrees / pending changes). They are
-// absent from the menu when their precondition is not met — which is the case
-// in the clean, worktree-free e2e host. Their per-state visibility is covered
-// by the quickActions unit tests.
+// Actions gated on repository state (worktrees / pending changes / GitHub
+// remote). They are absent from the menu when their precondition is not met —
+// which is the case in the clean, worktree-free, remote-less e2e host (its
+// test repos have no "origin" remote, so isGitHubRepo is false). Their
+// per-state visibility is covered by the quickActions unit tests.
 const CONDITIONAL_ACTIONS = [
   'copyStagedChangesToWorktree',
   'copyWipChangesToWorktree',
@@ -42,6 +41,8 @@ const CONDITIONAL_ACTIONS = [
   'removeWorktree',
   'removeMultipleWorktrees',
   'removePRReviewInWorktree',
+  'checkoutByPR',
+  'clonePullRequest',
 ];
 
 function delay(ms = 0): Promise<void> {

--- a/src/test/unit/clonePullRequestErrorHandling.test.ts
+++ b/src/test/unit/clonePullRequestErrorHandling.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { UserCancelledError } from '../../utils/userCancelledError';
+import * as errorIssueNotification from '../../utils/errorIssueNotification';
+
+/**
+ * `clonePullRequest` in extension.ts is registered via a raw
+ * `vscode.commands.registerCommand` (it needs webview wiring that doesn't fit
+ * the `ICommand` interface), so it can't go through `CommandManager`. It
+ * wraps its body in the same try/catch shape as `CommandManager.registerAll`
+ * so errors (e.g. "Could not determine GitHub repository information") still
+ * get the consistent error-notification treatment instead of vanishing as an
+ * unhandled rejection. This test exercises that exact wrapping shape.
+ */
+function registerWithConsistentErrorHandling(
+  commandId: string,
+  callback: () => Promise<void>
+): vscode.Disposable {
+  return vscode.commands.registerCommand(commandId, async () => {
+    try {
+      await callback();
+    } catch (error) {
+      if (error instanceof UserCancelledError) {
+        return;
+      }
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await errorIssueNotification.showErrorMessageWithIssueAction(
+        `Command failed: ${errorMessage}`,
+        'OK'
+      );
+    }
+  });
+}
+
+describe('clonePullRequest-style raw command error handling', () => {
+  it('shows the consistent error notification when repository info cannot be determined', async () => {
+    const commandId = 'gitSmartCheckout.test.clonePullRequestFailure';
+    const disposable = registerWithConsistentErrorHandling(commandId, async () => {
+      throw new Error('Could not determine GitHub repository information');
+    });
+
+    const originalShow = errorIssueNotification.showErrorMessageWithIssueAction;
+    let notificationMessage: string | undefined;
+    (
+      errorIssueNotification as unknown as { showErrorMessageWithIssueAction: typeof originalShow }
+    ).showErrorMessageWithIssueAction = async (message: string) => {
+      notificationMessage = message;
+      return undefined;
+    };
+
+    try {
+      await vscode.commands.executeCommand(commandId);
+      assert.strictEqual(
+        notificationMessage,
+        'Command failed: Could not determine GitHub repository information'
+      );
+    } finally {
+      (
+        errorIssueNotification as unknown as {
+          showErrorMessageWithIssueAction: typeof originalShow;
+        }
+      ).showErrorMessageWithIssueAction = originalShow;
+      disposable.dispose();
+    }
+  });
+
+  it('silently swallows UserCancelledError without a notification', async () => {
+    const commandId = 'gitSmartCheckout.test.clonePullRequestCancelled';
+    const disposable = registerWithConsistentErrorHandling(commandId, async () => {
+      throw new UserCancelledError();
+    });
+
+    const originalShow = errorIssueNotification.showErrorMessageWithIssueAction;
+    let notificationShown = false;
+    (
+      errorIssueNotification as unknown as { showErrorMessageWithIssueAction: typeof originalShow }
+    ).showErrorMessageWithIssueAction = async () => {
+      notificationShown = true;
+      return undefined;
+    };
+
+    try {
+      await vscode.commands.executeCommand(commandId);
+      assert.strictEqual(notificationShown, false);
+    } finally {
+      (
+        errorIssueNotification as unknown as {
+          showErrorMessageWithIssueAction: typeof originalShow;
+        }
+      ).showErrorMessageWithIssueAction = originalShow;
+      disposable.dispose();
+    }
+  });
+});

--- a/src/test/unit/configurationManager.test.ts
+++ b/src/test/unit/configurationManager.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { ConfigurationManager } from '../../configuration/configurationManager';
+import {
+  ConfigurationManager,
+  shouldShowJiraEmailMigrationNotice,
+} from '../../configuration/configurationManager';
 import { EXTENSION_NAME } from '../../const';
 import { JIRA_TOKEN_SECRET_KEY } from '../../configuration/jiraTokenStore';
 import { FakeSecretStorage } from './helpers/fakeSecretStorage';
@@ -31,6 +34,36 @@ describe('ConfigurationManager', () => {
     manager.reload();
 
     assert.strictEqual(manager.get().jira.username, 'current@example.com');
+  });
+
+  describe('deprecated jira.email migration notice', () => {
+    it('flags a repo still relying on the deprecated jira.email setting', async () => {
+      await config.update('jira.username', '', vscode.ConfigurationTarget.Global);
+      await config.update('jira.email', 'legacy@example.com', vscode.ConfigurationTarget.Global);
+
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      assert.strictEqual(manager.isUsingDeprecatedJiraEmailSetting(), true);
+    });
+
+    it('does not flag when jira.username is already set', async () => {
+      await config.update('jira.username', 'current@example.com', vscode.ConfigurationTarget.Global);
+      await config.update('jira.email', 'legacy@example.com', vscode.ConfigurationTarget.Global);
+
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      assert.strictEqual(manager.isUsingDeprecatedJiraEmailSetting(), false);
+    });
+
+    it('does not flag when neither setting is configured', async () => {
+      const manager = new ConfigurationManager(new FakeSecretStorage());
+      assert.strictEqual(manager.isUsingDeprecatedJiraEmailSetting(), false);
+    });
+
+    it('only recommends showing the notice once', () => {
+      assert.strictEqual(shouldShowJiraEmailMigrationNotice(true, false), true);
+      assert.strictEqual(shouldShowJiraEmailMigrationNotice(true, true), false);
+      assert.strictEqual(shouldShowJiraEmailMigrationNotice(false, false), false);
+      assert.strictEqual(shouldShowJiraEmailMigrationNotice(false, true), false);
+    });
   });
 
   describe('Jira token in Secret Storage', () => {

--- a/src/test/unit/forkPrClone.test.ts
+++ b/src/test/unit/forkPrClone.test.ts
@@ -161,16 +161,46 @@ describe('PrCloneTempWorktreeService fork-PR fetch handling', () => {
     );
 
     (service as any).tempGit = {
-      fetchAllRemoteBranchesAndTags: async () => {},
+      fetchSpecificBranch: async () => {},
       fetchPullRequestHead: async () => {
         throw new Error('couldn\'t find remote ref pull/71/head');
       },
     };
 
     await assert.rejects(
-      (service as any).fetchAllBranches(71),
+      (service as any).fetchAllBranches('main', 71),
       /Could not fetch the PR's commits from GitHub/
     );
+  });
+
+  it('does not force-fetch all tags when fetching a PR into the temp worktree', async () => {
+    const service = new PrCloneTempWorktreeService(
+      {} as GitExecutor,
+      {} as GitHubClient,
+      mockLogService
+    );
+
+    let calledFetchAllRemoteBranchesAndTags = false;
+    let fetchedBranch: string | undefined;
+
+    (service as any).tempGit = {
+      fetchAllRemoteBranchesAndTags: async () => {
+        calledFetchAllRemoteBranchesAndTags = true;
+      },
+      fetchSpecificBranch: async (branch: string) => {
+        fetchedBranch = branch;
+      },
+      fetchPullRequestHead: async () => {},
+    };
+
+    await (service as any).fetchAllBranches('main', 71);
+
+    assert.strictEqual(
+      calledFetchAllRemoteBranchesAndTags,
+      false,
+      'should not force-fetch all tags as part of the PR clone flow'
+    );
+    assert.strictEqual(fetchedBranch, 'main');
   });
 
   it('rejects cherry-picking when a selected commit is missing locally', async () => {

--- a/src/test/unit/gitVersion.test.ts
+++ b/src/test/unit/gitVersion.test.ts
@@ -7,6 +7,7 @@ import {
   GitExecutor,
   parseGitVersion,
   supportsMergeTreeWriteTree,
+  supportsStashShowIncludeUntracked,
 } from '../../common/git/gitExecutor';
 import { LoggingService } from '../../logging/loggingService';
 
@@ -70,6 +71,129 @@ describe('Git merge-tree compatibility', () => {
       );
       assert.strictEqual(warnings.length, 1);
       assert.ok(warnings.every((message) => message.includes('Git 2.38')));
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) {
+        delete process.env.GSC_GIT_TEST_LOG;
+      } else {
+        process.env.GSC_GIT_TEST_LOG = oldLog;
+      }
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Git stash --include-untracked compatibility', () => {
+  it('requires Git 2.32 or newer', () => {
+    assert.strictEqual(supportsStashShowIncludeUntracked('git version 2.31.9'), false);
+    assert.strictEqual(supportsStashShowIncludeUntracked('git version 2.32.0'), true);
+    assert.strictEqual(supportsStashShowIncludeUntracked('git version 3.0.0'), true);
+  });
+
+  it('drops --include-untracked and appends a note on older Git', async () => {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-fake-git-'));
+    const gitLog = path.join(fakeBin, 'commands.log');
+    const gitPath = path.join(fakeBin, 'git');
+    fs.writeFileSync(
+      gitPath,
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$*" >> "$GSC_GIT_TEST_LOG"',
+        'if [ "$1" = "--version" ]; then',
+        '  echo "git version 2.31.9"',
+        '  exit 0',
+        'fi',
+        'if [ "$1" = "stash" ] && [ "$2" = "show" ]; then',
+        '  echo "diff content"',
+        '  exit 0',
+        'fi',
+        'exit 99',
+        '',
+      ].join('\n'),
+      { mode: 0o755 }
+    );
+
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_GIT_TEST_LOG;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_GIT_TEST_LOG = gitLog;
+
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      dispose: () => {},
+    } as unknown as LoggingService;
+
+    try {
+      const git = new GitExecutor(fakeBin, logger);
+      const patch = await git.getStashPatch('stash@{0}');
+
+      assert.ok(patch.includes('diff content'));
+      assert.match(patch, /untracked files not shown/i);
+
+      const loggedCommands = fs.readFileSync(gitLog, 'utf8').trim().split('\n');
+      const stashCommand = loggedCommands.find((line) => line.startsWith('stash show'));
+      assert.ok(stashCommand, 'expected a stash show command to be logged');
+      assert.ok(!stashCommand!.includes('--include-untracked'));
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) {
+        delete process.env.GSC_GIT_TEST_LOG;
+      } else {
+        process.env.GSC_GIT_TEST_LOG = oldLog;
+      }
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps --include-untracked on newer Git without appending a note', async () => {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-fake-git-'));
+    const gitLog = path.join(fakeBin, 'commands.log');
+    const gitPath = path.join(fakeBin, 'git');
+    fs.writeFileSync(
+      gitPath,
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$*" >> "$GSC_GIT_TEST_LOG"',
+        'if [ "$1" = "--version" ]; then',
+        '  echo "git version 2.40.0"',
+        '  exit 0',
+        'fi',
+        'if [ "$1" = "stash" ] && [ "$2" = "show" ]; then',
+        '  echo "diff content"',
+        '  exit 0',
+        'fi',
+        'exit 99',
+        '',
+      ].join('\n'),
+      { mode: 0o755 }
+    );
+
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_GIT_TEST_LOG;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_GIT_TEST_LOG = gitLog;
+
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      dispose: () => {},
+    } as unknown as LoggingService;
+
+    try {
+      const git = new GitExecutor(fakeBin, logger);
+      const patch = await git.getStashPatch('stash@{0}');
+
+      assert.strictEqual(patch.trim(), 'diff content');
+
+      const loggedCommands = fs.readFileSync(gitLog, 'utf8').trim().split('\n');
+      const stashCommand = loggedCommands.find((line) => line.startsWith('stash show'));
+      assert.ok(stashCommand, 'expected a stash show command to be logged');
+      assert.ok(stashCommand!.includes('--include-untracked'));
     } finally {
       process.env.PATH = oldPath;
       if (oldLog === undefined) {

--- a/src/test/unit/quickActions.test.ts
+++ b/src/test/unit/quickActions.test.ts
@@ -3,10 +3,16 @@ import * as assert from 'assert';
 import { QuickPickItemKind } from 'vscode';
 import { EXTENSION_NAME } from '../../const';
 import {
+  buildModeQuickPickItems,
   buildQuickActionItems,
   filterVisibleQuickActions,
 } from '../../statusBar/statusBarManager';
 import { WorktreeQuickActionsState } from '../../statusBar/quickActionsState';
+import {
+  AUTO_STASH_MODE_BRANCH,
+  AUTO_STASH_MODE_MANUAL,
+  AUTO_STASH_MODES,
+} from '../../configuration/extensionConfig';
 
 const commandId = (name: string) => `${EXTENSION_NAME}.${name}`;
 
@@ -17,6 +23,7 @@ const ALL_TRUE_STATE: WorktreeQuickActionsState = {
   canCopyStagedToWorktree: true,
   canCopyWipToWorktree: true,
   hasPRReviewWorktree: true,
+  isGitHubRepo: true,
 };
 
 const ALL_FALSE_STATE: WorktreeQuickActionsState = {
@@ -26,6 +33,7 @@ const ALL_FALSE_STATE: WorktreeQuickActionsState = {
   canCopyStagedToWorktree: false,
   canCopyWipToWorktree: false,
   hasPRReviewWorktree: false,
+  isGitHubRepo: false,
 };
 
 const CONDITIONAL_COMMANDS = [
@@ -36,13 +44,14 @@ const CONDITIONAL_COMMANDS = [
   'removeWorktree',
   'removeMultipleWorktrees',
   'removePRReviewInWorktree',
+  'checkoutByPR',
+  'clonePullRequest',
 ];
 
 const ALWAYS_VISIBLE_COMMANDS = [
   'switchMode',
   'checkoutTo',
   'checkoutPrevious',
-  'checkoutByPR',
   'createBranchFromTemplate',
   'createTagFromTemplate',
   'pullWithStash',
@@ -51,7 +60,6 @@ const ALWAYS_VISIBLE_COMMANDS = [
   'moveToNewWorktree',
   'prReviewInWorktree',
   'openWorktreeDevTerminal',
-  'clonePullRequest',
   'openSettings',
 ];
 
@@ -172,5 +180,45 @@ describe('filterVisibleQuickActions', () => {
     const wipIds = visibleCommandIds(wipOnly);
     assert.ok(wipIds.includes(commandId('copyWipChangesToWorktree')));
     assert.ok(!wipIds.includes(commandId('copyStagedChangesToWorktree')));
+  });
+
+  it('hides GitHub-only actions and their separator for a non-GitHub repo', () => {
+    const ids = visibleCommandIds(ALL_FALSE_STATE);
+
+    assert.ok(!ids.includes(commandId('checkoutByPR')));
+    assert.ok(!ids.includes(commandId('clonePullRequest')));
+    assert.ok(!separatorLabels(ALL_FALSE_STATE).includes('GitHub'));
+  });
+
+  it('shows GitHub-only actions for a GitHub repo', () => {
+    const state: WorktreeQuickActionsState = { ...ALL_FALSE_STATE, isGitHubRepo: true };
+    const ids = visibleCommandIds(state);
+
+    assert.ok(ids.includes(commandId('checkoutByPR')));
+    assert.ok(ids.includes(commandId('clonePullRequest')));
+    assert.ok(separatorLabels(state).includes('GitHub'));
+  });
+});
+
+describe('buildModeQuickPickItems', () => {
+  it('tags each item with its actual mode value instead of relying on the label text', () => {
+    const items = buildModeQuickPickItems(AUTO_STASH_MODE_MANUAL);
+
+    assert.strictEqual(items.length, AUTO_STASH_MODES.length);
+    for (const mode of AUTO_STASH_MODES) {
+      const item = items.find((i) => i.mode === mode);
+      assert.ok(item, `expected an item for mode ${mode}`);
+      assert.ok(item!.label.length > 0);
+    }
+  });
+
+  it('marks only the current mode as "Currently active"', () => {
+    const items = buildModeQuickPickItems(AUTO_STASH_MODE_BRANCH);
+
+    const active = items.find((item) => item.detail === 'Currently active');
+    assert.strictEqual(active?.mode, AUTO_STASH_MODE_BRANCH);
+
+    const inactive = items.filter((item) => item.mode !== AUTO_STASH_MODE_BRANCH);
+    assert.ok(inactive.every((item) => item.detail === undefined));
   });
 });

--- a/src/test/unit/worktreeCompletionActions.test.ts
+++ b/src/test/unit/worktreeCompletionActions.test.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+
+import {
+  ACTION_ADD_TO_WORKSPACE,
+  ACTION_OPEN_FOLDER,
+  ACTION_OPEN_IN_NEW_WINDOW,
+  getWorktreeCompletionActions,
+} from '../../commands/utils/worktreeCompletionActions';
+
+describe('getWorktreeCompletionActions', () => {
+  it('offers to add the worktree to the workspace when it is not already a workspace folder', () => {
+    // The test host has no workspace folders open, so any path is "not in workspace".
+    const actions = getWorktreeCompletionActions('/some/worktree/path');
+
+    assert.deepStrictEqual(actions, [
+      ACTION_ADD_TO_WORKSPACE,
+      ACTION_OPEN_FOLDER,
+      ACTION_OPEN_IN_NEW_WINDOW,
+    ]);
+  });
+});

--- a/src/utils/handleErrorMessage.ts
+++ b/src/utils/handleErrorMessage.ts
@@ -1,12 +1,21 @@
+import { LoggingService } from '../logging/loggingService';
 
-export const handleErrorMessage = (error: unknown, checkMessage = 'No local changes to save', message = 'No local changes to stash.', defaultMessage = 'Failed to stash the current changes.') => {
+export const handleErrorMessage = (
+  error: unknown,
+  checkMessage = 'No local changes to save',
+  message = 'No local changes to stash.',
+  defaultMessage = 'Failed to stash the current changes.',
+  logService?: Pick<LoggingService, 'error'>
+) => {
   if (error instanceof Error) {
     if (error.message === checkMessage) {
       throw new Error(message);
-    } 
+    }
 
-    throw new Error(defaultMessage);
-  } 
-  
+    logService?.error(defaultMessage, { originalError: error.message });
+    throw new Error(`${defaultMessage} (${error.message})`);
+  }
+
+  logService?.error(defaultMessage, { originalError: String(error) });
   throw new Error(defaultMessage);
 };

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -523,7 +523,8 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
   }
 
   private async handleShowConfirmationDialog(message: string, details: string, data: any) {
-    const confirmAction = 'Proceed';
+    const isDiscardConfirmation = data?.action === 'discardChanges';
+    const confirmAction = isDiscardConfirmation ? 'Discard' : 'Proceed';
 
     const selectedAction = await window.showInformationMessage(
       message,
@@ -531,9 +532,20 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       confirmAction
     );
 
-    if (selectedAction === confirmAction) {
-      await this.handleClonePR(data);
+    if (selectedAction !== confirmAction) {
+      return;
     }
+
+    if (isDiscardConfirmation) {
+      // The user confirmed discarding their edited description (triggered by
+      // pressing Escape) — reset the form the same way the Cancel button does,
+      // without going through the clone flow.
+      await this.handleHideCommitsWebview();
+      this.webviewView?.webview.postMessage({ command: WebviewCommand.CLEAR_STATE });
+      return;
+    }
+
+    await this.handleClonePR(data);
   }
 
   private handleWebviewLog(level: 'info' | 'warn' | 'error' | 'debug', message: string) {

--- a/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
+++ b/src/webview/Apps/PR/pages/PrCloneForm/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/Button';
 import { DropDownAction, DropDownButton } from '@/components/DropDownButton';
@@ -66,6 +66,7 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
   const [isPreview, setIsPreview] = useState(false);
   const [selectedCommits, setSelectedCommits] = useState<string[]>([]);
   const [validationError, setValidationError] = useState<string | undefined>();
+  const initialDescriptionRef = useRef(description);
 
   const logger = useLogger(false);
   const sendMessage = useSendMessage();
@@ -101,17 +102,17 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !isCloning) {
-        handleCancel();
+        handleEscapeCancel();
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isCloning]);
+  }, [isCloning, description]);
 
   const handleTargetBranchClick = () => {
     if (isCloning) return; // Prevent action during cloning
-    
+
     sendMessage(WebviewCommand.SELECT_TARGET_BRANCH, { branches });
   };
 
@@ -121,6 +122,23 @@ export const PrCloneForm: React.FC<PrCloneFormProps> = ({
     sendMessage(WebviewCommand.HIDE_COMMITS_WEBVIEW);
 
     onStartOver();
+  };
+
+  const handleEscapeCancel = () => {
+    if (isCloning) return; // Prevent cancel during cloning
+
+    if (description !== initialDescriptionRef.current) {
+      // Description was edited — confirm before discarding it, mirroring the
+      // confirmation flow used by handleSubmit rather than resetting silently.
+      sendMessage(WebviewCommand.SHOW_CONFIRMATION_DIALOG, {
+        message: 'Discard changes to the PR description?',
+        details: 'You have unsaved edits to the description. This will discard them and return to the start.',
+        data: { action: 'discardChanges' },
+      });
+      return;
+    }
+
+    handleCancel();
   };
 
   const handleSubmit = (isDraft: boolean = false) => {

--- a/website/src/components/Features/Features.tsx
+++ b/website/src/components/Features/Features.tsx
@@ -54,7 +54,7 @@ const features: Feature[] = [
         magic. Think of it as <kbd>Ctrl + Z</kbd> for branch switching.
       </>
     ),
-    command: 'GSC: Checkout previous branch (With Stash)',
+    command: 'GSC: Checkout Previous Branch (With Stash)',
     color: 'purple',
   },
   {
@@ -71,7 +71,7 @@ const features: Feature[] = [
     title: 'GitHub PR Clone',
     description:
       'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
-    command: 'GSC: Clone pull request...',
+    command: 'GSC: Clone Pull Request...',
     tag: 'Beta',
     color: 'orange',
   },
@@ -80,7 +80,7 @@ const features: Feature[] = [
     title: 'Checkout by PR Number',
     description:
       "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
-    command: 'GSC: Checkout by PR number... (With Stash)',
+    command: 'GSC: Checkout by PR Number... (With Stash)',
     color: 'orange',
   },
   {
@@ -88,7 +88,7 @@ const features: Feature[] = [
     title: 'PR Review in Worktree',
     description:
       'Open a GitHub PR in an isolated linked worktree, track its review metadata, and remove the review worktree later with dirty-state stash handling.',
-    command: 'GSC: PR Review in Worktree',
+    command: 'GSC: PR Review in Worktree...',
     color: 'purple',
   },
   {
@@ -120,7 +120,7 @@ const features: Feature[] = [
     title: 'Worktree Workflows',
     description:
       'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
-    command: 'GSC: Move to new worktree',
+    command: 'GSC: Move to New Worktree...',
     color: 'green',
   },
   {
@@ -135,7 +135,7 @@ const features: Feature[] = [
     title: 'Auto-Stash Manager',
     description:
       'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
-    command: 'GSC: Manage auto-stashes...',
+    command: 'GSC: Manage Auto-Stashes...',
     tag: 'New',
     color: 'green',
   },
@@ -144,7 +144,7 @@ const features: Feature[] = [
     title: 'Status Bar Integration',
     description:
       "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",
-    command: 'GSC: Quick Actions',
+    command: 'GSC: Quick Actions...',
     color: 'purple',
   },
 ];


### PR DESCRIPTION
## Summary

Fixes a bundle of ten small, unrelated defects (review issue 21, sub-items a-j):

- **a** — `statusBarManager`'s Mode QuickPick now carries the actual `mode` value on each item instead of re-deriving it by splitting the display label text.
- **b** — `copyChangesToWorktreeCommand` no longer duplicates the completion-actions logic; it now reuses the shared `showWorktreeCompletionActions` helper from `worktreeCompletionActions.ts`.
- **c** — the `clonePullRequest` command (registered via a raw `vscode.commands.registerCommand`, since it doesn't fit the `ICommand` interface) now wraps its body in the same try/catch shape as `CommandManager.registerAll`, so failures get the consistent error-notification treatment instead of an unhandled rejection.
- **d** — the quick-actions menu now hides GitHub-only items ("Clone Pull Request...", "Checkout by PR Number...") when the repo's remote isn't a GitHub repo (`getRepoInfo() === null`).
- **e** — the PR-clone temp-worktree flow no longer force-fetches all tags (`fetch --tags --force`); it now fetches only the target branch plus the PR head, which is sufficient (and non-destructive to local tags).
- **f** — `PrCloneForm` now confirms before discarding an edited description when Escape is pressed, mirroring the existing `SHOW_CONFIRMATION_DIALOG` pattern used by Submit; pressing Cancel still resets immediately.
- **g** — normalized `package.json` command titles to consistent Title Case and added a trailing `...` to commands that open further UI (QuickPick/input box/confirmation/webview); synced the matching strings in `README.md` and the website's `Features.tsx`.
- **h** — `getStashPatch` now gates `--include-untracked` on Git >= 2.32 (mirroring the existing `supportsMergeTreeWriteTree` version-check pattern), falling back with a "(untracked files not shown...)" note on older Git instead of erroring.
- **i** — extension activation now shows a one-time information notice (persisted via `context.globalState`) when `jira.email` is set but the replacement `jira.username` isn't, suggesting migration.
- **j** — `handleErrorMessage` now appends the original error's message to the generic stash-failure message and logs the original error, instead of silently discarding the detail.

Each sub-item includes a new or updated unit test covering the specific behavior.

## Test plan
- [x] `yarn compile` (type check + lint) passes
- [x] `yarn check-types-webview` passes
- [x] `yarn test:unit` passes (450 passing)
- [x] `yarn test` passes
- [ ] Manual smoke test in the VS Code extension host (status bar quick actions on a GitHub vs. non-GitHub repo, PR clone Escape-with-edits, stash diff preview)