### PR TITLE
feat: show recent branches in checkout picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,12 @@
           "default": true,
           "description": "Use VS Code's cached git model for branch pickers, preload details for the first visible refs, and cache ref details for 48 hours. Disable to always build lists with a full 'git for-each-ref' scan."
         },
+        "git-smart-checkout.recentBranchCount": {
+          "type": "number",
+          "default": 5,
+          "minimum": 0,
+          "description": "Number of recently checked-out branches shown in the checkout picker. Set to 0 to disable."
+        },
         "git-smart-checkout.defaultTargetBranch": {
           "type": "string",
           "default": "main",

--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -181,11 +181,16 @@ export class CheckoutToCommand extends BaseCommand {
 
     const buildItems = () => {
       const [locals, remotes] = getMergedBranchLists(branchList, currentBranch);
+      const recentNames = recentBranchNames ?? [];
+      const recentRefs = recentNames
+        .map((name) => locals.find((ref) => ref.name === name))
+        .filter((ref): ref is IGitRef => Boolean(ref));
+      const recentSet = new Set(recentRefs.map((ref) => ref.name));
       const tags = branchList.filter((t) => t.isTag);
       // Preferred refs float to the top of each section, ordered by when they were starred.
       const preferredLocal = this.configManager.sortByPreferredOrder(
         repoId,
-        locals.filter((b) => this.configManager.isPreferred(repoId, b))
+        locals.filter((b) => !recentSet.has(b.name) && this.configManager.isPreferred(repoId, b))
       );
       const preferredRemote = this.configManager.sortByPreferredOrder(
         repoId,
@@ -195,12 +200,18 @@ export class CheckoutToCommand extends BaseCommand {
         repoId,
         tags.filter((t) => this.configManager.isPreferred(repoId, t))
       );
-      const nonPreferredLocal = locals.filter((b) => !this.configManager.isPreferred(repoId, b));
+      const nonPreferredLocal = locals.filter(
+        (b) => !recentSet.has(b.name) && !this.configManager.isPreferred(repoId, b)
+      );
       const nonPreferredRemote = remotes.filter((b) => !this.configManager.isPreferred(repoId, b));
       const otherTags = tags.filter((t) => !this.configManager.isPreferred(repoId, t));
 
       const items: (vscode.QuickPickItem & { ref?: IGitRef; type?: 'action' | 'ref' })[] = [];
       items.push(...quickPickActions.map((a) => ({ label: a.label, type: 'action' as const })));
+      if (recentRefs.length > 0) {
+        items.push({ label: 'Recent', kind: vscode.QuickPickItemKind.Separator });
+        items.push(...recentRefs.map(toItem));
+      }
       items.push({ label: 'Branches', kind: vscode.QuickPickItemKind.Separator });
       items.push(...preferredLocal.map(toItem), ...nonPreferredLocal.map(toItem));
       items.push({ label: 'Remote branches', kind: vscode.QuickPickItemKind.Separator });
@@ -209,6 +220,12 @@ export class CheckoutToCommand extends BaseCommand {
       items.push(...preferredTags.map(toItem), ...otherTags.map(toItem));
       return items;
     };
+
+    let recentBranchNames: string[] | undefined;
+    const recentBranchCount = this.configManager.get().recentBranchCount;
+    if (recentBranchCount > 0) {
+      recentBranchNames = await git.getRecentBranches(recentBranchCount);
+    }
 
     qp.onDidTriggerItemButton(async (e) => {
       const ref = (e.item as any).ref as IGitRef | undefined;

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -994,4 +994,30 @@ export class GitExecutor {
       return null;
     }
   }
+
+  async getRecentBranches(limit: number): Promise<string[]> {
+    if (limit <= 0) {
+      return [];
+    }
+    const { stdout } = await this.#execGitCommand(['reflog', '--format=%gs', '-n', '200']);
+    const current = await this.getCurrentBranch();
+    const stats = new Map<string, { count: number; first: number }>();
+    const lines = stdout.split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const match = lines[index].match(/^checkout: moving from (.+) to (.+)$/);
+      if (!match) {
+        continue;
+      }
+      const target = match[2].trim();
+      if (!target || target === current || target === 'HEAD' || target.includes('detached')) {
+        continue;
+      }
+      const previous = stats.get(target);
+      stats.set(target, { count: (previous?.count ?? 0) + 1, first: previous?.first ?? index });
+    }
+    return [...stats.entries()]
+      .sort((a, b) => b[1].count - a[1].count || a[1].first - b[1].first)
+      .slice(0, limit * 2)
+      .map(([name]) => name);
+  }
 }

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -95,6 +95,7 @@ export class ConfigurationManager {
     return {
       mode: vscodeConfig.get('mode', AUTO_STASH_MODE_MANUAL),
       useFastBranchList: vscodeConfig.get('useFastBranchList', true),
+      recentBranchCount: vscodeConfig.get('recentBranchCount', 5),
       showStatusBar: vscodeConfig.get('showStatusBar', true),
       defaultTargetBranch: vscodeConfig.get('defaultTargetBranch', 'main'),
       defaultWorktreeDirectory: vscodeConfig.get('defaultWorktreeDirectory', ''),

--- a/src/configuration/extensionConfig.ts
+++ b/src/configuration/extensionConfig.ts
@@ -41,6 +41,7 @@ export interface JiraConfig {
 export interface ExtensionConfig {
   mode: TAutoStashModeConfig;
   useFastBranchList: boolean;
+  recentBranchCount: number;
   showStatusBar: boolean;
   defaultTargetBranch: string;
   defaultWorktreeDirectory: string;

--- a/src/test/unit/branchTemplateAvailability.test.ts
+++ b/src/test/unit/branchTemplateAvailability.test.ts
@@ -11,6 +11,7 @@ function baseConfig(overrides: {
   return {
     mode: AUTO_STASH_MODE_MANUAL,
     useFastBranchList: true,
+    recentBranchCount: 5,
     showStatusBar: true,
     defaultTargetBranch: 'main',
     defaultWorktreeDirectory: '',

--- a/src/test/unit/recentBranches.test.ts
+++ b/src/test/unit/recentBranches.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('GitExecutor.getRecentBranches', () => {
+  it('parses checkout entries, excludes current/detached targets, and ranks by frequency', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-recent-'));
+    const git = path.join(dir, 'git');
+    fs.writeFileSync(git, [
+      '#!/bin/sh',
+      'if [ "$1" = "rev-parse" ]; then printf "main\\n"; else printf "checkout: moving from main to a\\ncheckout: moving from a to b\\ncheckout: moving from b to a\\ncheckout: moving from a to detached HEAD\\ncheckout: moving from a to b\\ncommit: ordinary\\n"; fi',
+    ].join('\n'), { mode: 0o755 });
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
+    try {
+      const executor = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+      assert.deepStrictEqual(await executor.getRecentBranches(3), ['a', 'b']);
+      assert.deepStrictEqual(await executor.getRecentBranches(0), []);
+    } finally {
+      process.env.PATH = oldPath;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add configurable recent-branch history ranked from the checkout reflog.
- Show recent local branches in a dedicated checkout-picker section and deduplicate them from Branches.

## Manual test plan
1. Open a Git repository with at least three local branches.
2. Set `git-smart-checkout.recentBranchCount` to `5` (or leave the default).
3. Check out branches in a known sequence, then run `GSC: Checkout to...`.
4. Confirm a `Recent` section appears above `Branches`, the current branch is absent, and recent branches do not repeat below.
5. Delete one recently-used local branch and reopen the picker; confirm it is silently omitted.
6. Set `recentBranchCount` to `0`; confirm the Recent section is absent.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (runner exits successfully; local runner reported 0 tests)
- [ ] `yarn test:e2e:ci` (environment lacks `xvfb-run`)
- [ ] Manual smoke test in VS Code extension host