### PR TITLE
feat: rescue stash conflicts with guided actions

### DIFF
--- a/src/commands/manageAutoStashesCommand/index.ts
+++ b/src/commands/manageAutoStashesCommand/index.ts
@@ -8,6 +8,7 @@ import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
 import { LoggingService } from '../../logging/loggingService';
 import { BaseCommand } from '../command';
 import { AUTO_STASH_PREFIX } from '../checkoutToCommand/constants';
+import { offerConflictRescue } from '../../services/stashConflictRescue';
 
 const ACTION_APPLY = 'Apply';
 const ACTION_POP = 'Pop';
@@ -161,13 +162,27 @@ export class ManageAutoStashesCommand extends BaseCommand {
     switch (action) {
       case 'apply': {
         const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-        await git.applyStash(selector);
+        try {
+          await git.applyStash(selector);
+        } catch (error) {
+          const conflicts = await git.getConflictedFiles();
+          if (conflicts.length === 0) throw error;
+          await offerConflictRescue(git, conflicts, 'apply');
+          return;
+        }
         await vscode.window.showInformationMessage('Auto-stash applied.', 'OK');
         return;
       }
       case 'pop': {
         const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-        await git.popStashBySelector(selector);
+        try {
+          await git.popStashBySelector(selector);
+        } catch (error) {
+          const conflicts = await git.getConflictedFiles();
+          if (conflicts.length === 0) throw error;
+          await offerConflictRescue(git, conflicts, 'pop');
+          return;
+        }
         await vscode.window.showInformationMessage('Auto-stash popped.', 'OK');
         return;
       }

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -835,6 +835,19 @@ export class GitExecutor {
     }
   }
 
+  async isMergeInProgress(): Promise<boolean> {
+    try {
+      await this.#execGitCommand(['rev-parse', '-q', '--verify', 'MERGE_HEAD']);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async resetMerge(): Promise<void> {
+    await this.#execGitCommand(['reset', '--merge']);
+  }
+
   async deleteLocalBranch(branchName: string) {
     const { stdout } = await this.#execGitCommand(['branch', '-D', branchName]);
     return stdout.trim();

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -409,6 +409,7 @@ export class AutoStashService {
       const conflicts = await git.getConflictedFiles();
       if (conflicts.length > 0) {
         await offerConflictRescue(git, conflicts, operation);
+        throw e;
       } else {
         handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
       }

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -11,6 +11,7 @@ import { IGitRef } from "../common/git/types";
 import { handleErrorMessage } from "../utils/handleErrorMessage";
 import { AnalyticsEvent, capture, captureException } from "../analytics/analytics";
 import { VscodeGitProvider } from "../common/git/vscodeGitProvider";
+import { offerConflictRescue } from './stashConflictRescue';
 
 export type TPullWithStashStrategy = 'merge' | 'rebase';
 
@@ -405,7 +406,12 @@ export class AutoStashService {
         await git.popStash(stashMessage, apply);
       }
     } catch (e) {
-      handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
+      const conflicts = await git.getConflictedFiles();
+      if (conflicts.length > 0) {
+        await offerConflictRescue(git, conflicts, operation);
+      } else {
+        handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
+      }
     }
 
     return 'completed';

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -409,7 +409,12 @@ export class AutoStashService {
       const conflicts = await git.getConflictedFiles();
       if (conflicts.length > 0) {
         await offerConflictRescue(git, conflicts, operation);
-        throw e;
+        handleErrorMessage(
+          e,
+          'No stash found',
+          `No stash to ${operation} on the new branch.`,
+          `Failed to ${operation} the stash on the new branch.`
+        );
       } else {
         handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
       }

--- a/src/services/stashConflictRescue.ts
+++ b/src/services/stashConflictRescue.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { GitExecutor } from '../common/git/gitExecutor';
+
+export type StashOperation = 'pop' | 'apply';
+
+export async function offerConflictRescue(
+  git: GitExecutor,
+  files: string[],
+  operation: StashOperation
+): Promise<void> {
+  const canUndo = !(await git.isMergeInProgress());
+  const message = `Stash restored with conflicts: ${files.length} file(s) need resolution. ${
+    operation === 'pop' ? 'The stash was preserved because pop conflicted.' : 'The stash is preserved because apply never removes it.'
+  }`;
+  const actions = ['Resolve conflicts', 'Open files', ...(canUndo ? ['Undo (keep stash)'] : [])];
+  const choice = await vscode.window.showWarningMessage(message, ...actions);
+  if (choice === 'Resolve conflicts') {
+    await vscode.commands.executeCommand('workbench.view.scm');
+    const uri = vscode.Uri.file(path.resolve(git.repositoryPath, files[0]));
+    try {
+      await vscode.commands.executeCommand('vscode.openWith', uri, 'workbench.editors.textFileEditor');
+    } catch {
+      await vscode.commands.executeCommand('vscode.open', uri);
+    }
+  } else if (choice === 'Open files') {
+    await Promise.all(files.map((file) => vscode.commands.executeCommand(
+      'vscode.open', vscode.Uri.file(path.resolve(git.repositoryPath, file))
+    )));
+  } else if (choice === 'Undo (keep stash)') {
+    await git.resetMerge();
+    await vscode.window.showInformationMessage(
+      'Conflicted changes were undone. The stash is preserved in GSC: Manage auto-stashes...'
+    );
+  }
+}

--- a/src/test/unit/stashConflictRescue.test.ts
+++ b/src/test/unit/stashConflictRescue.test.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('GitExecutor stash conflict recovery', () => {
+  it('issues reset --merge for the undo action', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-stash-rescue-'));
+    const log = path.join(dir, 'commands');
+    fs.writeFileSync(path.join(dir, 'git'), '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GSC_LOG"', { mode: 0o755 });
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_LOG;
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_LOG = log;
+    try {
+      await new GitExecutor(dir, mockLogService as unknown as LoggingService).resetMerge();
+      assert.strictEqual(fs.readFileSync(log, 'utf8').trim(), 'reset --merge');
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) delete process.env.GSC_LOG; else process.env.GSC_LOG = oldLog;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Detect conflicted stash pop/apply operations and show a guided rescue notification.
- Add actions to focus SCM/open conflicted files or undo with `git reset --merge` while preserving the stash.
- Reuse the rescue flow for Manage Auto-Stashes operations.

## Manual test plan
1. Create conflicting WIP changes and use checkout with auto-stash-and-pop.
2. Confirm the warning reports the conflicted file count and offers Resolve conflicts, Open files, and Undo (keep stash).
3. Choose Resolve conflicts and verify SCM focuses and the first conflicted file opens.
4. Repeat and choose Open files; verify all conflicted files open.
5. Choose Undo (keep stash); verify the worktree is cleaned and the stash remains in Manage Auto-Stashes.
6. Repeat through `GSC: Manage Auto-Stashes...` for both Apply and Pop; verify wording distinguishes them.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (runner exits successfully)
- [ ] `yarn test:e2e:ci` (environment lacks `xvfb-run`)