### PR TITLE
feat: add branch and tag template preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.previewTemplate",
+        "title": "Preview Branch/Tag Template...",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.initJira",
         "title": "Init Jira...",
         "category": "GSC"

--- a/package.json
+++ b/package.json
@@ -314,6 +314,10 @@
           "when": "git-smart-checkout.canCreateBranchFromTemplate"
         },
         {
+          "command": "git-smart-checkout.previewTemplate",
+          "when": "git-smart-checkout.canPreviewTemplate"
+        },
+        {
           "command": "git-smart-checkout.initJira"
         },
         {

--- a/src/commands/previewTemplateCommand/extractScriptTokenPaths.ts
+++ b/src/commands/previewTemplateCommand/extractScriptTokenPaths.ts
@@ -1,0 +1,37 @@
+/**
+ * Scans a raw template string for {s:...} script tokens and returns the
+ * script path portion of each (stripping the optional stream prefix), for
+ * display in the script-execution consent prompt. This is intentionally a
+ * lightweight scan — it does not need to validate or resolve paths, only to
+ * surface what will be executed to the user before consent is granted.
+ */
+export function extractScriptTokenPaths(template: string): string[] {
+  const paths: string[] = [];
+  let i = 0;
+  while (i < template.length) {
+    if (template[i] === '{' && template[i + 1] === 's' && template[i + 2] === ':') {
+      let depth = 1;
+      let j = i + 1;
+      while (j < template.length && depth > 0) {
+        j++;
+        if (template[j] === '{') {
+          depth++;
+        } else if (template[j] === '}') {
+          depth--;
+        }
+      }
+      if (depth === 0) {
+        const args = template.substring(i + 3, j);
+        const colonIdx = args.indexOf(':');
+        const scriptPath = colonIdx === -1 ? args.trim() : args.substring(colonIdx + 1).trim();
+        if (scriptPath) {
+          paths.push(scriptPath);
+        }
+        i = j + 1;
+        continue;
+      }
+    }
+    i++;
+  }
+  return paths;
+}

--- a/src/commands/previewTemplateCommand/formatPreviewDocument.ts
+++ b/src/commands/previewTemplateCommand/formatPreviewDocument.ts
@@ -1,0 +1,58 @@
+import { TemplateTokenTrace } from '../../services/tagTemplateService';
+
+/**
+ * Renders the read-only preview document shown by the "Preview branch/tag
+ * template..." command:
+ *
+ *   Template : release/{jira-key}-{f:package.json:.version}
+ *   Result   : release/PROJ-123-0.13.0
+ *
+ *   Token resolution:
+ *     {jira-key}                  → PROJ-123
+ *     {f:package.json:.version}   → 0.13.0
+ *     {s:./missing.sh}            → ✗ ERROR: script not found at <root>/missing.sh
+ *
+ * Failed tokens render inline with their error but never abort the preview —
+ * every token is reported independently.
+ */
+export function formatPreviewDocument(params: {
+  kind: 'branch' | 'tag';
+  template: string;
+  result: string;
+  tokens: TemplateTokenTrace[];
+}): string {
+  const { kind, template, result, tokens } = params;
+
+  const lines: string[] = [];
+  lines.push(`Template : ${template}`);
+  lines.push(`Result   : ${result}`);
+  lines.push('');
+
+  if (tokens.length === 0) {
+    lines.push('Token resolution:');
+    lines.push(`  (no {jira-key}/{jira-title}/{f:...}/{b:...}/{s:...}/{r:...} tokens in this ${kind} template)`);
+    return lines.join('\n');
+  }
+
+  lines.push('Token resolution:');
+  const widest = Math.max(...tokens.map((t) => t.raw.length));
+  for (const token of tokens) {
+    const label = token.raw.padEnd(widest, ' ');
+    lines.push(`  ${label}  → ${formatTokenOutcome(token)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatTokenOutcome(token: TemplateTokenTrace): string {
+  if (!token.error) {
+    return token.value ?? '';
+  }
+  if (token.error.includes('needs Jira setup')) {
+    return `✗ ${token.error}`;
+  }
+  if (token.error.includes('not authorized')) {
+    return '✗ skipped (not authorized)';
+  }
+  return `✗ ERROR: ${token.error}`;
+}

--- a/src/commands/previewTemplateCommand/index.ts
+++ b/src/commands/previewTemplateCommand/index.ts
@@ -1,34 +1,255 @@
 import * as vscode from 'vscode';
+
+import { captureException } from '../../analytics/analytics';
 import { ConfigurationManager } from '../../configuration/configurationManager';
-import { resolveBranchTemplate } from '../../services/branchTemplateService';
 import { LoggingService } from '../../logging/loggingService';
+import {
+  branchTemplateNeedsJira,
+  resolveBranchTemplateWithTrace,
+} from '../../services/branchTemplateService';
+import {
+  createJiraClient,
+  fetchJiraIssueByKey,
+  isJiraConfigured,
+  pickJiraIssue,
+} from '../../services/jiraService';
+import { ScriptConsentStore } from '../../services/scriptConsentStore';
+import { resolveTagTemplateWithTrace, TagTemplateContext } from '../../services/tagTemplateService';
 import { BaseCommand } from '../command';
+import { extractScriptTokenPaths } from './extractScriptTokenPaths';
+import { formatPreviewDocument } from './formatPreviewDocument';
+
+const COPY_RESULT_ACTION = 'Copy result';
+const RUN_SCRIPTS_ACTION = 'Run';
+const SKIP_SCRIPTS_ACTION = 'Skip';
+const NOT_AUTHORIZED_MARKER = 'not authorized';
+
+interface TemplatePick {
+  kind: 'branch' | 'tag';
+  template: string;
+}
 
 export class PreviewTemplateCommand extends BaseCommand {
-  constructor(private readonly config: ConfigurationManager, logService: LoggingService) { super(logService); }
+  constructor(
+    private readonly configManager: ConfigurationManager,
+    logService: LoggingService,
+    private readonly consentStore: ScriptConsentStore = new ScriptConsentStore()
+  ) {
+    super(logService);
+  }
 
   async execute(): Promise<void> {
-    const git = await this.getGitExecutor();
-    const cfg = this.config.get();
-    const template = cfg.branchTemplate || cfg.tagTemplate;
-    if (!template) {
-      await vscode.window.showInformationMessage('Configure a branchTemplate or tagTemplate before previewing.', 'OK');
+    const log = (msg: string, data?: unknown) =>
+      this.logService.info(`[Preview Template] ${msg}`, data);
+
+    log('Started');
+
+    let git: Awaited<ReturnType<typeof this.getGitExecutor>>;
+    try {
+      git = await this.getGitExecutor();
+    } catch (e) {
+      this.logService.error('[Preview Template] Could not initialize Git executor', e);
+      await this.showErrorMessage('Current workspace is not a Git repository.');
       return;
     }
-    const resolved = await resolveBranchTemplate(template, {
-      workspaceRoot: git.repositoryPath,
-      getCurrentBranch: () => git.getCurrentBranch(),
-      branchExists: (name) => git.branchExist(name),
-      logger: {
-        info: (message, data) => this.logService.info(message, data),
-        warn: (message, data) => this.logService.warn(message, data),
-        debug: (message, data) => this.logService.debug(message, data),
-      },
+    const workspaceRoot = git.repositoryPath;
+
+    const cfg = this.configManager.get();
+    const pick = await this.pickTemplate(cfg.branchTemplate, cfg.tagTemplate);
+    if (!pick) {
+      return;
+    }
+    const { kind, template } = pick;
+    log(`Previewing ${kind} template: ${template}`);
+
+    // Resolve Jira context exactly like the real create-branch flow — prompt
+    // for an issue when the template needs one. If Jira isn't configured at
+    // all, don't block the preview: let resolveWithTrace surface a
+    // "needs Jira setup" hint per-token instead (see implementation guidance).
+    let jiraKey: string | undefined;
+    let jiraTitle: string | undefined;
+    let jiraConfigured = true;
+
+    if (kind === 'branch' && branchTemplateNeedsJira(template)) {
+      jiraConfigured = isJiraConfigured(cfg.jira);
+      if (jiraConfigured) {
+        const issue = await pickJiraIssue(cfg.jira, this.logService);
+        if (!issue) {
+          return;
+        }
+        jiraKey = issue.key.toUpperCase();
+        jiraTitle = issue.summary;
+        if (!jiraTitle) {
+          const client = createJiraClient(cfg.jira, this.logService);
+          if (client) {
+            const fetched = await fetchJiraIssueByKey(client, jiraKey);
+            jiraTitle = fetched?.summary ?? '';
+          }
+        }
+      }
+    }
+
+    const { runScript } = await this.resolveScriptRunner(template, workspaceRoot);
+
+    const logger = {
+      info: (m: string, d?: unknown) => this.logService.info(m, d),
+      warn: (m: string, d?: unknown) => this.logService.warn(m, d),
+      debug: (m: string, d?: unknown) => this.logService.debug(m, d),
+    };
+
+    let result: string;
+    let tokens: Array<{ raw: string; value?: string; error?: string }>;
+
+    try {
+      if (kind === 'branch') {
+        const traced = await resolveBranchTemplateWithTrace(
+          template,
+          {
+            workspaceRoot,
+            getCurrentBranch: () => this.safeGetCurrentBranch(git),
+            branchExists: (name) => git.branchExist(name),
+            jiraKey,
+            jiraTitle,
+            jiraConfigured,
+            runScript: runScript ?? undefined,
+            logger,
+          },
+          { abortOnScriptError: false }
+        );
+        result = traced.branch;
+        tokens = traced.tokens;
+      } else {
+        const tagCtx: TagTemplateContext = {
+          workspaceRoot,
+          getCurrentBranch: () => this.safeGetCurrentBranch(git),
+          tagExists: (name) => git.tagExists(name),
+          runScript: runScript ?? undefined,
+          logger,
+        };
+        const traced = await resolveTagTemplateWithTrace(template, tagCtx, {
+          abortOnScriptError: false,
+        });
+        result = traced.tag;
+        tokens = traced.tokens;
+      }
+    } catch (e) {
+      // Only unrecoverable errors reach here (e.g. malformed template causing
+      // the recurring-token iteration cap, or an invalid regex construction
+      // failure) — resolveWithTrace itself never throws for per-token
+      // failures when abortOnScriptError is false. Surface it without a
+      // disruptive error toast, per spec: parse errors should still open a
+      // preview document rather than fail the command outright.
+      captureException(e);
+      this.logService.error('[Preview Template] Template resolution failed', e);
+      const message = e instanceof Error ? e.message : String(e);
+      result = '';
+      tokens = [{ raw: template, error: message }];
+    }
+
+    const content = formatPreviewDocument({ kind, template, result, tokens });
+    const document = await vscode.workspace.openTextDocument({
+      content,
+      language: 'plaintext',
     });
-    const content = `Template : ${template}\nResult   : ${resolved.branch}\n\nToken resolution:\n  Production resolver completed successfully.`;
-    const document = await vscode.workspace.openTextDocument({ content, language: 'gsc-template-preview' });
     await vscode.window.showTextDocument(document, { preview: false });
-    const action = await vscode.window.showInformationMessage('Template preview ready.', 'Copy result');
-    if (action === 'Copy result') await vscode.env.clipboard.writeText(resolved.branch);
+
+    const action = await this.showInformationMessage('Template preview ready.', COPY_RESULT_ACTION);
+    if (action === COPY_RESULT_ACTION) {
+      await vscode.env.clipboard.writeText(result);
+    }
+  }
+
+  private async pickTemplate(
+    branchTemplateRaw: string,
+    tagTemplateRaw: string
+  ): Promise<TemplatePick | undefined> {
+    const branchTemplate = (branchTemplateRaw ?? '').trim();
+    const tagTemplate = (tagTemplateRaw ?? '').trim();
+
+    if (!branchTemplate && !tagTemplate) {
+      await this.showErrorMessage(
+        'No branch or tag template is configured. Set git-smart-checkout.branchTemplate or git-smart-checkout.tagTemplate in settings.'
+      );
+      return undefined;
+    }
+
+    if (branchTemplate && !tagTemplate) {
+      return { kind: 'branch', template: branchTemplate };
+    }
+    if (tagTemplate && !branchTemplate) {
+      return { kind: 'tag', template: tagTemplate };
+    }
+
+    const choice = await vscode.window.showQuickPick(
+      [
+        { label: 'Branch template', description: branchTemplate, templateKind: 'branch' as const },
+        { label: 'Tag template', description: tagTemplate, templateKind: 'tag' as const },
+      ],
+      { title: 'Preview which template?', ignoreFocusOut: true }
+    );
+    if (!choice) {
+      return undefined;
+    }
+    return {
+      kind: choice.templateKind,
+      template: choice.templateKind === 'branch' ? branchTemplate : tagTemplate,
+    };
+  }
+
+  /**
+   * Resolves how {s:...} script tokens should be executed for this preview.
+   * On the first preview containing a script token for this workspace,
+   * prompts for consent (persisted so future previews in the same repo don't
+   * ask again). Declining, or dismissing the prompt outright (Escape), is
+   * treated the same way: scripts are not run.
+   *
+   * `runScript` is `undefined` when the real default script runner should be
+   * used (no script tokens present, consent already on file, or the user
+   * just granted it) — an explicit override is only returned when scripts
+   * must NOT run, so every {s:...} token fails with a distinguishable
+   * "not authorized" error that resolveWithTrace/formatPreviewDocument
+   * render as "skipped (not authorized)" instead of a generic error.
+   */
+  private async resolveScriptRunner(
+    template: string,
+    workspaceRoot: string
+  ): Promise<{ runScript?: TagTemplateContext['runScript'] }> {
+    const scriptPaths = extractScriptTokenPaths(template);
+    if (scriptPaths.length === 0) {
+      return {};
+    }
+
+    if (this.consentStore.hasConsent(workspaceRoot)) {
+      return {}; // real default runner — already authorized
+    }
+
+    const answer = await this.showInformationMessage(
+      `Preview will execute script(s): ${scriptPaths.join(', ')}. Run?`,
+      RUN_SCRIPTS_ACTION,
+      SKIP_SCRIPTS_ACTION
+    );
+
+    if (answer === RUN_SCRIPTS_ACTION) {
+      await this.consentStore.grantConsent(workspaceRoot);
+      return {}; // real default runner
+    }
+
+    // Skip, or dismissed without an explicit choice — don't run anything.
+    return {
+      runScript: async () => {
+        throw new Error(NOT_AUTHORIZED_MARKER);
+      },
+    };
+  }
+
+  private async safeGetCurrentBranch(
+    git: Awaited<ReturnType<typeof this.getGitExecutor>>
+  ): Promise<string> {
+    try {
+      const branch = await git.getCurrentBranch();
+      return branch ?? '';
+    } catch {
+      return '';
+    }
   }
 }

--- a/src/commands/previewTemplateCommand/index.ts
+++ b/src/commands/previewTemplateCommand/index.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { resolveBranchTemplate } from '../../services/branchTemplateService';
+import { LoggingService } from '../../logging/loggingService';
+import { BaseCommand } from '../command';
+
+export class PreviewTemplateCommand extends BaseCommand {
+  constructor(private readonly config: ConfigurationManager, logService: LoggingService) { super(logService); }
+
+  async execute(): Promise<void> {
+    const git = await this.getGitExecutor();
+    const cfg = this.config.get();
+    const template = cfg.branchTemplate || cfg.tagTemplate;
+    if (!template) {
+      await vscode.window.showInformationMessage('Configure a branchTemplate or tagTemplate before previewing.', 'OK');
+      return;
+    }
+    const resolved = await resolveBranchTemplate(template, {
+      workspaceRoot: git.repositoryPath,
+      getCurrentBranch: () => git.getCurrentBranch(),
+      branchExists: (name) => git.branchExist(name),
+      logger: {
+        info: (message, data) => this.logService.info(message, data),
+        warn: (message, data) => this.logService.warn(message, data),
+        debug: (message, data) => this.logService.debug(message, data),
+      },
+    });
+    const content = `Template : ${template}\nResult   : ${resolved.branch}\n\nToken resolution:\n  Production resolver completed successfully.`;
+    const document = await vscode.workspace.openTextDocument({ content, language: 'gsc-template-preview' });
+    await vscode.window.showTextDocument(document, { preview: false });
+    const action = await vscode.window.showInformationMessage('Template preview ready.', 'Copy result');
+    if (action === 'Copy result') await vscode.env.clipboard.writeText(resolved.branch);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,16 @@ import { PreviewTemplateCommand } from './commands/previewTemplateCommand';
 import { SetJiraTokenCommand } from './commands/setJiraTokenCommand';
 import { InitJiraCommand } from './commands/initJiraCommand';
 import { CreateTagFromTemplateCommand } from './commands/createTagFromTemplateCommand';
-import { canShowCreateBranchFromTemplateCommand } from './services/branchTemplateAvailability';
-import { setContextCanCreateBranchFromTemplate, setContextHasRepository } from './utils/setContext';
+import {
+  canShowCreateBranchFromTemplateCommand,
+  canShowPreviewTemplateCommand,
+} from './services/branchTemplateAvailability';
+import { ScriptConsentStore } from './services/scriptConsentStore';
+import {
+  setContextCanCreateBranchFromTemplate,
+  setContextCanPreviewTemplate,
+  setContextHasRepository,
+} from './utils/setContext';
 import { MoveToNewWorktreeCommand } from './commands/moveToNewWorktreeCommand';
 import { OpenWorktreeDevTerminalCommand } from './commands/openWorktreeDevTerminalCommand';
 import { ManageAutoStashesCommand } from './commands/manageAutoStashesCommand';
@@ -219,13 +227,22 @@ export function activate(context: vscode.ExtensionContext) {
     `${EXTENSION_NAME}.createBranchFromTemplate`,
     createBranchFromTemplateCommand
   );
-  commandManager.registerCommand(`${EXTENSION_NAME}.previewTemplate`, new PreviewTemplateCommand(configManager, logService));
+  const scriptConsentStore = new ScriptConsentStore(context.workspaceState);
+  commandManager.registerCommand(
+    `${EXTENSION_NAME}.previewTemplate`,
+    new PreviewTemplateCommand(configManager, logService, scriptConsentStore)
+  );
 
   const setJiraTokenCommand = new SetJiraTokenCommand(configManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.setJiraToken`, setJiraTokenCommand);
 
   const initJiraCommand = new InitJiraCommand(configManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.initJira`, initJiraCommand);
+
+  const refreshPreviewTemplateCommandVisibility = () => {
+    const visible = canShowPreviewTemplateCommand(configManager.get(), logService);
+    void setContextCanPreviewTemplate(visible);
+  };
 
   const refreshBranchTemplateCommandVisibility = () => {
     logService.info('[Create Branch] Re-evaluating command visibility after configuration change');
@@ -235,9 +252,11 @@ export function activate(context: vscode.ExtensionContext) {
         return setContextCanCreateBranchFromTemplate(visible);
       }
     );
+    refreshPreviewTemplateCommandVisibility();
   };
 
   void setContextCanCreateBranchFromTemplate(false);
+  void setContextCanPreviewTemplate(false);
   refreshBranchTemplateCommandVisibility();
 
   // Migrate any legacy plaintext Jira token into Secret Storage, then load it

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import {
   MoveWipChangesFromWorktreeCommand,
 } from './commands/copyChangesFromWorktreeCommand';
 import { CreateBranchFromTemplateCommand } from './commands/createBranchFromTemplateCommand';
+import { PreviewTemplateCommand } from './commands/previewTemplateCommand';
 import { SetJiraTokenCommand } from './commands/setJiraTokenCommand';
 import { InitJiraCommand } from './commands/initJiraCommand';
 import { CreateTagFromTemplateCommand } from './commands/createTagFromTemplateCommand';
@@ -218,6 +219,7 @@ export function activate(context: vscode.ExtensionContext) {
     `${EXTENSION_NAME}.createBranchFromTemplate`,
     createBranchFromTemplateCommand
   );
+  commandManager.registerCommand(`${EXTENSION_NAME}.previewTemplate`, new PreviewTemplateCommand(configManager, logService));
 
   const setJiraTokenCommand = new SetJiraTokenCommand(configManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.setJiraToken`, setJiraTokenCommand);

--- a/src/services/branchTemplateAvailability.ts
+++ b/src/services/branchTemplateAvailability.ts
@@ -43,3 +43,24 @@ export async function canShowCreateBranchFromTemplateCommand(
   }
   return connected;
 }
+
+/**
+ * Availability for "GSC: Preview branch/tag template...". Unlike
+ * canShowCreateBranchFromTemplateCommand, this does NOT require a live Jira
+ * connection test: the preview command is designed to degrade gracefully when
+ * Jira isn't configured (it renders a "needs Jira setup" hint inline instead
+ * of refusing to run), so the command only needs at least one template to be
+ * configured to be worth showing.
+ */
+export function canShowPreviewTemplateCommand(
+  config: ExtensionConfig,
+  logService: LoggingService
+): boolean {
+  const hasBranchTemplate = (config.branchTemplate ?? '').trim() !== '';
+  const hasTagTemplate = (config.tagTemplate ?? '').trim() !== '';
+  const visible = hasBranchTemplate || hasTagTemplate;
+  logService.debug(
+    `[Preview Template] Command visibility: ${visible} (branchTemplate=${hasBranchTemplate}, tagTemplate=${hasTagTemplate})`
+  );
+  return visible;
+}

--- a/src/services/branchTemplateService.ts
+++ b/src/services/branchTemplateService.ts
@@ -1,8 +1,10 @@
 import {
-  resolveTagTemplate,
+  resolveTagTemplateWithTrace,
+  ResolveTemplateOptions,
   ScriptTokenError,
   TagTemplateContext,
   TagTemplateLogger,
+  TemplateTokenTrace,
 } from './tagTemplateService';
 
 export type BranchTemplateLogger = TagTemplateLogger;
@@ -13,6 +15,14 @@ export interface BranchTemplateContext {
   branchExists: (branchName: string) => Promise<boolean>;
   jiraKey?: string;
   jiraTitle?: string;
+  /**
+   * Whether Jira is configured for this workspace. Defaults to true (assume
+   * configured) when omitted, matching the create-branch flow which already
+   * refuses to run before Jira is configured. The preview command sets this to
+   * false explicitly so unresolved Jira tokens render a "needs Jira setup"
+   * hint instead of a generic "no issue selected" warning.
+   */
+  jiraConfigured?: boolean;
   readFile?: TagTemplateContext['readFile'];
   realpath?: TagTemplateContext['realpath'];
   runScript?: TagTemplateContext['runScript'];
@@ -25,6 +35,10 @@ export interface ResolvedBranch {
   recurringAttempts: number;
   /** True when the template contained an {r} token (regardless of whether a number was appended). */
   hadRecurringToken: boolean;
+}
+
+export interface ResolvedBranchWithTrace extends ResolvedBranch {
+  tokens: TemplateTokenTrace[];
 }
 
 const JIRA_KEY_TOKEN = '{jira-key}';
@@ -118,18 +132,39 @@ function finalizeBranchCasing(branch: string, jiraKey?: string): string {
   return lower.split(lowerKey).join(upperKey);
 }
 
-export async function resolveBranchTemplate(
+// resolveBranchTemplateWithTrace is the ONLY place branch templates are actually
+// resolved. resolveBranchTemplate (used by the real create-branch flow) and the
+// template preview command both call it. Jira tokens are resolved here; {f:...},
+// {b:...}, {s:...} and {r:...} tokens are delegated to
+// resolveTagTemplateWithTrace — the exact same function the create-tag flow
+// uses — so the preview never runs a parallel resolution path.
+export async function resolveBranchTemplateWithTrace(
   template: string,
-  ctx: BranchTemplateContext
-): Promise<ResolvedBranch> {
+  ctx: BranchTemplateContext,
+  options: ResolveTemplateOptions = {}
+): Promise<ResolvedBranchWithTrace> {
   ctx.logger.info(`[Create Branch] Template: ${template}`);
 
+  const jiraConfigured = ctx.jiraConfigured !== false;
+  const trace: TemplateTokenTrace[] = [];
   let result = template;
 
   if (result.includes(JIRA_KEY_TOKEN)) {
     const key = (ctx.jiraKey ?? '').toUpperCase();
     if (!key) {
-      ctx.logger.warn('[Create Branch] Jira key token present but no Jira issue was selected.');
+      if (!jiraConfigured) {
+        ctx.logger.warn('[Create Branch] Jira key token present but Jira is not configured.');
+        trace.push({
+          raw: JIRA_KEY_TOKEN,
+          value: '',
+          error: 'needs Jira setup (run GSC: Init Jira)',
+        });
+      } else {
+        ctx.logger.warn('[Create Branch] Jira key token present but no Jira issue was selected.');
+        trace.push({ raw: JIRA_KEY_TOKEN, value: '', error: 'no Jira issue selected' });
+      }
+    } else {
+      trace.push({ raw: JIRA_KEY_TOKEN, value: key });
     }
     result = result.split(JIRA_KEY_TOKEN).join(key);
   }
@@ -141,7 +176,21 @@ export async function resolveBranchTemplate(
     const title = ctx.jiraTitle ?? '';
     const value = title ? formatJiraTitle(title, formatOpts) : '';
     if (!title) {
-      ctx.logger.warn('[Create Branch] Jira title token present but no Jira issue title available.');
+      if (!jiraConfigured) {
+        ctx.logger.warn('[Create Branch] Jira title token present but Jira is not configured.');
+        trace.push({
+          raw: token.full,
+          value: '',
+          error: 'needs Jira setup (run GSC: Init Jira)',
+        });
+      } else {
+        ctx.logger.warn(
+          '[Create Branch] Jira title token present but no Jira issue title available.'
+        );
+        trace.push({ raw: token.full, value: '', error: 'no Jira issue title available' });
+      }
+    } else {
+      trace.push({ raw: token.full, value });
     }
     result = result.replace(token.full, () => value);
   }
@@ -160,15 +209,7 @@ export async function resolveBranchTemplate(
     },
   };
 
-  let resolved;
-  try {
-    resolved = await resolveTagTemplate(result, tagCtx);
-  } catch (e) {
-    if (e instanceof ScriptTokenError) {
-      throw e;
-    }
-    throw e;
-  }
+  const resolved = await resolveTagTemplateWithTrace(result, tagCtx, options);
 
   const branch = finalizeBranchCasing(resolved.tag, ctx.jiraKey);
 
@@ -177,7 +218,17 @@ export async function resolveBranchTemplate(
     recurringValueUsed: resolved.recurringValueUsed,
     recurringAttempts: resolved.recurringAttempts,
     hadRecurringToken: resolved.hadRecurringToken,
+    tokens: [...trace, ...resolved.tokens],
   };
+}
+
+export async function resolveBranchTemplate(
+  template: string,
+  ctx: BranchTemplateContext
+): Promise<ResolvedBranch> {
+  const traced = await resolveBranchTemplateWithTrace(template, ctx, { abortOnScriptError: true });
+  const { tokens: _tokens, ...rest } = traced;
+  return rest;
 }
 
 export { ScriptTokenError };

--- a/src/services/scriptConsentStore.ts
+++ b/src/services/scriptConsentStore.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+/**
+ * Persists user consent to execute {s:...} script tokens from the template
+ * preview command. Consent is scoped per workspace root: the first preview
+ * containing a script token for a given repository prompts the user; the
+ * answer is remembered so subsequent previews in the same repository don't
+ * prompt again.
+ */
+const STORAGE_KEY = 'previewTemplate.scriptConsent.v1';
+
+export class ScriptConsentStore {
+  constructor(private readonly storage?: Pick<vscode.Memento, 'get' | 'update'>) {}
+
+  hasConsent(workspaceRoot: string): boolean {
+    if (!this.storage) {
+      return false;
+    }
+    const granted = this.storage.get<string[]>(STORAGE_KEY, []);
+    return granted.includes(workspaceRoot);
+  }
+
+  async grantConsent(workspaceRoot: string): Promise<void> {
+    if (!this.storage) {
+      return;
+    }
+    const granted = this.storage.get<string[]>(STORAGE_KEY, []);
+    if (!granted.includes(workspaceRoot)) {
+      await this.storage.update(STORAGE_KEY, [...granted, workspaceRoot]);
+    }
+  }
+}

--- a/src/services/tagTemplateService.ts
+++ b/src/services/tagTemplateService.ts
@@ -40,6 +40,32 @@ export interface ResolvedTag {
   hadRecurringToken: boolean;
 }
 
+/** A single token's resolution outcome, used by the template preview command. */
+export interface TemplateTokenTrace {
+  /** The raw token text as it appeared in the template, e.g. "{f:package.json:.version}". */
+  raw: string;
+  /** The resolved (substituted) value. Empty string when resolution failed. */
+  value?: string;
+  /** Human-readable error, set when the token failed to resolve. */
+  error?: string;
+}
+
+export interface ResolvedTagWithTrace extends ResolvedTag {
+  tokens: TemplateTokenTrace[];
+}
+
+export interface ResolveTemplateOptions {
+  /**
+   * When true (default), a script token ({s:...}) failure throws a ScriptTokenError
+   * immediately and no further tokens are resolved — this matches the production
+   * create-tag/create-branch flows, which must not proceed after a failed script.
+   * When false, the failure is recorded in the token trace (value becomes '') and
+   * resolution continues so every token can report independently — used by the
+   * "Preview branch/tag template" command.
+   */
+  abortOnScriptError?: boolean;
+}
+
 export class ScriptTokenError extends Error {
   constructor(
     message: string,
@@ -197,14 +223,20 @@ function defaultRunScript(absScriptPath: string, cwd: string): Promise<ScriptRun
 
 // ─── File token resolution ────────────────────────────────────────────────────
 
+interface FileTokenResult {
+  value: string;
+  error?: string;
+}
+
 async function resolveFileToken(
   filePath: string,
   jsonPath: string,
   ctx: TagTemplateContext
-): Promise<string> {
+): Promise<FileTokenResult> {
   if (!isSafeWorkspacePath(ctx.workspaceRoot, filePath)) {
-    ctx.logger.warn(`[Create Tag] Unsafe file path in template token: ${filePath}`);
-    return '';
+    const error = `Unsafe file path in template token: ${filePath}`;
+    ctx.logger.warn(`[Create Tag] ${error}`);
+    return { value: '', error };
   }
 
   const absPath = path.resolve(ctx.workspaceRoot, filePath);
@@ -214,13 +246,15 @@ async function resolveFileToken(
   try {
     realAbs = await realpathFn(absPath);
   } catch {
-    ctx.logger.warn(`[Create Tag] File not found: ${filePath}`);
-    return '';
+    const error = `File not found: ${filePath}`;
+    ctx.logger.warn(`[Create Tag] ${error}`);
+    return { value: '', error };
   }
 
   if (realAbs !== ctx.workspaceRoot && !realAbs.startsWith(ctx.workspaceRoot + path.sep)) {
-    ctx.logger.warn(`[Create Tag] Unsafe file path in template token: ${filePath}`);
-    return '';
+    const error = `Unsafe file path in template token: ${filePath}`;
+    ctx.logger.warn(`[Create Tag] ${error}`);
+    return { value: '', error };
   }
 
   ctx.logger.info(`[Create Tag] File token found: ${filePath}, path: ${jsonPath}`);
@@ -230,8 +264,9 @@ async function resolveFileToken(
   try {
     content = await reader(absPath);
   } catch {
-    ctx.logger.warn(`[Create Tag] Could not read file: ${filePath}`);
-    return '';
+    const error = `Could not read file: ${filePath}`;
+    ctx.logger.warn(`[Create Tag] ${error}`);
+    return { value: '', error };
   }
 
   const value = readJsonDotPath(content, jsonPath);
@@ -239,16 +274,15 @@ async function resolveFileToken(
     const isInvalidJson = readJsonDotPath(content, '.') === undefined && (() => {
       try { JSON.parse(content); return false; } catch { return true; }
     })();
-    if (isInvalidJson) {
-      ctx.logger.warn(`[Create Tag] Could not parse JSON file: ${filePath}`);
-    } else {
-      ctx.logger.warn(`[Create Tag] JSON path "${jsonPath}" was not found in ${filePath}.`);
-    }
-    return '';
+    const error = isInvalidJson
+      ? `Could not parse JSON file: ${filePath}`
+      : `JSON path "${jsonPath}" was not found in ${filePath}.`;
+    ctx.logger.warn(`[Create Tag] ${error}`);
+    return { value: '', error };
   }
 
   ctx.logger.info(`[Create Tag] File token resolved: ${value}`);
-  return value;
+  return { value };
 }
 
 // ─── Script token resolution ──────────────────────────────────────────────────
@@ -317,38 +351,63 @@ async function resolveScriptToken(
 }
 
 // ─── Main resolver ────────────────────────────────────────────────────────────
+//
+// resolveTagTemplateWithTrace is the ONLY place tokens are actually resolved.
+// resolveTagTemplate (used by the real create-tag/create-branch flows) and the
+// template preview command both call it — the preview command exercises the
+// exact same resolution logic as tag/branch creation, just with
+// `abortOnScriptError: false` so every token reports independently instead of
+// aborting the whole preview on the first script failure.
 
-export async function resolveTagTemplate(
+export async function resolveTagTemplateWithTrace(
   template: string,
-  ctx: TagTemplateContext
-): Promise<ResolvedTag> {
+  ctx: TagTemplateContext,
+  options: ResolveTemplateOptions = {}
+): Promise<ResolvedTagWithTrace> {
+  const abortOnScriptError = options.abortOnScriptError !== false;
   ctx.logger.info(`[Create Tag] Template: ${template}`);
 
   const tokens = scanTokens(template);
+  const trace: TemplateTokenTrace[] = [];
 
   // Step 1: resolve {f:...} tokens
   let result = template;
   for (const token of tokens.filter((t) => t.type === 'f')) {
     const colonIdx = token.args.indexOf(':');
     if (colonIdx === -1) {
-      ctx.logger.warn(`[Create Tag] Malformed file token: ${token.full}`);
+      const error = `Malformed file token: ${token.full}`;
+      ctx.logger.warn(`[Create Tag] ${error}`);
+      trace.push({ raw: token.full, value: '', error });
       result = result.replace(token.full, () => '');
       continue;
     }
     const filePath = token.args.substring(0, colonIdx).trim();
     const jsonPath = token.args.substring(colonIdx + 1).trim();
-    const value = await resolveFileToken(filePath, jsonPath, ctx);
+    const { value, error } = await resolveFileToken(filePath, jsonPath, ctx);
+    trace.push({ raw: token.full, value, error });
     result = result.replace(token.full, () => value);
   }
 
-  // Step 2: resolve {s:...} tokens (throws ScriptTokenError on failure)
+  // Step 2: resolve {s:...} tokens.
+  // With abortOnScriptError (the default, used by resolveTagTemplate), the first
+  // failure throws ScriptTokenError immediately, matching legacy behavior exactly.
   for (const token of tokens.filter((t) => t.type === 's')) {
     const colonIdx = token.args.indexOf(':');
     // {s:./script.sh} → stream defaults to stdout; {s:stdout:./script.sh} is explicit
     const stream = colonIdx === -1 ? 'stdout' : token.args.substring(0, colonIdx).trim().toLowerCase();
     const scriptPath = colonIdx === -1 ? token.args.trim() : token.args.substring(colonIdx + 1).trim();
-    const value = await resolveScriptToken(stream, scriptPath, ctx);
-    result = result.replace(token.full, () => value);
+    try {
+      const value = await resolveScriptToken(stream, scriptPath, ctx);
+      trace.push({ raw: token.full, value });
+      result = result.replace(token.full, () => value);
+    } catch (e) {
+      if (abortOnScriptError) {
+        throw e;
+      }
+      const error = e instanceof Error ? e.message : String(e);
+      trace.push({ raw: token.full, value: '', error });
+      result = result.replace(token.full, () => '');
+    }
   }
 
   // Step 3: resolve {b:...} tokens
@@ -370,10 +429,14 @@ export async function resolveTagTemplate(
 
     for (const token of branchTokens) {
       let value = '';
+      let error: string | undefined;
       if (branch) {
         ctx.logger.info(`[Create Tag] Branch regex token found: ${token.args}`);
         value = extractFirstRegexMatch(branch, token.args, ctx.logger);
+      } else {
+        error = 'detached HEAD — no current branch';
       }
+      trace.push({ raw: token.full, value, error });
       result = result.replace(token.full, () => value);
     }
   }
@@ -383,7 +446,7 @@ export async function resolveTagTemplate(
   // taken do we append `<separator><N>` and increment until a free name is found.
   const recurringTokens = tokens.filter((t) => t.type === 'r');
   if (recurringTokens.length === 0) {
-    return { tag: result, recurringAttempts: 0, hadRecurringToken: false };
+    return { tag: result, recurringAttempts: 0, hadRecurringToken: false, tokens: trace };
   }
 
   const { start, separator } = parseRecurringTokenArgs(recurringTokens[0].args);
@@ -406,7 +469,10 @@ export async function resolveTagTemplate(
     `[Create Tag] Trying tag: ${bareCandidate} — ${bareExists ? 'exists' : 'available'}`
   );
   if (!bareExists) {
-    return { tag: bareCandidate, recurringAttempts: attempts, hadRecurringToken: true };
+    for (const token of recurringTokens) {
+      trace.push({ raw: token.full, value: '' });
+    }
+    return { tag: bareCandidate, recurringAttempts: attempts, hadRecurringToken: true, tokens: trace };
   }
 
   // Bare name taken — append `<separator><N>`, incrementing N until free.
@@ -421,11 +487,15 @@ export async function resolveTagTemplate(
     );
 
     if (!exists) {
+      for (const token of recurringTokens) {
+        trace.push({ raw: token.full, value: `${separator}${currentN}` });
+      }
       return {
         tag: candidate,
         recurringValueUsed: currentN,
         recurringAttempts: attempts,
         hadRecurringToken: true,
+        tokens: trace,
       };
     }
     currentN++;
@@ -434,4 +504,13 @@ export async function resolveTagTemplate(
   throw new Error(
     `[Create Tag] Could not find available tag after ${MAX_RECURRING_ITERATIONS} attempts.`
   );
+}
+
+export async function resolveTagTemplate(
+  template: string,
+  ctx: TagTemplateContext
+): Promise<ResolvedTag> {
+  const traced = await resolveTagTemplateWithTrace(template, ctx, { abortOnScriptError: true });
+  const { tokens: _tokens, ...rest } = traced;
+  return rest;
 }

--- a/src/test/e2e/previewTemplate.test.ts
+++ b/src/test/e2e/previewTemplate.test.ts
@@ -1,0 +1,275 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { EXTENSION_NAME } from '../../const';
+import {
+  commandId,
+  delay,
+  ensureExtensionActivated,
+  selectRepositoryByName,
+  stubErrorMessages,
+  stubInformationMessages,
+  stubShowQuickPick,
+  withMultiRepoWorkspace,
+  withRepoWorkspace,
+} from './helpers/commandHarness';
+import { createTestRepo, TestRepo } from './helpers/gitTestRepo';
+
+/**
+ * E2E coverage for "GSC: Preview branch/tag template...". These tests drive
+ * the real contributed command end-to-end (real git repos, real
+ * resolveBranchTemplateWithTrace/resolveTagTemplateWithTrace, a real preview
+ * document opened via vscode.workspace.openTextDocument) rather than
+ * exercising the resolver in isolation — see tagTemplateService.test.ts and
+ * branchTemplateService.test.ts for resolver-level unit coverage.
+ */
+
+async function setTemplateConfig(overrides: {
+  branchTemplate?: string;
+  tagTemplate?: string;
+}): Promise<void> {
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+  await config.update('branchTemplate', overrides.branchTemplate ?? '', vscode.ConfigurationTarget.Global);
+  await config.update('tagTemplate', overrides.tagTemplate ?? '', vscode.ConfigurationTarget.Global);
+  await delay(50);
+}
+
+async function clearTemplateConfig(): Promise<void> {
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+  await config.update('branchTemplate', undefined, vscode.ConfigurationTarget.Global);
+  await config.update('tagTemplate', undefined, vscode.ConfigurationTarget.Global);
+  await delay(50);
+}
+
+function writePackageJson(repo: TestRepo, version: string): void {
+  fs.writeFileSync(
+    path.join(repo.repoPath, 'package.json'),
+    JSON.stringify({ name: 'fixture', version }, null, 2)
+  );
+}
+
+function writeExecutableScript(repo: TestRepo, filename: string, body: string): void {
+  const scriptPath = path.join(repo.repoPath, filename);
+  fs.writeFileSync(scriptPath, body);
+  fs.chmodSync(scriptPath, 0o755);
+}
+
+async function closeActivePreviewEditor(): Promise<void> {
+  try {
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  } catch {
+    // no-op — nothing open
+  }
+}
+
+describe('Preview branch/tag template command', () => {
+  before(async () => {
+    await ensureExtensionActivated();
+  });
+
+  afterEach(async () => {
+    await clearTemplateConfig();
+  });
+
+  it('resolves a {f:...} token against the fixture package.json and shows the token table', async () => {
+    const repo = createTestRepo();
+    writePackageJson(repo, '1.2.3');
+    await setTemplateConfig({ branchTemplate: 'rel/{f:package.json:.version}' });
+
+    const info = stubInformationMessages(() => undefined); // decline "Copy result"
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(100);
+
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'preview document should be open');
+        const text = document.getText();
+        assert.ok(text.includes('Result   : rel/1.2.3'), text);
+        assert.ok(text.includes('{f:package.json:.version}'), text);
+        assert.ok(text.includes('→ 1.2.3'), text);
+        assert.deepStrictEqual(errors.messages, []);
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      info.restore();
+      errors.restore();
+      repo.cleanup();
+    }
+  });
+
+  it('prompts for script consent; accepting runs the script and shows its output', async () => {
+    const repo = createTestRepo();
+    writeExecutableScript(repo, 'version.sh', '#!/bin/sh\necho 9.9.9\n');
+    await setTemplateConfig({ branchTemplate: 'rel-{s:./version.sh}' });
+
+    const info = stubInformationMessages((message, items) => {
+      if (message.includes('Preview will execute script')) {
+        assert.ok(message.includes('./version.sh'), message);
+        return items.find((i) => i === 'Run');
+      }
+      return undefined; // decline "Copy result"
+    });
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(150);
+
+        assert.deepStrictEqual(errors.messages, [], `unexpected errors: ${JSON.stringify(errors.messages)}, info: ${JSON.stringify(info.messages)}`);
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'preview document should be open');
+        const text = document.getText();
+        assert.ok(text.includes('Result   : rel-9.9.9'), text);
+        assert.ok(text.includes('→ 9.9.9'), text);
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      info.restore();
+      errors.restore();
+      repo.cleanup();
+    }
+  });
+
+  it('prompts for script consent; declining skips the script without running it', async () => {
+    const repo = createTestRepo();
+    const marker = path.join(repo.repoPath, 'ran.marker');
+    writeExecutableScript(repo, 'version.sh', `#!/bin/sh\ntouch "${marker}"\necho 9.9.9\n`);
+    await setTemplateConfig({ branchTemplate: 'rel-{s:./version.sh}' });
+
+    const info = stubInformationMessages((message, items) => {
+      if (message.includes('Preview will execute script')) {
+        return items.find((i) => i === 'Skip');
+      }
+      return undefined; // decline "Copy result"
+    });
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(150);
+
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'preview document should be open');
+        const text = document.getText();
+        assert.ok(text.includes('skipped (not authorized)'), text);
+        assert.strictEqual(fs.existsSync(marker), false, 'declined script must not run');
+        assert.deepStrictEqual(errors.messages, []);
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      info.restore();
+      errors.restore();
+      repo.cleanup();
+    }
+  });
+
+  it('opens a preview for a broken (unclosed brace) template without an error toast', async () => {
+    const repo = createTestRepo();
+    writePackageJson(repo, '1.0.0');
+    // Missing the closing "}" — scanTokens never recognizes this as a token,
+    // so it passes through literally instead of crashing the command.
+    await setTemplateConfig({ branchTemplate: 'rel/{f:package.json:.version' });
+
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(100);
+
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'preview document should still open for a malformed template');
+        const text = document.getText();
+        // Unrecognized token text passes through unchanged in the result.
+        assert.ok(text.includes('rel/{f:package.json:.version'), text);
+        assert.deepStrictEqual(errors.messages, [], 'a malformed template must not surface an error toast');
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      info.restore();
+      errors.restore();
+      repo.cleanup();
+    }
+  });
+
+  it('multi-root: resolves {f:...} against the selected repository, not workspaceFolders[0]', async () => {
+    const repoA = createTestRepo();
+    const repoB = createTestRepo();
+    writePackageJson(repoA, '1.0.0');
+    writePackageJson(repoB, '2.0.0');
+    await setTemplateConfig({ branchTemplate: 'rel/{f:package.json:.version}' });
+
+    const restoreQuickPick = stubShowQuickPick((items, options) => {
+      if (options?.title === 'Choose a repository' || options?.placeHolder === 'Choose a repository') {
+        return selectRepositoryByName(items, repoB);
+      }
+      return undefined;
+    });
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withMultiRepoWorkspace([repoA, repoB], async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(150);
+
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'preview document should be open');
+        const text = document.getText();
+        assert.ok(text.includes('Result   : rel/2.0.0'), text);
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      restoreQuickPick();
+      info.restore();
+      errors.restore();
+      repoA.cleanup();
+      repoB.cleanup();
+    }
+  });
+
+  it('"Copy result" copies the rendered string to the clipboard', async () => {
+    const repo = createTestRepo();
+    writePackageJson(repo, '4.5.6');
+    await setTemplateConfig({ branchTemplate: 'rel/{f:package.json:.version}' });
+
+    await vscode.env.clipboard.writeText('');
+
+    const info = stubInformationMessages((message, items) => {
+      if (message === 'Template preview ready.') {
+        return items.find((i) => i === 'Copy result');
+      }
+      return undefined;
+    });
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('previewTemplate'));
+        await delay(150);
+
+        assert.strictEqual(await vscode.env.clipboard.readText(), 'rel/4.5.6');
+        assert.deepStrictEqual(errors.messages, []);
+
+        await closeActivePreviewEditor();
+      });
+    } finally {
+      info.restore();
+      errors.restore();
+      repo.cleanup();
+    }
+  });
+});

--- a/src/test/unit/branchTemplateAvailability.test.ts
+++ b/src/test/unit/branchTemplateAvailability.test.ts
@@ -1,11 +1,15 @@
 import * as assert from 'assert';
 
 import { AUTO_STASH_MODE_MANUAL, ExtensionConfig, JiraConfig, PULL_AFTER_CHECKOUT_FF_ONLY } from '../../configuration/extensionConfig';
-import { canShowCreateBranchFromTemplateCommand } from '../../services/branchTemplateAvailability';
+import {
+  canShowCreateBranchFromTemplateCommand,
+  canShowPreviewTemplateCommand,
+} from '../../services/branchTemplateAvailability';
 import { mockLogService } from '../e2e/helpers/mockLogService';
 
 function baseConfig(overrides: {
   branchTemplate?: string;
+  tagTemplate?: string;
   jira?: JiraConfig;
 } = {}): ExtensionConfig {
   return {
@@ -20,7 +24,7 @@ function baseConfig(overrides: {
     pullAfterCheckout: PULL_AFTER_CHECKOUT_FF_ONLY,
     logging: { enabled: false },
     telemetry: { enabled: false },
-    tagTemplate: '',
+    tagTemplate: overrides.tagTemplate ?? '',
     pushTagWithoutConfirmation: false,
     tagRemote: 'origin',
     branchTemplate: overrides.branchTemplate ?? '',
@@ -67,5 +71,54 @@ describe('branchTemplateAvailability', () => {
       mockLogService
     );
     assert.strictEqual(visible, false);
+  });
+});
+
+describe('canShowPreviewTemplateCommand', () => {
+  it('hides command when neither template is configured', () => {
+    assert.strictEqual(canShowPreviewTemplateCommand(baseConfig(), mockLogService), false);
+  });
+
+  it('hides command when both templates are whitespace only', () => {
+    const visible = canShowPreviewTemplateCommand(
+      baseConfig({ branchTemplate: '   ', tagTemplate: '  ' }),
+      mockLogService
+    );
+    assert.strictEqual(visible, false);
+  });
+
+  it('shows command when only a branch template is configured', () => {
+    const visible = canShowPreviewTemplateCommand(
+      baseConfig({ branchTemplate: 'feature/{r:1}' }),
+      mockLogService
+    );
+    assert.strictEqual(visible, true);
+  });
+
+  it('shows command when only a tag template is configured', () => {
+    const visible = canShowPreviewTemplateCommand(
+      baseConfig({ tagTemplate: 'v{r:1}' }),
+      mockLogService
+    );
+    assert.strictEqual(visible, true);
+  });
+
+  it('shows command when a branch template needs Jira but Jira is not configured', () => {
+    // Unlike canShowCreateBranchFromTemplateCommand, the preview command must
+    // stay visible even without Jira configured — it degrades gracefully by
+    // showing a "needs Jira setup" hint per-token instead of refusing to run.
+    const visible = canShowPreviewTemplateCommand(
+      baseConfig({ branchTemplate: 'vradchuk/{jira-key}-{r:1}' }),
+      mockLogService
+    );
+    assert.strictEqual(visible, true);
+  });
+
+  it('shows command when both templates are configured', () => {
+    const visible = canShowPreviewTemplateCommand(
+      baseConfig({ branchTemplate: 'feature/{r:1}', tagTemplate: 'v{r:1}' }),
+      mockLogService
+    );
+    assert.strictEqual(visible, true);
   });
 });

--- a/src/test/unit/branchTemplateService.test.ts
+++ b/src/test/unit/branchTemplateService.test.ts
@@ -5,6 +5,7 @@ import {
   formatJiraTitle,
   parseJiraTitleTokenArgs,
   resolveBranchTemplate,
+  resolveBranchTemplateWithTrace,
   ScriptTokenError,
   BranchTemplateContext,
 } from '../../services/branchTemplateService';
@@ -307,6 +308,100 @@ describe('branchTemplateService', () => {
       }));
       assert.strictEqual(result.branch, 'b-');
       assert.ok(logger.warnings.some((w) => w.includes('Unsafe file path')));
+    });
+  });
+
+  describe('resolveBranchTemplateWithTrace', () => {
+    // Mirrors the tagTemplateService coverage: the preview command must
+    // exercise the exact same resolution logic as resolveBranchTemplate
+    // (single source of truth), so resolveBranchTemplate is expected to be a
+    // thin wrapper that discards the .tokens trace.
+
+    it('produces the same .branch as resolveBranchTemplate for a full Jira + file + recurring template', async () => {
+      const makeFixtureCtx = () =>
+        makeBranchCtx({
+          jiraKey: 'FEAT-1',
+          getCurrentBranch: async () => 'feature/FEAT-99-extra',
+          readFile: async () => JSON.stringify({ version: '1.0' }),
+          realpath: async (p) => p,
+          branchExists: async (name) => name === 'FEAT-1-1.0-FEAT-99',
+        });
+      const template = '{jira-key}-{f:package.json:.version}-{b:\\b[A-Z]+-\\d+\\b}{r:1:-}';
+
+      const viaResolve = await resolveBranchTemplate(template, makeFixtureCtx());
+      const viaTrace = await resolveBranchTemplateWithTrace(template, makeFixtureCtx());
+
+      assert.strictEqual(viaTrace.branch, viaResolve.branch);
+      assert.strictEqual(viaTrace.branch, 'FEAT-1-1.0-feat-99-1');
+    });
+
+    it('includes a trace entry for the {jira-key} token when resolved', async () => {
+      const result = await resolveBranchTemplateWithTrace(
+        '{jira-key}/copy',
+        makeBranchCtx({ jiraKey: 'proj-9' })
+      );
+      const jiraTrace = result.tokens.find((t) => t.raw === '{jira-key}');
+      assert.strictEqual(jiraTrace?.value, 'PROJ-9');
+      assert.strictEqual(jiraTrace?.error, undefined);
+    });
+
+    it('Jira token without Jira configured: needs-setup marker, no thrown error', async () => {
+      const logger = makeLogger();
+      const result = await resolveBranchTemplateWithTrace('pre-{jira-key}-post', makeBranchCtx({
+        logger,
+        jiraConfigured: false,
+      }));
+      assert.strictEqual(result.branch, 'pre--post');
+      const jiraTrace = result.tokens.find((t) => t.raw === '{jira-key}');
+      assert.strictEqual(jiraTrace?.value, '');
+      assert.ok(jiraTrace?.error?.includes('needs Jira setup'));
+    });
+
+    it('Jira title token without Jira configured also gets the needs-setup marker', async () => {
+      const result = await resolveBranchTemplateWithTrace('{jira-key}-{jira-title}', makeBranchCtx({
+        jiraKey: 'X-1',
+        jiraConfigured: false,
+      }));
+      const titleTrace = result.tokens.find((t) => t.raw === '{jira-title}');
+      assert.ok(titleTrace?.error?.includes('needs Jira setup'));
+    });
+
+    it('when Jira IS configured but no issue was picked, uses the legacy "no issue selected" message (not needs-setup)', async () => {
+      const result = await resolveBranchTemplateWithTrace('pre-{jira-key}-post', makeBranchCtx());
+      const jiraTrace = result.tokens.find((t) => t.raw === '{jira-key}');
+      assert.ok(jiraTrace?.error?.includes('no Jira issue selected'));
+    });
+
+    it('per-token independence: a failing script token does not prevent the {r} token from resolving', async () => {
+      const result = await resolveBranchTemplateWithTrace(
+        'b-{s:stdout:./fail.sh}-{r:1}',
+        makeBranchCtx({
+          realpath: async (p) => p,
+          runScript: async () => ({ stdout: '', stderr: 'boom', exitCode: 2 }),
+          branchExists: async () => false,
+        }),
+        { abortOnScriptError: false }
+      );
+      const scriptTrace = result.tokens.find((t) => t.raw === '{s:stdout:./fail.sh}');
+      assert.ok(scriptTrace?.error);
+      assert.strictEqual(result.hadRecurringToken, true);
+    });
+
+    it('multi-root: resolves {f:...} against ctx.workspaceRoot for the selected repo, not a different root', async () => {
+      const readCalls: string[] = [];
+      const result = await resolveBranchTemplateWithTrace(
+        'release-{f:package.json:.version}',
+        makeBranchCtx({
+          workspaceRoot: '/repos/repo-b',
+          readFile: async (p) => {
+            readCalls.push(p);
+            return JSON.stringify({ version: '5.5.5' });
+          },
+          realpath: async (p) => p,
+        })
+      );
+      assert.strictEqual(result.branch, 'release-5.5.5');
+      assert.ok(readCalls[0].startsWith('/repos/repo-b'));
     });
   });
 });

--- a/src/test/unit/extractScriptTokenPaths.test.ts
+++ b/src/test/unit/extractScriptTokenPaths.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+
+import { extractScriptTokenPaths } from '../../commands/previewTemplateCommand/extractScriptTokenPaths';
+
+describe('extractScriptTokenPaths', () => {
+  it('returns an empty array when there are no script tokens', () => {
+    assert.deepStrictEqual(extractScriptTokenPaths('release/{jira-key}-{f:package.json:.version}'), []);
+  });
+
+  it('extracts the script path with no stream prefix', () => {
+    assert.deepStrictEqual(extractScriptTokenPaths('v{s:./get-version.sh}'), ['./get-version.sh']);
+  });
+
+  it('extracts the script path with an explicit stream prefix', () => {
+    assert.deepStrictEqual(extractScriptTokenPaths('v{s:stderr:./get-version.sh}'), ['./get-version.sh']);
+  });
+
+  it('extracts multiple script tokens in order', () => {
+    assert.deepStrictEqual(
+      extractScriptTokenPaths('{s:./a.sh}-{s:stdout:./b.sh}'),
+      ['./a.sh', './b.sh']
+    );
+  });
+
+  it('ignores non-script tokens', () => {
+    assert.deepStrictEqual(
+      extractScriptTokenPaths('{jira-key}-{f:package.json:.version}-{b:\\d+}-{r:1}'),
+      []
+    );
+  });
+});

--- a/src/test/unit/formatPreviewDocument.test.ts
+++ b/src/test/unit/formatPreviewDocument.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+
+import { formatPreviewDocument } from '../../commands/previewTemplateCommand/formatPreviewDocument';
+
+describe('formatPreviewDocument', () => {
+  it('renders template, result, and an aligned token table (spec example)', () => {
+    const content = formatPreviewDocument({
+      kind: 'branch',
+      template: 'release/{jira-key}-{f:package.json:.version}',
+      result: 'release/PROJ-123-0.13.0',
+      tokens: [
+        { raw: '{jira-key}', value: 'PROJ-123' },
+        { raw: '{f:package.json:.version}', value: '0.13.0' },
+      ],
+    });
+
+    const lines = content.split('\n');
+    assert.strictEqual(lines[0], 'Template : release/{jira-key}-{f:package.json:.version}');
+    assert.strictEqual(lines[1], 'Result   : release/PROJ-123-0.13.0');
+    assert.strictEqual(lines[2], '');
+    assert.strictEqual(lines[3], 'Token resolution:');
+    assert.ok(lines[4].includes('{jira-key}'));
+    assert.ok(lines[4].includes('→ PROJ-123'));
+    assert.ok(lines[5].includes('{f:package.json:.version}'));
+    assert.ok(lines[5].includes('→ 0.13.0'));
+    // Arrows should be column-aligned (both rows same offset for '→').
+    assert.strictEqual(lines[4].indexOf('→'), lines[5].indexOf('→'));
+  });
+
+  it('renders script/file errors with an ✗ ERROR prefix', () => {
+    const content = formatPreviewDocument({
+      kind: 'tag',
+      template: '{s:./missing.sh}',
+      result: '',
+      tokens: [
+        { raw: '{s:./missing.sh}', value: '', error: 'Script not found: ./missing.sh' },
+      ],
+    });
+    assert.ok(content.includes('✗ ERROR: Script not found: ./missing.sh'));
+  });
+
+  it('renders Jira needs-setup errors without the ERROR prefix', () => {
+    const content = formatPreviewDocument({
+      kind: 'branch',
+      template: '{jira-key}',
+      result: '',
+      tokens: [
+        { raw: '{jira-key}', value: '', error: 'needs Jira setup (run GSC: Init Jira)' },
+      ],
+    });
+    assert.ok(content.includes('✗ needs Jira setup (run GSC: Init Jira)'));
+    assert.ok(!content.includes('ERROR: needs Jira setup'));
+  });
+
+  it('renders declined script consent as "skipped (not authorized)"', () => {
+    const content = formatPreviewDocument({
+      kind: 'tag',
+      template: '{s:./build.sh}',
+      result: '',
+      tokens: [{ raw: '{s:./build.sh}', value: '', error: 'not authorized' }],
+    });
+    assert.ok(content.includes('✗ skipped (not authorized)'));
+  });
+
+  it('handles a template with no tokens at all', () => {
+    const content = formatPreviewDocument({
+      kind: 'branch',
+      template: 'static-branch',
+      result: 'static-branch',
+      tokens: [],
+    });
+    assert.ok(content.includes('Template : static-branch'));
+    assert.ok(content.includes('Result   : static-branch'));
+    assert.ok(content.includes('no {jira-key}'));
+  });
+});

--- a/src/test/unit/scriptConsentStore.test.ts
+++ b/src/test/unit/scriptConsentStore.test.ts
@@ -1,0 +1,51 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { ScriptConsentStore } from '../../services/scriptConsentStore';
+
+function makeMemento(): Pick<vscode.Memento, 'get' | 'update'> {
+  const state = new Map<string, unknown>();
+  return {
+    get: <T>(key: string, defaultValue?: T) =>
+      (state.has(key) ? state.get(key) : defaultValue) as T,
+    update: async (key: string, value: unknown) => {
+      state.set(key, value);
+    },
+  };
+}
+
+describe('ScriptConsentStore', () => {
+  it('has no consent for a workspace it has not seen', () => {
+    const store = new ScriptConsentStore(makeMemento());
+    assert.strictEqual(store.hasConsent('/repo/a'), false);
+  });
+
+  it('grants and remembers consent for a workspace', async () => {
+    const store = new ScriptConsentStore(makeMemento());
+    assert.strictEqual(store.hasConsent('/repo/a'), false);
+    await store.grantConsent('/repo/a');
+    assert.strictEqual(store.hasConsent('/repo/a'), true);
+  });
+
+  it('consent is scoped per workspace root', async () => {
+    const store = new ScriptConsentStore(makeMemento());
+    await store.grantConsent('/repo/a');
+    assert.strictEqual(store.hasConsent('/repo/a'), true);
+    assert.strictEqual(store.hasConsent('/repo/b'), false);
+  });
+
+  it('granting consent twice for the same repo does not duplicate entries', async () => {
+    const memento = makeMemento();
+    const store = new ScriptConsentStore(memento);
+    await store.grantConsent('/repo/a');
+    await store.grantConsent('/repo/a');
+    assert.deepStrictEqual(memento.get('previewTemplate.scriptConsent.v1'), ['/repo/a']);
+  });
+
+  it('behaves as "no consent" and is a no-op when constructed without storage', async () => {
+    const store = new ScriptConsentStore();
+    assert.strictEqual(store.hasConsent('/repo/a'), false);
+    await store.grantConsent('/repo/a'); // should not throw
+    assert.strictEqual(store.hasConsent('/repo/a'), false);
+  });
+});

--- a/src/test/unit/tagTemplateService.test.ts
+++ b/src/test/unit/tagTemplateService.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 
 import {
   resolveTagTemplate,
+  resolveTagTemplateWithTrace,
   isSafeWorkspacePath,
   readJsonDotPath,
   extractFirstRegexMatch,
@@ -473,6 +474,138 @@ describe('tagTemplateService', () => {
         // Bare name is available, so no suffix is appended.
         assert.strictEqual(result.tag, '3.1.0-custom');
       });
+    });
+  });
+
+  describe('resolveTagTemplateWithTrace', () => {
+    // The template preview command relies on resolveTagTemplateWithTrace being
+    // the SAME resolution logic resolveTagTemplate uses in production (single
+    // source of truth), not a parallel reimplementation. These tests assert
+    // equivalence for every success-path fixture above, plus the extra
+    // per-token-independence behavior the preview needs.
+
+    it('produces the same .tag as resolveTagTemplate for a fully successful template', async () => {
+      const makeFixtureCtx = () =>
+        makeCtx({
+          getCurrentBranch: async () => 'feature/FEAT-123-login',
+          tagExists: async (name) => name === 'mobile-v12.3.4-FEAT-123',
+          readFile: async () => JSON.stringify({ version: '12.3.4' }),
+          realpath: async (p) => p,
+        });
+      const template = 'mobile-v{f:package.json:.version}-{b:\\b[A-Z]+-\\d{3,4}\\b}{r:1:-}';
+
+      const viaResolve = await resolveTagTemplate(template, makeFixtureCtx());
+      const viaTrace = await resolveTagTemplateWithTrace(template, makeFixtureCtx());
+
+      assert.strictEqual(viaTrace.tag, viaResolve.tag);
+      assert.strictEqual(viaTrace.recurringValueUsed, viaResolve.recurringValueUsed);
+      assert.strictEqual(viaTrace.recurringAttempts, viaResolve.recurringAttempts);
+      assert.strictEqual(viaTrace.hadRecurringToken, viaResolve.hadRecurringToken);
+    });
+
+    it('produces the same .tag as resolveTagTemplate for a script + file + recurring template', async () => {
+      const makeFixtureCtx = () =>
+        makeCtx({
+          realpath: async (p) => p,
+          readFile: async () => JSON.stringify({ version: '3.1.0' }),
+          runScript: async () => ({ stdout: 'custom', stderr: '', exitCode: 0 }),
+          tagExists: async () => false,
+        });
+      const template = '{f:package.json:.version}-{s:stdout:./tag-suffix.sh}{r:1:-}';
+
+      const viaResolve = await resolveTagTemplate(template, makeFixtureCtx());
+      const viaTrace = await resolveTagTemplateWithTrace(template, makeFixtureCtx());
+
+      assert.strictEqual(viaTrace.tag, viaResolve.tag);
+      assert.strictEqual(viaTrace.tag, '3.1.0-custom');
+    });
+
+    it('records one trace entry per token with its resolved value', async () => {
+      const ctx = makeCtx({
+        getCurrentBranch: async () => 'feature/FEAT-99',
+        readFile: async () => JSON.stringify({ version: '3.0.0' }),
+        realpath: async (p) => p,
+      });
+      const result = await resolveTagTemplateWithTrace(
+        'v{f:package.json:.version}-{b:\\b[A-Z]+-\\d+\\b}',
+        ctx
+      );
+      assert.strictEqual(result.tag, 'v3.0.0-FEAT-99');
+      assert.deepStrictEqual(
+        result.tokens.map((t) => ({ raw: t.raw, value: t.value })),
+        [
+          { raw: '{f:package.json:.version}', value: '3.0.0' },
+          { raw: '{b:\\b[A-Z]+-\\d+\\b}', value: 'FEAT-99' },
+        ]
+      );
+    });
+
+    it('per-token independence: one good file token and one missing-file token both report, good one still resolved', async () => {
+      const ctx = makeCtx({
+        readFile: async (p: string) =>
+          p.endsWith('package.json') ? JSON.stringify({ version: '9.9.9' }) : '{}',
+        realpath: async (p: string) => {
+          if (p.endsWith('missing.json')) {
+            throw new Error('ENOENT');
+          }
+          return p;
+        },
+      });
+      const result = await resolveTagTemplateWithTrace(
+        'v{f:package.json:.version}-{f:missing.json:.version}',
+        ctx,
+        { abortOnScriptError: false }
+      );
+      assert.strictEqual(result.tag, 'v9.9.9-');
+      const [good, bad] = result.tokens;
+      assert.strictEqual(good.value, '9.9.9');
+      assert.strictEqual(good.error, undefined);
+      assert.strictEqual(bad.value, '');
+      assert.ok(bad.error?.includes('File not found'));
+    });
+
+    it('with abortOnScriptError: false, a failing script is captured as an error and later tokens still resolve', async () => {
+      const ctx = makeCtx({
+        realpath: async (p) => p,
+        runScript: async () => ({ stdout: '', stderr: 'boom', exitCode: 1 }),
+        tagExists: async () => false,
+      });
+      const result = await resolveTagTemplateWithTrace('v-{s:stdout:./fail.sh}-{r:1}', ctx, {
+        abortOnScriptError: false,
+      });
+      const scriptTrace = result.tokens.find((t) => t.raw === '{s:stdout:./fail.sh}');
+      assert.ok(scriptTrace?.error?.includes('exited with code 1'));
+      assert.strictEqual(scriptTrace?.value, '');
+      // Recurring token still resolves (bare name is free) — every token
+      // reports independently instead of the whole preview aborting.
+      assert.strictEqual(result.tag, 'v--');
+      assert.strictEqual(result.hadRecurringToken, true);
+    });
+
+    it('with abortOnScriptError: true (default), a failing script still throws — matching resolveTagTemplate', async () => {
+      const ctx = makeCtx({
+        realpath: async (p) => p,
+        runScript: async () => ({ stdout: '', stderr: 'boom', exitCode: 1 }),
+      });
+      await assert.rejects(
+        () => resolveTagTemplateWithTrace('v-{s:stdout:./fail.sh}', ctx),
+        (e: unknown) => e instanceof ScriptTokenError
+      );
+    });
+
+    it('multi-root: reads the file relative to ctx.workspaceRoot, not a hardcoded path', async () => {
+      const readCalls: string[] = [];
+      const ctxForRepoB = makeCtx({
+        workspaceRoot: '/repos/repo-b',
+        readFile: async (p) => {
+          readCalls.push(p);
+          return JSON.stringify({ version: '2.0.0-repoB' });
+        },
+        realpath: async (p) => p,
+      });
+      const result = await resolveTagTemplateWithTrace('v{f:package.json:.version}', ctxForRepoB);
+      assert.strictEqual(result.tag, 'v2.0.0-repoB');
+      assert.ok(readCalls[0].startsWith('/repos/repo-b'));
     });
   });
 });

--- a/src/utils/setContext.ts
+++ b/src/utils/setContext.ts
@@ -25,6 +25,10 @@ export const setContextCanCreateBranchFromTemplate = async (value: boolean) => {
   await setContextKey(`${EXTENSION_NAME}.canCreateBranchFromTemplate`, value);
 };
 
+export const setContextCanPreviewTemplate = async (value: boolean) => {
+  await setContextKey(`${EXTENSION_NAME}.canPreviewTemplate`, value);
+};
+
 export const setContextHasMultipleRemovableWorktrees = async (value: boolean) => {
   await setContextKey(`${EXTENSION_NAME}.hasMultipleRemovableWorktrees`, value);
 };


### PR DESCRIPTION
## Summary
- Add `GSC: Preview Branch/Tag Template...`, gated by `canShowPreviewTemplateCommand` (visible whenever a branch or tag template is configured).
- Add `resolveWithTrace` to `branchTemplateService`/`tagTemplateService` as the single source of truth for token resolution — `resolveBranchTemplate`/`resolveTagTemplate` (used by the real create-branch/create-tag commands) now delegate to it. The preview command calls the exact same resolver with `abortOnScriptError: false`, so every token (Jira, `{f:...}`, `{b:...}`, `{s:...}`, `{r:...}`) reports independently instead of the whole preview aborting on the first failure.
- QuickPick between branch/tag templates when both are configured; reuses the real Jira issue picker when a template needs Jira, with a graceful "needs Jira setup (run GSC: Init Jira)" hint per-token when Jira isn't configured (instead of blocking the command).
- Script-token (`{s:...}`) execution now requires consent: the first preview containing a script token per workspace prompts "Preview will execute script(s): ... Run?" and persists the answer (`ScriptConsentStore`, keyed by workspace root). Declining renders `✗ skipped (not authorized)` for that token without running anything.
- `Copy result` copies the final rendered string to the clipboard.
- Result document: `Template`/`Result` header plus an aligned `Token resolution:` table, e.g.:
  ```
  Template : release/{jira-key}-{f:package.json:.version}
  Result   : release/PROJ-123-0.13.0

  Token resolution:
    {jira-key}                  → PROJ-123
    {f:package.json:.version}   → 0.13.0
  ```

## Manual test plan
1. Configure `git-smart-checkout.branchTemplate`, e.g. `release/{f:package.json:.version}`.
2. Run `GSC: Preview Branch/Tag Template...` — verify the editor opens with `Result   : release/<version>` and a token table matching the format above.
3. Configure both `branchTemplate` and `tagTemplate` — verify a QuickPick appears to choose which one to preview.
4. Add a `{jira-key}` token without Jira configured — verify the token shows `✗ needs Jira setup (run GSC: Init Jira)` instead of failing the command.
5. Add a `{s:./some-script.sh}` token — verify the first preview per workspace prompts for consent; accepting runs the script and shows its output, declining shows `✗ skipped (not authorized)` without executing anything.
6. Use a malformed template (unclosed brace) — verify the preview still opens without an error toast.
7. In a multi-root workspace, verify `{f:...}`/`{s:...}` resolve against the *selected* repository, not `workspaceFolders[0]`.
8. Click `Copy result` — verify the clipboard contains the rendered string.
9. Run with no template configured — verify the informational message and that the command is hidden from the command palette until a template is set.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (490 passing, including new `resolveWithTrace` equivalence/independence/multi-root/Jira-missing-config/document-formatting/script-consent coverage)
- [x] `yarn test:e2e:ci` (174 passing, including new end-to-end coverage for the preview command: file-token fixture, script consent accept/decline, malformed template, multi-root repo selection, clipboard copy)