### PR TITLE
feat: add inline branch actions to checkout picker

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -162,18 +162,28 @@ export class CheckoutToCommand extends BaseCommand {
         .filter(Boolean)
         .join(' ');
 
+      const buttons: (vscode.QuickInputButton & { action?: string })[] = [{
+        iconPath: new vscode.ThemeIcon(
+          this.configManager.isPreferred(repoId, ref) ? 'star-full' : 'star'
+        ),
+        tooltip: this.configManager.isPreferred(repoId, ref) ? 'Unstar' : 'Star',
+        action: 'star',
+      }];
+      const canPush = !ref.isTag && !ref.remote && (!ref.upstreamTrack || Boolean(ref.parsedUpstreamTrack?.[0]));
+      if (ref.isTag) {
+        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete tag', action: 'delete' });
+      } else if (ref.remote) {
+        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete remote branch', action: 'delete' });
+      } else if (ref.name !== currentBranch) {
+        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete branch', action: 'delete' });
+        buttons.push({ iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Rename branch', action: 'rename' });
+        if (canPush) buttons.push({ iconPath: new vscode.ThemeIcon('cloud-upload'), tooltip: 'Publish branch', action: 'push' });
+      }
       return {
         label,
         description: getRefDescription(ref),
         detail: getRefDetails(ref),
-        buttons: [
-          {
-            iconPath: new vscode.ThemeIcon(
-              this.configManager.isPreferred(repoId, ref) ? 'star-full' : 'star'
-            ),
-            tooltip: this.configManager.isPreferred(repoId, ref) ? 'Unstar' : 'Star',
-          },
-        ],
+        buttons,
         ref,
         type: 'ref',
       };
@@ -215,8 +225,40 @@ export class CheckoutToCommand extends BaseCommand {
       if (!ref) {
         return;
       }
-      await this.configManager.togglePreferred(repoId, ref, branchList);
-      qp.items = buildItems();
+      const action = (e.button as any).action ?? 'star';
+      qp.busy = true;
+      try {
+        if (action === 'star') {
+          await this.configManager.togglePreferred(repoId, ref, branchList);
+        } else if (action === 'rename') {
+          const name = await vscode.window.showInputBox({ value: ref.name, prompt: 'New branch name' });
+          if (!name) return;
+          if (!/^[A-Za-z0-9._/-]+$/.test(name) || name.includes('..')) {
+            await vscode.window.showErrorMessage('Invalid branch name.', 'OK');
+            return;
+          }
+          await git.renameBranch(ref.name, name);
+        } else if (action === 'push') {
+          await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: `Publishing ${ref.name}` }, () => git.pushSetUpstream(ref.name));
+        } else if (ref.isTag) {
+          const confirmed = await vscode.window.showWarningMessage(`Delete tag ${ref.name}?`, { modal: true }, 'Delete');
+          if (confirmed === 'Delete') await git.deleteTag(ref.name);
+        } else if (ref.remote) {
+          const confirmed = await vscode.window.showWarningMessage(`Delete remote branch ${ref.remote}/${ref.name}?`, { modal: true }, 'Delete');
+          if (confirmed === 'Delete') await git.deleteRemoteBranch(ref.remote, ref.name);
+        } else {
+          const merged = await git.getMergedBranches(this.configManager.get().defaultTargetBranch);
+          const force = !merged.includes(ref.name);
+          if (force) {
+            const confirmed = await vscode.window.showWarningMessage(`Branch ${ref.name} is not merged into ${this.configManager.get().defaultTargetBranch}. Delete anyway?`, { modal: true }, 'Delete');
+            if (confirmed !== 'Delete') return;
+          }
+          await git.deleteBranch(ref.name, force);
+        }
+      } finally {
+        qp.busy = false;
+        qp.items = buildItems();
+      }
     });
 
     // Promise that resolves when the user makes a selection (or dismisses).

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -840,6 +840,31 @@ export class GitExecutor {
     return stdout.trim();
   }
 
+  async deleteBranch(name: string, force = false): Promise<void> {
+    await this.#execGitCommand(['branch', force ? '-D' : '-d', name]);
+  }
+
+  async deleteRemoteBranch(remote: string, name: string): Promise<void> {
+    await this.#execGitCommand(['push', remote, '--delete', name]);
+  }
+
+  async renameBranch(oldName: string, newName: string): Promise<void> {
+    await this.#execGitCommand(['branch', '-m', oldName, newName]);
+  }
+
+  async deleteTag(name: string): Promise<void> {
+    await this.#execGitCommand(['tag', '-d', name]);
+  }
+
+  async pushSetUpstream(branch: string): Promise<void> {
+    await this.#execGitCommand(['push', '-u', 'origin', branch]);
+  }
+
+  async getMergedBranches(base: string): Promise<string[]> {
+    const { stdout } = await this.#execGitCommand(['branch', '--merged', base]);
+    return stdout.split('\n').map((line) => line.replace(/^\s*[*+]\s*/, '').trim()).filter(Boolean);
+  }
+
   async worktreeList(muteError = false) {
     try {
       const { stdout } = await this.#execGitCommand(['worktree', 'list', '--porcelain']);

--- a/src/test/unit/branchActions.test.ts
+++ b/src/test/unit/branchActions.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { LoggingService } from '../../logging/loggingService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('GitExecutor branch actions', () => {
+  it('uses the expected git arguments for branch and tag operations', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-branch-actions-'));
+    const log = path.join(dir, 'commands');
+    fs.writeFileSync(path.join(dir, 'git'), '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GSC_LOG"\nprintf "main\\n"', { mode: 0o755 });
+    const oldPath = process.env.PATH;
+    const oldLog = process.env.GSC_LOG;
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
+    process.env.GSC_LOG = log;
+    try {
+      const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+      await git.deleteBranch('feature', false);
+      await git.renameBranch('feature', 'renamed');
+      await git.deleteTag('v1');
+      assert.deepStrictEqual(fs.readFileSync(log, 'utf8').trim().split('\n'), [
+        'branch -d feature', 'branch -m feature renamed', 'tag -d v1',
+      ]);
+    } finally {
+      process.env.PATH = oldPath;
+      if (oldLog === undefined) delete process.env.GSC_LOG; else process.env.GSC_LOG = oldLog;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add delete, rename, and publish buttons for local branches in the checkout picker.
- Add remote-branch and tag deletion with confirmation dialogs.
- Keep the picker open and refresh it after actions.

## Manual test plan
1. Open `GSC: Checkout to...` in a repository with local branches, a remote branch, and a tag.
2. Confirm local items show delete/rename buttons and publish when appropriate.
3. Rename a local branch and confirm the picker refreshes with the new name.
4. Delete a merged branch and confirm it is removed without a force-delete warning.
5. Delete an unmerged branch, dismiss once, then confirm; verify cancellation is silent and confirmation removes it.
6. Publish a local-only branch and verify its upstream is set.
7. Delete a remote branch/tag and confirm the modal names the target.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (runner exits successfully)
- [ ] `yarn test:e2e:ci` (environment lacks `xvfb-run`)