### PR TITLE
feat: add merged branch cleanup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,11 @@
         "command": "git-smart-checkout.manageAutoStashes",
         "title": "Manage Auto-Stashes...",
         "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.cleanupBranches",
+        "title": "Delete Merged Branches...",
+        "category": "GSC"
       }
     ],
     "menus": {

--- a/src/commands/cleanupBranchesCommand/index.ts
+++ b/src/commands/cleanupBranchesCommand/index.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { LoggingService } from '../../logging/loggingService';
+import { BaseCommand } from '../command';
+
+export class CleanupBranchesCommand extends BaseCommand {
+  constructor(logService: LoggingService, private readonly provider?: VscodeGitProvider) { super(logService); }
+
+  async execute(): Promise<void> {
+    const git = await this.getGitExecutor(this.provider, 'Delete merged branches');
+    const current = await git.getCurrentBranch();
+    const base = await git.getDefaultBranch();
+    const merged = new Set(await git.getMergedBranches(base));
+    const worktreeBranches = new Set((await git.worktreeListDetailed(true)).map((item) => item.branch?.replace(/^refs\/heads\//, '')));
+    const refs = (await git.getAllRefListExtended()).filter((ref) => !ref.remote && !ref.isTag);
+    const candidates = refs.filter((ref) => ref.name !== current && ref.name !== base && !worktreeBranches.has(ref.name) && merged.has(ref.name));
+    if (candidates.length === 0) {
+      await vscode.window.showInformationMessage('No merged or orphaned branches to clean up.', 'OK');
+      return;
+    }
+    const selected = await vscode.window.showQuickPick(candidates.map((ref) => ({ label: ref.name, picked: true, ref })), { canPickMany: true, title: `Delete merged branches (base: ${base})` });
+    if (!selected?.length) return;
+    const confirmed = await vscode.window.showWarningMessage(`Delete ${selected.length} branches? They can be recovered from the reflog for ~30 days.`, { modal: true }, 'Delete');
+    if (confirmed !== 'Delete') return;
+    let deleted = 0;
+    for (const item of selected) {
+      try { await git.deleteBranch(item.ref.name, false); deleted += 1; } catch (error) { this.logService.warn(`Failed to delete ${item.ref.name}: ${error}`); }
+    }
+    await vscode.window.showInformationMessage(`Deleted ${deleted} branches`, 'OK');
+  }
+}

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -878,6 +878,18 @@ export class GitExecutor {
     return stdout.split('\n').map((line) => line.replace(/^\s*[*+]\s*/, '').trim()).filter(Boolean);
   }
 
+  async getDefaultBranch(): Promise<string> {
+    try {
+      const { stdout } = await this.#execGitCommand(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+      return stdout.trim().replace(/^origin\//, '');
+    } catch {
+      const refs = await this.getAllRefListExtended();
+      if (refs.some((ref) => !ref.remote && !ref.isTag && ref.name === 'main')) return 'main';
+      if (refs.some((ref) => !ref.remote && !ref.isTag && ref.name === 'master')) return 'master';
+      throw new Error('Could not determine the default branch.');
+    }
+  }
+
   async worktreeList(muteError = false) {
     try {
       const { stdout } = await this.#execGitCommand(['worktree', 'list', '--porcelain']);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ import { setContextCanCreateBranchFromTemplate, setContextHasRepository } from '
 import { MoveToNewWorktreeCommand } from './commands/moveToNewWorktreeCommand';
 import { OpenWorktreeDevTerminalCommand } from './commands/openWorktreeDevTerminalCommand';
 import { ManageAutoStashesCommand } from './commands/manageAutoStashesCommand';
+import { CleanupBranchesCommand } from './commands/cleanupBranchesCommand';
 import { RemovePRReviewInWorktreeCommand } from './commands/removePRReviewInWorktreeCommand';
 import { RemoveWorktreeCommand } from './commands/removeWorktreeCommand';
 import { RemoveMultipleWorktreesCommand } from './commands/removeMultipleWorktreesCommand';
@@ -271,6 +272,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const manageAutoStashesCommand = new ManageAutoStashesCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.manageAutoStashes`, manageAutoStashesCommand);
+  commandManager.registerCommand(`${EXTENSION_NAME}.cleanupBranches`, new CleanupBranchesCommand(logService, vscodeGitProvider));
 
   const removePRReviewInWorktreeCommand = new RemovePRReviewInWorktreeCommand(
     logService,


### PR DESCRIPTION
## Summary
- Add `GSC: Delete Merged Branches...` with default-branch detection and worktree exclusions.
- Confirm and batch-delete merged local branches while preserving sequential failure handling.

## Manual test plan
1. Create and merge two local branches into the default branch.
2. Run `GSC: Delete Merged Branches...`.
3. Confirm merged branches are preselected and the current/default/worktree branches are excluded.
4. Confirm deletion and verify the selected branches are removed.
5. Run it in a clean repository and verify the informational no-candidates message.

## Test plan
- [x] `yarn compile`
- [ ] `yarn test:unit`
- [ ] `yarn test:e2e:ci` (environment lacks `xvfb-run`)