### PR TITLE
feat: add worktree explorer view

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,12 +221,56 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.worktree.open",
+        "title": "Open Worktree in New Window",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.terminal",
+        "title": "Open Worktree Dev Terminal",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.remove",
+        "title": "Remove Worktree",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.manageAutoStashes",
         "title": "Manage Auto-Stashes...",
         "category": "GSC"
       }
     ],
     "menus": {
+      "view/item/context": [
+        {
+          "command": "git-smart-checkout.worktree.open",
+          "when": "view == git-smart-checkout.worktrees && viewItem == worktree",
+          "group": "inline@1"
+        },
+        {
+          "command": "git-smart-checkout.worktree.terminal",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /^worktree/",
+          "group": "inline@2"
+        },
+        {
+          "command": "git-smart-checkout.worktree.remove",
+          "when": "view == git-smart-checkout.worktrees && viewItem == worktree",
+          "group": "inline@3"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "git-smart-checkout.moveToNewWorktree",
+          "when": "view == git-smart-checkout.worktrees",
+          "group": "navigation@1"
+        },
+        {
+          "command": "git-smart-checkout.removeMultipleWorktrees",
+          "when": "view == git-smart-checkout.worktrees && git-smart-checkout.hasMultipleRemovableWorktrees",
+          "group": "navigation@2"
+        }
+      ],
       "commandPalette": [
         {
           "command": "git-smart-checkout.prCancelCloneMenu",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,13 @@
     "views": {
       "git-smart-checkout": [
         {
+          "id": "git-smart-checkout.worktrees",
+          "name": "Worktrees",
+          "type": "tree",
+          "icon": "$(repo)",
+          "when": "git-smart-checkout.hasRepository"
+        },
+        {
           "id": "git-smart-checkout.prClone",
           "name": "PR Clone",
           "type": "webview",

--- a/src/commands/worktreeTreeActionCommand.ts
+++ b/src/commands/worktreeTreeActionCommand.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+import { GitExecutor } from '../common/git/gitExecutor';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { LoggingService } from '../logging/loggingService';
+import { BaseCommand } from './command';
+
+export type WorktreeTreeAction = 'open' | 'terminal' | 'remove';
+
+export class WorktreeTreeActionCommand extends BaseCommand {
+  constructor(
+    private readonly action: WorktreeTreeAction,
+    logService: LoggingService,
+    private readonly vscodeGitProvider?: VscodeGitProvider
+  ) {
+    super(logService);
+  }
+
+  async execute(worktreePath?: string, repositoryPath?: string): Promise<void> {
+    if (!worktreePath) return;
+    if (this.action === 'open') {
+      await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(worktreePath), true);
+      return;
+    }
+    if (this.action === 'terminal') {
+      const terminal = vscode.window.createTerminal({ name: 'Worktree', cwd: worktreePath });
+      terminal.show();
+      return;
+    }
+    if (!repositoryPath) return;
+    const confirmed = await vscode.window.showWarningMessage(
+      `Remove worktree at ${worktreePath}?`,
+      { modal: true },
+      'Remove Worktree'
+    );
+    if (confirmed !== 'Remove Worktree') return;
+    await new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider).worktreeRemove(worktreePath, false);
+    await vscode.window.showInformationMessage(`Worktree removed: ${worktreePath}`);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ import { randomUUID } from 'crypto';
 import { showErrorMessageWithIssueAction } from './utils/errorIssueNotification';
 import { UserCancelledError } from './utils/userCancelledError';
 import { WorktreeTreeDataProvider } from './view/WorktreeTreeDataProvider';
+import { WorktreeTreeActionCommand } from './commands/worktreeTreeActionCommand';
 
 export function activate(context: vscode.ExtensionContext) {
   const anonymousId = context.globalState.get<string>('analytics.anonymousId') ?? (() => {
@@ -115,6 +116,9 @@ export function activate(context: vscode.ExtensionContext) {
   const vscodeGitProvider = VscodeGitProvider.tryCreate(logService);
   const prReviewWorktreeStore = new PRReviewWorktreeStore(context.globalState, logService);
   const worktreeTreeDataProvider = new WorktreeTreeDataProvider(logService, prReviewWorktreeStore, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.open`, new WorktreeTreeActionCommand('open', logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.terminal`, new WorktreeTreeActionCommand('terminal', logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.remove`, new WorktreeTreeActionCommand('remove', logService, vscodeGitProvider));
   const statusBarManager = new StatusBarManager(
     configManager,
     logService,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -396,11 +396,13 @@ export function activate(context: vscode.ExtensionContext) {
   const windowStateListener = vscode.window.onDidChangeWindowState((state) => {
     if (state.focused) {
       void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
+      setTimeout(() => worktreeTreeDataProvider.refresh(), 2000);
     }
   });
   const workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
     void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
     void refreshRepositoryContext(logService);
+    worktreeTreeDataProvider.refresh();
   });
 
   // Listen for configuration changes

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ import { SetJiraTokenCommand } from './commands/setJiraTokenCommand';
 import { InitJiraCommand } from './commands/initJiraCommand';
 import { CreateTagFromTemplateCommand } from './commands/createTagFromTemplateCommand';
 import { canShowCreateBranchFromTemplateCommand } from './services/branchTemplateAvailability';
-import { setContextCanCreateBranchFromTemplate } from './utils/setContext';
+import { setContextCanCreateBranchFromTemplate, setContextHasRepository } from './utils/setContext';
 import { MoveToNewWorktreeCommand } from './commands/moveToNewWorktreeCommand';
 import { OpenWorktreeDevTerminalCommand } from './commands/openWorktreeDevTerminalCommand';
 import { ManageAutoStashesCommand } from './commands/manageAutoStashesCommand';
@@ -60,6 +60,7 @@ import { AnalyticsEvent, capture, initAnalytics, setAnalyticsEnabled, shutdownAn
 import { randomUUID } from 'crypto';
 import { showErrorMessageWithIssueAction } from './utils/errorIssueNotification';
 import { UserCancelledError } from './utils/userCancelledError';
+import { WorktreeTreeDataProvider } from './view/WorktreeTreeDataProvider';
 
 export function activate(context: vscode.ExtensionContext) {
   const anonymousId = context.globalState.get<string>('analytics.anonymousId') ?? (() => {
@@ -113,6 +114,7 @@ export function activate(context: vscode.ExtensionContext) {
   const logService = new LoggingService(configManager);
   const vscodeGitProvider = VscodeGitProvider.tryCreate(logService);
   const prReviewWorktreeStore = new PRReviewWorktreeStore(context.globalState, logService);
+  const worktreeTreeDataProvider = new WorktreeTreeDataProvider(logService, prReviewWorktreeStore, vscodeGitProvider);
   const statusBarManager = new StatusBarManager(
     configManager,
     logService,
@@ -151,6 +153,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Set initial context to hide PR Clone view and commits view
   setContextShowPRClone(false);
   setContextShowPRCommits(false);
+  void refreshRepositoryContext(logService);
 
   // Register commands
   const switchModeCommand = new SwitchModeCommand(statusBarManager, logService);
@@ -397,6 +400,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   const workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
     void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
+    void refreshRepositoryContext(logService);
   });
 
   // Listen for configuration changes
@@ -431,13 +435,28 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.registerWebviewViewProvider(
       `${EXTENSION_NAME}.prCommits`,
       prCommitsWebViewProvider
-    )
+    ),
+    vscode.window.registerTreeDataProvider(`${EXTENSION_NAME}.worktrees`, worktreeTreeDataProvider),
+    worktreeTreeDataProvider
   );
 
   // Show status bar
   statusBarManager.show();
 
   return { commandManager };
+}
+
+async function refreshRepositoryContext(logService: LoggingService): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  const hasRepository = (await Promise.all(folders.map(async (folder) => {
+    try {
+      await resolveGitRepositoryRoot(folder.uri.fsPath, logService);
+      return true;
+    } catch {
+      return false;
+    }
+  }))).some(Boolean);
+  await setContextHasRepository(hasRepository);
 }
 
 /**

--- a/src/test/unit/worktreeTreeDataProvider.test.ts
+++ b/src/test/unit/worktreeTreeDataProvider.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import { WorktreeTreeItem } from '../../view/WorktreeTreeDataProvider';
+
+describe('WorktreeTreeItem', () => {
+  it('describes dirty, tracked, and PR-review worktrees', () => {
+    const item = new WorktreeTreeItem(
+      { path: '/repo/review', branch: 'refs/heads/feature', head: 'abcdef123456' },
+      '/repo',
+      true,
+      [2, 1],
+      true
+    );
+    assert.strictEqual(item.label, 'feature');
+    assert.strictEqual(item.description, '/repo/review ⇡2 ⇣1 ● PR review');
+    assert.strictEqual(item.contextValue, 'worktree.prReview');
+  });
+
+  it('uses a short SHA for detached worktrees', () => {
+    const item = new WorktreeTreeItem(
+      { path: '/repo/detached', head: 'abcdef123456' },
+      '/repo',
+      false
+    );
+    assert.strictEqual(item.label, 'abcdef12');
+  });
+});

--- a/src/utils/setContext.ts
+++ b/src/utils/setContext.ts
@@ -28,3 +28,7 @@ export const setContextCanCreateBranchFromTemplate = async (value: boolean) => {
 export const setContextHasMultipleRemovableWorktrees = async (value: boolean) => {
   await setContextKey(`${EXTENSION_NAME}.hasMultipleRemovableWorktrees`, value);
 };
+
+export const setContextHasRepository = async (value: boolean) => {
+  await setContextKey(`${EXTENSION_NAME}.hasRepository`, value);
+};

--- a/src/view/WorktreeTreeDataProvider.ts
+++ b/src/view/WorktreeTreeDataProvider.ts
@@ -1,0 +1,99 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { GitExecutor } from '../common/git/gitExecutor';
+import { IGitWorktree } from '../common/git/types';
+import { LoggingService } from '../logging/loggingService';
+import { PRReviewWorktreeStore } from '../services/prReviewWorktreeStore';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { resolveGitRepositoryRoot } from '../utils/getGitExecutor';
+
+export class WorktreeTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly worktree: IGitWorktree,
+    public readonly repositoryPath: string,
+    isDirty: boolean,
+    track?: [number, number],
+    isPrReview = false
+  ) {
+    const branch = worktree.branch?.replace(/^refs\/heads\//, '');
+    super(branch || worktree.head?.slice(0, 8) || 'Detached HEAD', vscode.TreeItemCollapsibleState.None);
+    const shortened = worktree.path.startsWith(os.homedir())
+      ? `~${worktree.path.slice(os.homedir().length)}`
+      : worktree.path;
+    const arrows = track ? `⇡${track[0]} ⇣${track[1]}` : '';
+    this.description = [shortened, arrows, isDirty ? '●' : '', isPrReview ? 'PR review' : '']
+      .filter(Boolean)
+      .join(' ');
+    this.tooltip = `${worktree.path}\n${branch || 'detached HEAD'}`;
+    this.contextValue = isPrReview ? 'worktree.prReview' : 'worktree';
+    this.iconPath = new vscode.ThemeIcon(
+      isPrReview ? 'git-pull-request' : worktree.path === repositoryPath ? 'repo' : 'folder-library'
+    );
+    this.command = {
+      command: 'vscode.openFolder',
+      title: 'Open Worktree',
+      arguments: [vscode.Uri.file(worktree.path), true],
+    };
+  }
+}
+
+export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<WorktreeTreeItem> {
+  private readonly changeEmitter = new vscode.EventEmitter<WorktreeTreeItem | undefined>();
+  readonly onDidChangeTreeData = this.changeEmitter.event;
+  private items: WorktreeTreeItem[] = [];
+
+  constructor(
+    private readonly logService: LoggingService,
+    private readonly store: PRReviewWorktreeStore,
+    private readonly vscodeGitProvider?: VscodeGitProvider
+  ) {}
+
+  getTreeItem(item: WorktreeTreeItem): vscode.TreeItem {
+    return item;
+  }
+
+  async getChildren(): Promise<WorktreeTreeItem[]> {
+    await this.load();
+    return this.items;
+  }
+
+  refresh(): void {
+    this.items = [];
+    this.changeEmitter.fire(undefined);
+  }
+
+  dispose(): void {
+    this.changeEmitter.dispose();
+  }
+
+  private async load(): Promise<void> {
+    if (this.items.length > 0) {
+      return;
+    }
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    const loaded: WorktreeTreeItem[] = [];
+    for (const folder of folders) {
+      try {
+        const repositoryPath = await resolveGitRepositoryRoot(folder.uri.fsPath, this.logService);
+        const git = new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider);
+        const worktrees = await git.worktreeListDetailed(true);
+        const refs = await git.getAllRefListExtended();
+        const reviews = await this.store.getForRepository({
+          repoKey: repositoryPath,
+          repositoryPath,
+        });
+        for (const worktree of worktrees.filter((item) => !item.bare && !item.prunable)) {
+          const branch = worktree.branch?.replace(/^refs\/heads\//, '');
+          const ref = branch ? refs.find((item) => !item.remote && item.name === branch) : undefined;
+          const dirty = await new GitExecutor(worktree.path, this.logService, this.vscodeGitProvider).isWorkdirHasChanges();
+          const isPrReview = reviews.some((review) => path.resolve(review.worktreePath) === path.resolve(worktree.path));
+          loaded.push(new WorktreeTreeItem(worktree, repositoryPath, dirty, ref?.parsedUpstreamTrack, isPrReview));
+        }
+      } catch (error) {
+        this.logService.warn(`Failed to load worktrees for ${folder.uri.fsPath}: ${error}`);
+      }
+    }
+    this.items = loaded;
+  }
+}

--- a/src/view/WorktreeTreeDataProvider.ts
+++ b/src/view/WorktreeTreeDataProvider.ts
@@ -38,10 +38,22 @@ export class WorktreeTreeItem extends vscode.TreeItem {
   }
 }
 
-export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<WorktreeTreeItem> {
-  private readonly changeEmitter = new vscode.EventEmitter<WorktreeTreeItem | undefined>();
+export class WorktreeRepositoryTreeItem extends vscode.TreeItem {
+  constructor(public readonly repositoryPath: string, public readonly children: WorktreeTreeItem[]) {
+    super(path.basename(repositoryPath) || repositoryPath, vscode.TreeItemCollapsibleState.Expanded);
+    this.description = repositoryPath;
+    this.contextValue = 'worktree.repository';
+    this.iconPath = new vscode.ThemeIcon('repo');
+  }
+}
+
+type WorktreeNode = WorktreeTreeItem | WorktreeRepositoryTreeItem;
+
+export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<WorktreeNode> {
+  private readonly changeEmitter = new vscode.EventEmitter<WorktreeNode | undefined>();
   readonly onDidChangeTreeData = this.changeEmitter.event;
   private items: WorktreeTreeItem[] = [];
+  private repositories: WorktreeRepositoryTreeItem[] = [];
 
   constructor(
     private readonly logService: LoggingService,
@@ -49,17 +61,24 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
     private readonly vscodeGitProvider?: VscodeGitProvider
   ) {}
 
-  getTreeItem(item: WorktreeTreeItem): vscode.TreeItem {
+  getTreeItem(item: WorktreeNode): vscode.TreeItem {
     return item;
   }
 
-  async getChildren(): Promise<WorktreeTreeItem[]> {
+  async getChildren(element?: WorktreeRepositoryTreeItem): Promise<WorktreeNode[]> {
     await this.load();
+    if (element) {
+      return element.children;
+    }
+    if (this.repositories.length > 1) {
+      return this.repositories;
+    }
     return this.items;
   }
 
   refresh(): void {
     this.items = [];
+    this.repositories = [];
     this.changeEmitter.fire(undefined);
   }
 
@@ -73,6 +92,7 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
     }
     const folders = vscode.workspace.workspaceFolders ?? [];
     const loaded: WorktreeTreeItem[] = [];
+    const grouped = new Map<string, WorktreeTreeItem[]>();
     for (const folder of folders) {
       try {
         const repositoryPath = await resolveGitRepositoryRoot(folder.uri.fsPath, this.logService);
@@ -88,12 +108,19 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
           const ref = branch ? refs.find((item) => !item.remote && item.name === branch) : undefined;
           const dirty = await new GitExecutor(worktree.path, this.logService, this.vscodeGitProvider).isWorkdirHasChanges();
           const isPrReview = reviews.some((review) => path.resolve(review.worktreePath) === path.resolve(worktree.path));
-          loaded.push(new WorktreeTreeItem(worktree, repositoryPath, dirty, ref?.parsedUpstreamTrack, isPrReview));
+          const item = new WorktreeTreeItem(worktree, repositoryPath, dirty, ref?.parsedUpstreamTrack, isPrReview);
+          loaded.push(item);
+          const repoItems = grouped.get(repositoryPath) ?? [];
+          repoItems.push(item);
+          grouped.set(repositoryPath, repoItems);
         }
       } catch (error) {
         this.logService.warn(`Failed to load worktrees for ${folder.uri.fsPath}: ${error}`);
       }
     }
     this.items = loaded;
+    this.repositories = [...grouped.entries()].map(
+      ([repositoryPath, children]) => new WorktreeRepositoryTreeItem(repositoryPath, children)
+    );
   }
 }

--- a/src/view/WorktreeTreeDataProvider.ts
+++ b/src/view/WorktreeTreeDataProvider.ts
@@ -31,9 +31,9 @@ export class WorktreeTreeItem extends vscode.TreeItem {
       isPrReview ? 'git-pull-request' : worktree.path === repositoryPath ? 'repo' : 'folder-library'
     );
     this.command = {
-      command: 'vscode.openFolder',
+      command: 'git-smart-checkout.worktree.open',
       title: 'Open Worktree',
-      arguments: [vscode.Uri.file(worktree.path), true],
+      arguments: [worktree.path, repositoryPath],
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add a Worktrees tree view to the Git Smart Checkout activity bar.
- Show branch or detached-HEAD labels, shortened paths, dirty state, upstream ahead/behind markers, and PR-review badges.
- Group worktrees by repository in multi-root workspaces and refresh on focus/workspace changes.
- Add tree actions for opening, terminal access, and removal.

## Manual test plan
1. Open a Git repository containing the main worktree and at least one linked worktree.
2. Open the Git Smart Checkout activity-bar container and select `Worktrees`.
3. Confirm each worktree displays its branch (or short detached SHA), path, and main/linked icon.
4. Add an untracked file to the linked worktree and refocus VS Code; confirm its item shows `●`.
5. Create upstream divergence and refocus; confirm `⇡N ⇣M` appears.
6. Use the inline open and terminal actions; confirm they target the selected worktree.
7. Use Remove Worktree, confirm the modal, and verify the item disappears after refresh.
8. Open two repositories in a multi-root workspace; confirm repository parent nodes group their worktrees.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (runner exits successfully)
- [ ] `yarn test:e2e:ci` (environment lacks `xvfb-run`)
- [ ] Manual smoke test in VS Code extension host