### PR TITLE
fix(worktree-explorer): close gaps in the Worktrees tree view vs spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ All commands are grouped under the `GSC:` prefix in the Command Palette.
 | Copy staged or WIP changes between existing worktrees | `GSC: Copy Staged Changes to Worktree...`, `GSC: Copy WIP Changes to Worktree...`, `GSC: Copy WIP from Worktree...`, `GSC: Move WIP from Worktree...` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
 | Open a terminal in a selected worktree's directory | `GSC: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
 | Remove several Git worktrees at once with a single confirmation | `GSC: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
+| Browse all worktrees for the open repositories in a dedicated "Worktrees" view (activity bar), with dirty/ahead-behind/PR-review status and inline Open/Terminal/Copy WIP/Remove actions | *(tree view — right-click an item for Add to Workspace, Copy Path, Reveal in Finder/Explorer)* | — |
 | Create a new PR from selected commits in another GitHub PR | `GSC: Clone Pull Request...` | [GitHub PR clone](docs/github-pr-clone.md) |
 | Generate and optionally push a tag from a reusable template | `GSC: Create Tag from Template...` | [Create tag from template](docs/create-tag-from-template.md) |
 | Create and check out a branch from a template (Jira, file, regex, scripts) | `GSC: Create Branch from Template...` | [Create branch from template](docs/create-branch-from-template.md) |

--- a/package.json
+++ b/package.json
@@ -227,12 +227,41 @@
       },
       {
         "command": "git-smart-checkout.worktree.terminal",
-        "title": "Open Worktree Dev Terminal",
+        "title": "Open Dev Terminal",
+        "icon": "$(terminal)",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.copyWip",
+        "title": "Copy WIP Here",
+        "icon": "$(git-commit)",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.worktree.remove",
         "title": "Remove Worktree",
+        "icon": "$(trash)",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.addToWorkspace",
+        "title": "Add to Workspace",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.copyPath",
+        "title": "Copy Path",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.reveal",
+        "title": "Reveal in Finder/Explorer",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.worktree.refresh",
+        "title": "Refresh Worktrees",
+        "icon": "$(refresh)",
         "category": "GSC"
       },
       {
@@ -250,30 +279,65 @@
       "view/item/context": [
         {
           "command": "git-smart-checkout.worktree.open",
-          "when": "view == git-smart-checkout.worktrees && viewItem == worktree",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
           "group": "inline@1"
         },
         {
           "command": "git-smart-checkout.worktree.terminal",
-          "when": "view == git-smart-checkout.worktrees && viewItem =~ /^worktree/",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
           "group": "inline@2"
         },
         {
-          "command": "git-smart-checkout.worktree.remove",
-          "when": "view == git-smart-checkout.worktrees && viewItem == worktree",
+          "command": "git-smart-checkout.worktree.copyWip",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/ && viewItem =~ /\\blinked\\b/",
           "group": "inline@3"
+        },
+        {
+          "command": "git-smart-checkout.worktree.remove",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/ && viewItem =~ /\\blinked\\b/",
+          "group": "inline@4"
+        },
+        {
+          "command": "git-smart-checkout.worktree.addToWorkspace",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
+          "group": "7_modification@1"
+        },
+        {
+          "command": "git-smart-checkout.worktree.copyPath",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
+          "group": "7_modification@2"
+        },
+        {
+          "command": "git-smart-checkout.worktree.reveal",
+          "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
+          "group": "7_modification@3"
         }
       ],
       "view/title": [
         {
-          "command": "git-smart-checkout.moveToNewWorktree",
+          "command": "git-smart-checkout.worktree.refresh",
           "when": "view == git-smart-checkout.worktrees",
           "group": "navigation@1"
         },
         {
+          "command": "git-smart-checkout.moveToNewWorktree",
+          "when": "view == git-smart-checkout.worktrees",
+          "group": "navigation@2"
+        },
+        {
           "command": "git-smart-checkout.removeMultipleWorktrees",
           "when": "view == git-smart-checkout.worktrees && git-smart-checkout.hasMultipleRemovableWorktrees",
-          "group": "navigation@2"
+          "group": "navigation@3"
+        },
+        {
+          "command": "git-smart-checkout.prCancelCloneMenu",
+          "when": "view == git-smart-checkout.prClone && git-smart-checkout.isCloning == true && git-smart-checkout.isConflict == true",
+          "group": "navigation"
+        },
+        {
+          "command": "git-smart-checkout.prConflictsResolvedMenu",
+          "when": "view == git-smart-checkout.prClone && git-smart-checkout.isCloning == true && git-smart-checkout.isConflict == true",
+          "group": "navigation"
         }
       ],
       "commandPalette": [
@@ -355,18 +419,6 @@
         },
         {
           "command": "git-smart-checkout.manageAutoStashes"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "git-smart-checkout.prCancelCloneMenu",
-          "when": "view == git-smart-checkout.prClone && git-smart-checkout.isCloning == true && git-smart-checkout.isConflict == true",
-          "group": "navigation"
-        },
-        {
-          "command": "git-smart-checkout.prConflictsResolvedMenu",
-          "when": "view == git-smart-checkout.prClone && git-smart-checkout.isCloning == true && git-smart-checkout.isConflict == true",
-          "group": "navigation"
         }
       ]
     },

--- a/src/commands/commandManager.ts
+++ b/src/commands/commandManager.ts
@@ -3,12 +3,35 @@ import { showErrorMessageWithIssueAction } from '../utils/errorIssueNotification
 import { UserCancelledError } from '../utils/userCancelledError';
 import { ICommand } from './command';
 
+export interface RegisterCommandOptions {
+  /**
+   * Marks a command as mutating worktree state (creating, removing, or
+   * copying changes into/out of a worktree). When such a command completes
+   * successfully, `onCommandCompleted` is invoked so listeners (e.g. the
+   * Worktrees tree view) can refresh.
+   */
+  mutatesWorktrees?: boolean;
+}
+
 export class CommandManager {
   private commands: Map<string, ICommand> = new Map();
+  private mutatingCommandIds: Set<string> = new Set();
   private disposables: vscode.Disposable[] = [];
+  private onCommandCompleted?: (commandId: string) => void;
 
-  registerCommand(commandId: string, command: ICommand): void {
+  registerCommand(commandId: string, command: ICommand, options?: RegisterCommandOptions): void {
     this.commands.set(commandId, command);
+    if (options?.mutatesWorktrees) {
+      this.mutatingCommandIds.add(commandId);
+    }
+  }
+
+  /**
+   * Registers a callback invoked after any worktree-mutating command
+   * (registered with `{ mutatesWorktrees: true }`) completes successfully.
+   */
+  setOnCommandCompleted(callback: (commandId: string) => void): void {
+    this.onCommandCompleted = callback;
   }
 
   getCommand(commandId: string): ICommand | undefined {
@@ -24,6 +47,9 @@ export class CommandManager {
       const disposable = vscode.commands.registerCommand(commandId, async (...args: any[]) => {
         try {
           await command.execute(...args);
+          if (this.mutatingCommandIds.has(commandId)) {
+            this.onCommandCompleted?.(commandId);
+          }
         } catch (error) {
           if (error instanceof UserCancelledError) {
             return;
@@ -43,5 +69,6 @@ export class CommandManager {
     this.disposables.forEach((disposable) => disposable.dispose());
     this.disposables = [];
     this.commands.clear();
+    this.mutatingCommandIds.clear();
   }
 }

--- a/src/commands/copyChangesToWorktreeCommand/index.ts
+++ b/src/commands/copyChangesToWorktreeCommand/index.ts
@@ -37,10 +37,10 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
     super(logService);
   }
 
-  async execute(): Promise<void> {
+  async execute(preselectedWorktreePath?: string): Promise<void> {
     try {
       const git = await this.getGitExecutor(this.vscodeGitProvider);
-      const worktree = await this.selectWorktree(git);
+      const worktree = await this.selectWorktree(git, preselectedWorktreePath);
 
       if (!worktree) {
         return;
@@ -86,7 +86,10 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
     }
   }
 
-  private async selectWorktree(git: GitExecutor): Promise<IGitWorktree | undefined> {
+  private async selectWorktree(
+    git: GitExecutor,
+    preselectedWorktreePath?: string
+  ): Promise<IGitWorktree | undefined> {
     const worktrees = await git.worktreeListDetailed();
     const selectableWorktrees = worktrees.filter(
       (worktree) =>
@@ -101,6 +104,15 @@ abstract class CopyChangesToWorktreeCommand extends BaseCommand {
         ACTION_OK
       );
       return undefined;
+    }
+
+    if (preselectedWorktreePath) {
+      const preselected = selectableWorktrees.find((worktree) =>
+        isSamePath(worktree.path, preselectedWorktreePath)
+      );
+      if (preselected) {
+        return preselected;
+      }
     }
 
     const items = await Promise.all(

--- a/src/commands/openWorktreeDevTerminalCommand/index.ts
+++ b/src/commands/openWorktreeDevTerminalCommand/index.ts
@@ -15,9 +15,16 @@ export class OpenWorktreeDevTerminalCommand extends BaseCommand {
     super(logService);
   }
 
-  async execute(): Promise<void> {
+  async execute(preselectedWorktreePath?: string): Promise<void> {
     try {
       const git = await this.getGitExecutor(this.vscodeGitProvider, 'Open Worktree Dev Terminal');
+
+      if (preselectedWorktreePath) {
+        this.openTerminal(preselectedWorktreePath);
+        capture(AnalyticsEvent.WorktreeDevTerminalOpened, { had_multiple_worktrees: true });
+        return;
+      }
+
       const worktrees = await git.worktreeListDetailed(true);
 
       // No worktrees (or just the current one): behave like opening a plain

--- a/src/commands/removeWorktreeCommand/index.ts
+++ b/src/commands/removeWorktreeCommand/index.ts
@@ -10,9 +10,14 @@ import {
   getWorktreeDetail,
   getWorktreeLabel,
   getWorktreeStashName,
+  normalizePathForComparison,
   removeWorkspaceFoldersForPath,
 } from '../utils/worktreeRemoval';
 import { BaseCommand } from '../command';
+
+function isSamePath(left: string, right: string): boolean {
+  return normalizePathForComparison(left) === normalizePathForComparison(right);
+}
 
 const ACTION_REMOVE_WORKTREE = 'Remove Worktree';
 const ACTION_STASH_AND_REMOVE = 'Stash Changes and Remove';
@@ -30,10 +35,10 @@ export class RemoveWorktreeCommand extends BaseCommand {
     super(logService);
   }
 
-  async execute(): Promise<void> {
+  async execute(preselectedWorktreePath?: string): Promise<void> {
     try {
       const git = await this.getGitExecutor(this.vscodeGitProvider);
-      const worktree = await this.selectWorktree(git);
+      const worktree = await this.selectWorktree(git, preselectedWorktreePath);
 
       if (!worktree) {
         return;
@@ -64,13 +69,25 @@ export class RemoveWorktreeCommand extends BaseCommand {
     }
   }
 
-  private async selectWorktree(git: GitExecutor): Promise<IGitWorktree | undefined> {
+  private async selectWorktree(
+    git: GitExecutor,
+    preselectedWorktreePath?: string
+  ): Promise<IGitWorktree | undefined> {
     const worktrees = await git.worktreeListDetailed();
     const removableWorktrees = getRemovableWorktrees(worktrees);
 
     if (removableWorktrees.length === 0) {
       await vscode.window.showInformationMessage('No removable Git worktrees found.', 'OK');
       return undefined;
+    }
+
+    if (preselectedWorktreePath) {
+      const preselected = removableWorktrees.find(
+        (worktree) => isSamePath(worktree.path, preselectedWorktreePath)
+      );
+      if (preselected) {
+        return preselected;
+      }
     }
 
     const items: WorktreeQuickPickItem[] = removableWorktrees.map((worktree) => ({

--- a/src/commands/utils/worktreeCompletionActions.ts
+++ b/src/commands/utils/worktreeCompletionActions.ts
@@ -38,7 +38,7 @@ export function getWorktreeCompletionActions(worktreePath: string): string[] {
   return actions;
 }
 
-function addToWorkspace(worktreePath: string): void {
+export function addToWorkspace(worktreePath: string): void {
   const folders = vscode.workspace.workspaceFolders ?? [];
   vscode.workspace.updateWorkspaceFolders(folders.length, null, {
     uri: vscode.Uri.file(worktreePath),

--- a/src/commands/worktreeTreeActionCommand.ts
+++ b/src/commands/worktreeTreeActionCommand.ts
@@ -1,11 +1,27 @@
 import * as vscode from 'vscode';
-import { GitExecutor } from '../common/git/gitExecutor';
+import { CopyWipChangesToWorktreeCommand } from './copyChangesToWorktreeCommand';
+import { OpenWorktreeDevTerminalCommand } from './openWorktreeDevTerminalCommand';
+import { RemoveWorktreeCommand } from './removeWorktreeCommand';
 import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
 import { LoggingService } from '../logging/loggingService';
+import { addToWorkspace } from './utils/worktreeCompletionActions';
 import { BaseCommand } from './command';
 
-export type WorktreeTreeAction = 'open' | 'terminal' | 'remove';
+export type WorktreeTreeAction =
+  | 'open'
+  | 'terminal'
+  | 'remove'
+  | 'copyWip'
+  | 'addToWorkspace'
+  | 'copyPath'
+  | 'reveal';
 
+/**
+ * Handles inline/context-menu actions triggered from the Worktrees tree view.
+ * Actions that duplicate an existing command's business logic (dirty-state
+ * handling, picker fallback, analytics) delegate to that command with the
+ * tree's selected worktree path pre-bound, rather than reimplementing it.
+ */
 export class WorktreeTreeActionCommand extends BaseCommand {
   constructor(
     private readonly action: WorktreeTreeAction,
@@ -17,23 +33,37 @@ export class WorktreeTreeActionCommand extends BaseCommand {
 
   async execute(worktreePath?: string, repositoryPath?: string): Promise<void> {
     if (!worktreePath) return;
-    if (this.action === 'open') {
-      await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(worktreePath), true);
-      return;
+
+    switch (this.action) {
+      case 'open':
+        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(worktreePath), true);
+        return;
+      case 'terminal':
+        await new OpenWorktreeDevTerminalCommand(this.logService, this.vscodeGitProvider).execute(
+          worktreePath
+        );
+        return;
+      case 'copyWip':
+        await new CopyWipChangesToWorktreeCommand(this.logService, this.vscodeGitProvider).execute(
+          worktreePath
+        );
+        return;
+      case 'remove':
+        await new RemoveWorktreeCommand(this.logService, this.vscodeGitProvider).execute(worktreePath);
+        return;
+      case 'addToWorkspace':
+        addToWorkspace(worktreePath);
+        return;
+      case 'copyPath':
+        await vscode.env.clipboard.writeText(worktreePath);
+        await vscode.window.showInformationMessage(`Copied path: ${worktreePath}`);
+        return;
+      case 'reveal':
+        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(worktreePath));
+        return;
+      default:
+        void repositoryPath;
+        return;
     }
-    if (this.action === 'terminal') {
-      const terminal = vscode.window.createTerminal({ name: 'Worktree', cwd: worktreePath });
-      terminal.show();
-      return;
-    }
-    if (!repositoryPath) return;
-    const confirmed = await vscode.window.showWarningMessage(
-      `Remove worktree at ${worktreePath}?`,
-      { modal: true },
-      'Remove Worktree'
-    );
-    if (confirmed !== 'Remove Worktree') return;
-    await new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider).worktreeRemove(worktreePath, false);
-    await vscode.window.showInformationMessage(`Worktree removed: ${worktreePath}`);
   }
 }

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -614,8 +614,15 @@ export class GitExecutor {
   }
 
   async isWorkdirHasChanges() {
+    const dirtyFileCount = await this.getDirtyFileCount();
+    return dirtyFileCount !== 0;
+  }
+
+  /** Number of changed/untracked files reported by `git status --porcelain`. */
+  async getDirtyFileCount(): Promise<number> {
     const { stdout } = await this.#execGitCommand(['status', '--porcelain']);
-    return stdout.trim().length !== 0;
+    const trimmed = stdout.trim();
+    return trimmed.length === 0 ? 0 : trimmed.split('\n').length;
   }
 
   /**

--- a/src/common/git/vscodeGitApi.d.ts
+++ b/src/common/git/vscodeGitApi.d.ts
@@ -1,6 +1,8 @@
 // Minimal type stubs for the VS Code built-in git extension public API.
 // Source: https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts
 
+import type { Event } from 'vscode';
+
 export const enum RefType {
   Head = 0,
   RemoteHead = 1,
@@ -41,6 +43,7 @@ export interface Commit {
 export interface RepositoryState {
   readonly HEAD: Ref | undefined;
   readonly refs: Ref[];
+  readonly onDidChange: Event<void>;
 }
 
 export interface RefQuery {
@@ -62,6 +65,8 @@ export interface Repository {
 export interface API {
   readonly repositories: Repository[];
   getRepository(uri: { fsPath: string }): Repository | null;
+  readonly onDidOpenRepository: Event<Repository>;
+  readonly onDidCloseRepository: Event<Repository>;
 }
 
 export interface GitExtension {

--- a/src/common/git/vscodeGitProvider.ts
+++ b/src/common/git/vscodeGitProvider.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { LoggingService } from '../../logging/loggingService';
 
 import { IGitRef } from './types';
-import type { API, Commit, GitExtension, Ref } from './vscodeGitApi';
+import type { API, Commit, GitExtension, Ref, Repository } from './vscodeGitApi';
 
 // Numeric literals matching the RefType const enum in vscodeGitApi.d.ts.
 // We cannot import const enum values at runtime from a .d.ts file.
@@ -49,6 +49,27 @@ export class VscodeGitProvider {
     } catch {
       return undefined;
     }
+  }
+
+  /**
+   * Subscribes to state changes (HEAD, refs) across all currently-open
+   * repositories, plus repositories opened later. Used to keep UI (e.g. the
+   * Worktrees tree view) in sync with checkouts/commits/stashes performed
+   * outside the extension (built-in Source Control view, terminal `git`).
+   */
+  onDidChangeAnyRepositoryState(callback: () => void): vscode.Disposable {
+    const api = this.getApi();
+    if (!api) {
+      return new vscode.Disposable(() => undefined);
+    }
+
+    const disposables: vscode.Disposable[] = [];
+    const wireRepo = (repo: Repository) => disposables.push(repo.state.onDidChange(callback));
+
+    api.repositories.forEach(wireRepo);
+    disposables.push(api.onDidOpenRepository(wireRepo));
+
+    return vscode.Disposable.from(...disposables);
   }
 
   private findRepo(repoPath: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,23 @@ export function activate(context: vscode.ExtensionContext) {
   const worktreeTreeDataProvider = new WorktreeTreeDataProvider(logService, prReviewWorktreeStore, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.worktree.open`, new WorktreeTreeActionCommand('open', logService, vscodeGitProvider));
   commandManager.registerCommand(`${EXTENSION_NAME}.worktree.terminal`, new WorktreeTreeActionCommand('terminal', logService, vscodeGitProvider));
-  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.remove`, new WorktreeTreeActionCommand('remove', logService, vscodeGitProvider));
+  commandManager.registerCommand(
+    `${EXTENSION_NAME}.worktree.copyWip`,
+    new WorktreeTreeActionCommand('copyWip', logService, vscodeGitProvider),
+    { mutatesWorktrees: true }
+  );
+  commandManager.registerCommand(
+    `${EXTENSION_NAME}.worktree.remove`,
+    new WorktreeTreeActionCommand('remove', logService, vscodeGitProvider),
+    { mutatesWorktrees: true }
+  );
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.addToWorkspace`, new WorktreeTreeActionCommand('addToWorkspace', logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.copyPath`, new WorktreeTreeActionCommand('copyPath', logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.reveal`, new WorktreeTreeActionCommand('reveal', logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.worktree.refresh`, {
+    execute: async () => worktreeTreeDataProvider.refresh(),
+  });
+  commandManager.setOnCommandCompleted(() => worktreeTreeDataProvider.refreshDebounced());
   const statusBarManager = new StatusBarManager(
     configManager,
     logService,
@@ -209,7 +225,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscodeGitProvider,
     prReviewWorktreeStore
   );
-  commandManager.registerCommand(`${EXTENSION_NAME}.prReviewInWorktree`, prReviewInWorktreeCommand);
+  commandManager.registerCommand(`${EXTENSION_NAME}.prReviewInWorktree`, prReviewInWorktreeCommand, {
+    mutatesWorktrees: true,
+  });
 
   const createTagFromTemplateCommand = new CreateTagFromTemplateCommand(configManager, logService);
   commandManager.registerCommand(`${EXTENSION_NAME}.createTagFromTemplate`, createTagFromTemplateCommand);
@@ -256,15 +274,20 @@ export function activate(context: vscode.ExtensionContext) {
     vscodeGitProvider,
     refDetailsCache
   );
-  commandManager.registerCommand(`${EXTENSION_NAME}.moveToNewWorktree`, moveToNewWorktreeCommand);
+  commandManager.registerCommand(`${EXTENSION_NAME}.moveToNewWorktree`, moveToNewWorktreeCommand, {
+    mutatesWorktrees: true,
+  });
 
   const removeWorktreeCommand = new RemoveWorktreeCommand(logService, vscodeGitProvider);
-  commandManager.registerCommand(`${EXTENSION_NAME}.removeWorktree`, removeWorktreeCommand);
+  commandManager.registerCommand(`${EXTENSION_NAME}.removeWorktree`, removeWorktreeCommand, {
+    mutatesWorktrees: true,
+  });
 
   const removeMultipleWorktreesCommand = new RemoveMultipleWorktreesCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(
     `${EXTENSION_NAME}.removeMultipleWorktrees`,
-    removeMultipleWorktreesCommand
+    removeMultipleWorktreesCommand,
+    { mutatesWorktrees: true }
   );
 
   const openWorktreeDevTerminalCommand = new OpenWorktreeDevTerminalCommand(logService, vscodeGitProvider);
@@ -281,31 +304,36 @@ export function activate(context: vscode.ExtensionContext) {
   );
   commandManager.registerCommand(
     `${EXTENSION_NAME}.removePRReviewInWorktree`,
-    removePRReviewInWorktreeCommand
+    removePRReviewInWorktreeCommand,
+    { mutatesWorktrees: true }
   );
 
   const copyStagedChangesToWorktreeCommand = new CopyStagedChangesToWorktreeCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(
     `${EXTENSION_NAME}.copyStagedChangesToWorktree`,
-    copyStagedChangesToWorktreeCommand
+    copyStagedChangesToWorktreeCommand,
+    { mutatesWorktrees: true }
   );
 
   const copyWipChangesToWorktreeCommand = new CopyWipChangesToWorktreeCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(
     `${EXTENSION_NAME}.copyWipChangesToWorktree`,
-    copyWipChangesToWorktreeCommand
+    copyWipChangesToWorktreeCommand,
+    { mutatesWorktrees: true }
   );
 
   const copyWipChangesFromWorktreeCommand = new CopyWipChangesFromWorktreeCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(
     `${EXTENSION_NAME}.copyWipChangesFromWorktree`,
-    copyWipChangesFromWorktreeCommand
+    copyWipChangesFromWorktreeCommand,
+    { mutatesWorktrees: true }
   );
 
   const moveWipChangesFromWorktreeCommand = new MoveWipChangesFromWorktreeCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(
     `${EXTENSION_NAME}.moveWipChangesFromWorktree`,
-    moveWipChangesFromWorktreeCommand
+    moveWipChangesFromWorktreeCommand,
+    { mutatesWorktrees: true }
   );
 
   // Register clone pull request command
@@ -402,13 +430,21 @@ export function activate(context: vscode.ExtensionContext) {
   const windowStateListener = vscode.window.onDidChangeWindowState((state) => {
     if (state.focused) {
       void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
-      setTimeout(() => worktreeTreeDataProvider.refresh(), 2000);
+      // Debounced: rapid focus toggling (e.g. alt-tabbing) collapses into a
+      // single reload rather than one per focus event.
+      worktreeTreeDataProvider.refreshDebounced();
     }
   });
   const workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
     void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
     void refreshRepositoryContext(logService);
     worktreeTreeDataProvider.refresh();
+  });
+  // Keep the tree in sync with checkouts/commits/stash operations performed
+  // outside this extension (VS Code's built-in Source Control view, terminal
+  // git commands, etc.) by listening to vscode.git repository state changes.
+  const gitStateListener = vscodeGitProvider?.onDidChangeAnyRepositoryState(() => {
+    worktreeTreeDataProvider.refreshDebounced();
   });
 
   // Listen for configuration changes
@@ -428,6 +464,7 @@ export function activate(context: vscode.ExtensionContext) {
     configChangeListener,
     windowStateListener,
     workspaceFoldersListener,
+    ...(gitStateListener ? [gitStateListener] : []),
     telemetryChangeListener,
     statusBarManager,
     logService,

--- a/src/test/unit/commandManagerCancellation.test.ts
+++ b/src/test/unit/commandManagerCancellation.test.ts
@@ -85,3 +85,78 @@ describe('CommandManager user-cancellation handling', () => {
     }
   });
 });
+
+describe('CommandManager mutatesWorktrees hook', () => {
+  it('invokes onCommandCompleted after a flagged command succeeds', async () => {
+    const manager = new CommandManager();
+    const commandId = 'gitSmartCheckout.test.mutatingCommand';
+    const command: ICommand = { execute: async () => undefined };
+    manager.registerCommand(commandId, command, { mutatesWorktrees: true });
+
+    const completed: string[] = [];
+    manager.setOnCommandCompleted((id) => completed.push(id));
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    try {
+      manager.registerAll(context);
+      await vscode.commands.executeCommand(commandId);
+      assert.deepStrictEqual(completed, [commandId]);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('does not invoke onCommandCompleted for a non-flagged command', async () => {
+    const manager = new CommandManager();
+    const commandId = 'gitSmartCheckout.test.nonMutatingCommand';
+    const command: ICommand = { execute: async () => undefined };
+    manager.registerCommand(commandId, command);
+
+    const completed: string[] = [];
+    manager.setOnCommandCompleted((id) => completed.push(id));
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    try {
+      manager.registerAll(context);
+      await vscode.commands.executeCommand(commandId);
+      assert.deepStrictEqual(completed, []);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('does not invoke onCommandCompleted when a flagged command throws', async () => {
+    const manager = new CommandManager();
+    const commandId = 'gitSmartCheckout.test.mutatingCommandFails';
+    const command: ICommand = {
+      execute: async () => {
+        throw new Error('boom');
+      },
+    };
+    manager.registerCommand(commandId, command, { mutatesWorktrees: true });
+
+    const completed: string[] = [];
+    manager.setOnCommandCompleted((id) => completed.push(id));
+
+    const originalShow = errorIssueNotification.showErrorMessageWithIssueAction;
+    (
+      errorIssueNotification as unknown as {
+        showErrorMessageWithIssueAction: typeof originalShow;
+      }
+    ).showErrorMessageWithIssueAction = async () => undefined;
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    try {
+      manager.registerAll(context);
+      await vscode.commands.executeCommand(commandId);
+      assert.deepStrictEqual(completed, []);
+    } finally {
+      (
+        errorIssueNotification as unknown as {
+          showErrorMessageWithIssueAction: typeof originalShow;
+        }
+      ).showErrorMessageWithIssueAction = originalShow;
+      manager.dispose();
+    }
+  });
+});

--- a/src/test/unit/copyChangesToWorktreeCommand.test.ts
+++ b/src/test/unit/copyChangesToWorktreeCommand.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { CopyWipChangesToWorktreeCommand } from '../../commands/copyChangesToWorktreeCommand';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('CopyWipChangesToWorktreeCommand preselected worktree (tree-view delegation)', () => {
+  function makeGit(
+    repositoryPath: string,
+    worktrees: Array<{ path: string; head: string; branch?: string }>
+  ): GitExecutor {
+    return {
+      repositoryPath,
+      worktreeListDetailed: async () => worktrees,
+    } as unknown as GitExecutor;
+  }
+
+  it('resolves a preselected worktree without showing a picker', async () => {
+    const command = new CopyWipChangesToWorktreeCommand(mockLogService);
+    const git = makeGit('/repo', [
+      { path: '/repo', head: 'a', branch: 'refs/heads/main' },
+      { path: '/repo-feature', head: 'b', branch: 'refs/heads/feature' },
+    ]);
+
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    let pickerShown = false;
+    (vscode.window as any).showQuickPick = async () => {
+      pickerShown = true;
+      return undefined;
+    };
+
+    try {
+      const worktree = await (command as any).selectWorktree(git, '/repo-feature');
+      assert.strictEqual(worktree?.path, '/repo-feature');
+      assert.strictEqual(pickerShown, false, 'should not open a QuickPick when the path is preselected');
+    } finally {
+      (vscode.window as any).showQuickPick = originalShowQuickPick;
+    }
+  });
+
+  it('excludes the currently open repository path from the preselected match', async () => {
+    const command = new CopyWipChangesToWorktreeCommand(mockLogService);
+    const git = makeGit('/repo', [{ path: '/repo', head: 'a', branch: 'refs/heads/main' }]);
+
+    const originalShowInformationMessage = vscode.window.showInformationMessage;
+    const messages: string[] = [];
+    (vscode.window as any).showInformationMessage = async (message: string) => {
+      messages.push(message);
+      return undefined;
+    };
+
+    try {
+      const worktree = await (command as any).selectWorktree(git, '/repo');
+      assert.strictEqual(worktree, undefined);
+      assert.deepStrictEqual(messages, ['No other Git worktrees available to copy changes to.']);
+    } finally {
+      (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+    }
+  });
+});

--- a/src/test/unit/removeWorktreeCommand.test.ts
+++ b/src/test/unit/removeWorktreeCommand.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { RemoveWorktreeCommand } from '../../commands/removeWorktreeCommand';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('RemoveWorktreeCommand preselected worktree (tree-view delegation)', () => {
+  function makeGit(worktrees: Array<{ path: string; head: string; branch?: string }>): GitExecutor {
+    return { worktreeListDetailed: async () => worktrees } as unknown as GitExecutor;
+  }
+
+  it('resolves a preselected removable worktree without showing a picker', async () => {
+    const command = new RemoveWorktreeCommand(mockLogService);
+    const git = makeGit([
+      { path: '/repo', head: 'a', branch: 'refs/heads/main' },
+      { path: '/repo-feature', head: 'b', branch: 'refs/heads/feature' },
+    ]);
+
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    let pickerShown = false;
+    (vscode.window as any).showQuickPick = async (...args: unknown[]) => {
+      pickerShown = true;
+      return originalShowQuickPick.apply(vscode.window, args as any);
+    };
+
+    try {
+      const worktree = await (command as any).selectWorktree(git, '/repo-feature');
+      assert.strictEqual(worktree?.path, '/repo-feature');
+      assert.strictEqual(pickerShown, false, 'should not open a QuickPick when the path is preselected');
+    } finally {
+      (vscode.window as any).showQuickPick = originalShowQuickPick;
+    }
+  });
+
+  it('falls back to the picker when the preselected path is not a removable worktree', async () => {
+    const command = new RemoveWorktreeCommand(mockLogService);
+    const git = makeGit([
+      { path: '/repo', head: 'a', branch: 'refs/heads/main' },
+      { path: '/repo-feature', head: 'b', branch: 'refs/heads/feature' },
+    ]);
+
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    (vscode.window as any).showQuickPick = async () => undefined;
+
+    try {
+      const worktree = await (command as any).selectWorktree(git, '/does-not-exist');
+      assert.strictEqual(worktree, undefined);
+    } finally {
+      (vscode.window as any).showQuickPick = originalShowQuickPick;
+    }
+  });
+
+  it('reports no removable worktrees when only the main worktree exists', async () => {
+    const command = new RemoveWorktreeCommand(mockLogService);
+    const git = makeGit([{ path: '/repo', head: 'a', branch: 'refs/heads/main' }]);
+
+    const originalShowInformationMessage = vscode.window.showInformationMessage;
+    const messages: string[] = [];
+    (vscode.window as any).showInformationMessage = async (message: string) => {
+      messages.push(message);
+      return undefined;
+    };
+
+    try {
+      const worktree = await (command as any).selectWorktree(git, '/repo');
+      assert.strictEqual(worktree, undefined);
+      assert.deepStrictEqual(messages, ['No removable Git worktrees found.']);
+    } finally {
+      (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+    }
+  });
+});

--- a/src/test/unit/worktreeTreeDataProvider.test.ts
+++ b/src/test/unit/worktreeTreeDataProvider.test.ts
@@ -1,26 +1,125 @@
 import * as assert from 'assert';
-import { WorktreeTreeItem } from '../../view/WorktreeTreeDataProvider';
+import * as os from 'os';
+import { WorktreeTreeDataProvider, WorktreeTreeItem } from '../../view/WorktreeTreeDataProvider';
+import { PRReviewWorktreeStore } from '../../services/prReviewWorktreeStore';
+import { mockLogService } from '../e2e/helpers/mockLogService';
 
 describe('WorktreeTreeItem', () => {
-  it('describes dirty, tracked, and PR-review worktrees', () => {
+  it('renders a pending state before enrichment resolves', () => {
+    const item = new WorktreeTreeItem(
+      { path: '/repo', branch: 'refs/heads/main', head: 'abcdef123456' },
+      '/repo',
+      true
+    );
+
+    assert.strictEqual(item.label, 'main');
+    // No dirty marker, arrows, or PR-review badge yet — just the path.
+    assert.strictEqual(item.description, '/repo');
+    assert.strictEqual(item.contextValue, 'worktree main');
+    assert.ok((item.iconPath as { id: string }).id === 'repo');
+  });
+
+  it('describes dirty, tracked, and PR-review worktrees once enriched', () => {
     const item = new WorktreeTreeItem(
       { path: '/repo/review', branch: 'refs/heads/feature', head: 'abcdef123456' },
       '/repo',
-      true,
-      [2, 1],
-      true
+      false
     );
+
+    item.applyEnrichment({ isDirty: true, dirtyFileCount: 3, track: [2, 1], isPrReview: true });
+
     assert.strictEqual(item.label, 'feature');
     assert.strictEqual(item.description, '/repo/review ⇡2 ⇣1 ● PR review');
-    assert.strictEqual(item.contextValue, 'worktree.prReview');
+    assert.strictEqual(item.contextValue, 'worktree linked dirty prReview');
+    assert.ok((item.iconPath as { id: string }).id === 'git-pull-request');
+    assert.ok(String(item.tooltip).includes('Dirty files: 3'));
+    assert.ok(String(item.tooltip).includes('Tracked as a PR-review worktree'));
   });
 
-  it('uses a short SHA for detached worktrees', () => {
+  it('marks a clean linked worktree with the clean contextValue and folder-library icon', () => {
     const item = new WorktreeTreeItem(
-      { path: '/repo/detached', head: 'abcdef123456' },
+      { path: '/repo/linked', branch: 'refs/heads/chore', head: 'abcdef123456' },
       '/repo',
       false
     );
+
+    item.applyEnrichment({ isDirty: false, dirtyFileCount: 0, isPrReview: false });
+
+    assert.strictEqual(item.contextValue, 'worktree linked clean');
+    assert.ok((item.iconPath as { id: string }).id === 'folder-library');
+    assert.strictEqual(item.description, '/repo/linked');
+  });
+
+  it('uses a short SHA and the detached tag for detached-HEAD worktrees', () => {
+    const item = new WorktreeTreeItem({ path: '/repo/detached', head: 'abcdef123456' }, '/repo', false);
+
+    item.applyEnrichment({ isDirty: false, dirtyFileCount: 0, isPrReview: false });
+
     assert.strictEqual(item.label, 'abcdef12');
+    assert.strictEqual(item.contextValue, 'worktree linked detached clean');
+    assert.ok(String(item.tooltip).includes('Detached HEAD'));
+  });
+
+  it('shortens a home-directory path with a tilde', () => {
+    const home = os.homedir();
+    const item = new WorktreeTreeItem(
+      { path: `${home}/projects/repo-review`, branch: 'refs/heads/feature' },
+      home,
+      false
+    );
+
+    item.applyEnrichment({ isDirty: false, dirtyFileCount: 0, isPrReview: false });
+
+    assert.strictEqual(item.description, '~/projects/repo-review');
+  });
+});
+
+describe('WorktreeTreeDataProvider.refreshDebounced', () => {
+  function makeProvider() {
+    const store = { getForRepository: async () => [] } as unknown as PRReviewWorktreeStore;
+    return new WorktreeTreeDataProvider(mockLogService, store);
+  }
+
+  it('coalesces rapid refresh calls into a single reload', async () => {
+    const provider = makeProvider();
+    let fireCount = 0;
+    provider.onDidChangeTreeData(() => fireCount++);
+
+    for (let i = 0; i < 5; i++) {
+      provider.refreshDebounced(30);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    assert.strictEqual(fireCount, 1);
+    provider.dispose();
+  });
+
+  it('does not fire before the debounce window elapses', async () => {
+    const provider = makeProvider();
+    let fireCount = 0;
+    provider.onDidChangeTreeData(() => fireCount++);
+
+    provider.refreshDebounced(50);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.strictEqual(fireCount, 0);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.strictEqual(fireCount, 1);
+    provider.dispose();
+  });
+
+  it('refresh() fires immediately and cancels a pending debounce', async () => {
+    const provider = makeProvider();
+    let fireCount = 0;
+    provider.onDidChangeTreeData(() => fireCount++);
+
+    provider.refreshDebounced(50);
+    provider.refresh();
+    assert.strictEqual(fireCount, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    // The pending debounced refresh must not fire a second time.
+    assert.strictEqual(fireCount, 1);
+    provider.dispose();
   });
 });

--- a/src/view/WorktreeTreeDataProvider.ts
+++ b/src/view/WorktreeTreeDataProvider.ts
@@ -2,39 +2,89 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { GitExecutor } from '../common/git/gitExecutor';
-import { IGitWorktree } from '../common/git/types';
+import { IGitWorktree, TUpstreamTrack } from '../common/git/types';
 import { LoggingService } from '../logging/loggingService';
 import { PRReviewWorktreeStore } from '../services/prReviewWorktreeStore';
 import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
 import { resolveGitRepositoryRoot } from '../utils/getGitExecutor';
 
+export interface WorktreeEnrichment {
+  isDirty: boolean;
+  dirtyFileCount: number;
+  track?: TUpstreamTrack;
+  isPrReview: boolean;
+}
+
 export class WorktreeTreeItem extends vscode.TreeItem {
+  public readonly branch: string | undefined;
+  public readonly isMain: boolean;
+  public readonly isDetached: boolean;
+
   constructor(
     public readonly worktree: IGitWorktree,
     public readonly repositoryPath: string,
-    isDirty: boolean,
-    track?: [number, number],
-    isPrReview = false
+    isMain: boolean,
+    enrichment?: WorktreeEnrichment
   ) {
     const branch = worktree.branch?.replace(/^refs\/heads\//, '');
     super(branch || worktree.head?.slice(0, 8) || 'Detached HEAD', vscode.TreeItemCollapsibleState.None);
-    const shortened = worktree.path.startsWith(os.homedir())
-      ? `~${worktree.path.slice(os.homedir().length)}`
-      : worktree.path;
-    const arrows = track ? `⇡${track[0]} ⇣${track[1]}` : '';
-    this.description = [shortened, arrows, isDirty ? '●' : '', isPrReview ? 'PR review' : '']
-      .filter(Boolean)
-      .join(' ');
-    this.tooltip = `${worktree.path}\n${branch || 'detached HEAD'}`;
-    this.contextValue = isPrReview ? 'worktree.prReview' : 'worktree';
-    this.iconPath = new vscode.ThemeIcon(
-      isPrReview ? 'git-pull-request' : worktree.path === repositoryPath ? 'repo' : 'folder-library'
-    );
+    this.branch = branch;
+    this.isMain = isMain;
+    this.isDetached = !branch;
     this.command = {
       command: 'git-smart-checkout.worktree.open',
       title: 'Open Worktree',
       arguments: [worktree.path, repositoryPath],
     };
+    this.applyEnrichment(enrichment);
+  }
+
+  /** Updates description, tooltip, icon and contextValue from freshly-loaded state. */
+  applyEnrichment(enrichment?: WorktreeEnrichment): void {
+    const shortened = this.worktree.path.startsWith(os.homedir())
+      ? `~${this.worktree.path.slice(os.homedir().length)}`
+      : this.worktree.path;
+    const arrows = enrichment?.track ? `⇡${enrichment.track[0]} ⇣${enrichment.track[1]}` : '';
+    this.description = [
+      shortened,
+      arrows,
+      enrichment?.isDirty ? '●' : '',
+      enrichment?.isPrReview ? 'PR review' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const lines = [
+      this.worktree.path,
+      this.branch ? `Branch: ${this.branch}` : 'Detached HEAD',
+      enrichment?.track
+        ? `Upstream: ⇡${enrichment.track[0]} ahead, ⇣${enrichment.track[1]} behind`
+        : 'Upstream: none',
+      enrichment
+        ? `Dirty files: ${enrichment.dirtyFileCount}`
+        : 'Dirty files: (loading...)',
+      this.isMain ? 'Source: main worktree' : 'Source: linked worktree',
+    ];
+    if (enrichment?.isPrReview) {
+      lines.push('Tracked as a PR-review worktree');
+    }
+    this.tooltip = lines.join('\n');
+
+    const tags = ['worktree', this.isMain ? 'main' : 'linked'];
+    if (this.isDetached) {
+      tags.push('detached');
+    }
+    if (enrichment) {
+      tags.push(enrichment.isDirty ? 'dirty' : 'clean');
+      if (enrichment.isPrReview) {
+        tags.push('prReview');
+      }
+    }
+    this.contextValue = tags.join(' ');
+
+    this.iconPath = new vscode.ThemeIcon(
+      enrichment?.isPrReview ? 'git-pull-request' : this.isMain ? 'repo' : 'folder-library'
+    );
   }
 }
 
@@ -49,11 +99,15 @@ export class WorktreeRepositoryTreeItem extends vscode.TreeItem {
 
 type WorktreeNode = WorktreeTreeItem | WorktreeRepositoryTreeItem;
 
+const DEFAULT_DEBOUNCE_MS = 2000;
+
 export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<WorktreeNode> {
   private readonly changeEmitter = new vscode.EventEmitter<WorktreeNode | undefined>();
   readonly onDidChangeTreeData = this.changeEmitter.event;
   private items: WorktreeTreeItem[] = [];
   private repositories: WorktreeRepositoryTreeItem[] = [];
+  private loaded = false;
+  private debounceTimer?: ReturnType<typeof setTimeout>;
 
   constructor(
     private readonly logService: LoggingService,
@@ -66,7 +120,9 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
   }
 
   async getChildren(element?: WorktreeRepositoryTreeItem): Promise<WorktreeNode[]> {
-    await this.load();
+    if (!this.loaded) {
+      await this.load();
+    }
     if (element) {
       return element.children;
     }
@@ -76,51 +132,111 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
     return this.items;
   }
 
+  /** Reloads immediately. Used for explicit user-triggered refreshes. */
   refresh(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+    this.loaded = false;
     this.items = [];
     this.repositories = [];
     this.changeEmitter.fire(undefined);
   }
 
+  /**
+   * Coalesces bursts of change notifications (e.g. rapid window focus events,
+   * several worktree-mutating commands run back to back) into a single
+   * reload after `delayMs` of quiet.
+   */
+  refreshDebounced(delayMs = DEFAULT_DEBOUNCE_MS): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.refresh();
+    }, delayMs);
+  }
+
   dispose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
     this.changeEmitter.dispose();
   }
 
+  /**
+   * Phase 1: builds tree items immediately from `worktreeListDetailed` only
+   * (no git calls beyond that single listing), so the view populates fast.
+   * Phase 2 (`enrich`) fills in dirty/ahead-behind/PR-review state
+   * asynchronously and fires a per-item change event as each resolves.
+   */
   private async load(): Promise<void> {
-    if (this.items.length > 0) {
-      return;
-    }
     const folders = vscode.workspace.workspaceFolders ?? [];
     const loaded: WorktreeTreeItem[] = [];
     const grouped = new Map<string, WorktreeTreeItem[]>();
+    const enrichmentTasks: Array<() => Promise<void>> = [];
+
     for (const folder of folders) {
       try {
         const repositoryPath = await resolveGitRepositoryRoot(folder.uri.fsPath, this.logService);
         const git = new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider);
         const worktrees = await git.worktreeListDetailed(true);
-        const refs = await git.getAllRefListExtended();
-        const reviews = await this.store.getForRepository({
-          repoKey: repositoryPath,
-          repositoryPath,
-        });
-        for (const worktree of worktrees.filter((item) => !item.bare && !item.prunable)) {
-          const branch = worktree.branch?.replace(/^refs\/heads\//, '');
-          const ref = branch ? refs.find((item) => !item.remote && item.name === branch) : undefined;
-          const dirty = await new GitExecutor(worktree.path, this.logService, this.vscodeGitProvider).isWorkdirHasChanges();
-          const isPrReview = reviews.some((review) => path.resolve(review.worktreePath) === path.resolve(worktree.path));
-          const item = new WorktreeTreeItem(worktree, repositoryPath, dirty, ref?.parsedUpstreamTrack, isPrReview);
+        const visibleWorktrees = worktrees.filter((item) => !item.bare && !item.prunable);
+
+        visibleWorktrees.forEach((worktree, index) => {
+          // git worktree list always reports the main worktree first.
+          const isMain = index === 0;
+          const item = new WorktreeTreeItem(worktree, repositoryPath, isMain);
           loaded.push(item);
           const repoItems = grouped.get(repositoryPath) ?? [];
           repoItems.push(item);
           grouped.set(repositoryPath, repoItems);
-        }
+
+          enrichmentTasks.push(() => this.enrichItem(item, git, repositoryPath));
+        });
       } catch (error) {
         this.logService.warn(`Failed to load worktrees for ${folder.uri.fsPath}: ${error}`);
       }
     }
+
     this.items = loaded;
     this.repositories = [...grouped.entries()].map(
       ([repositoryPath, children]) => new WorktreeRepositoryTreeItem(repositoryPath, children)
     );
+    this.loaded = true;
+
+    // Fire-and-forget: enrichment must not block the initial render.
+    void Promise.all(enrichmentTasks.map((task) => task()));
+  }
+
+  private async enrichItem(
+    item: WorktreeTreeItem,
+    git: GitExecutor,
+    repositoryPath: string
+  ): Promise<void> {
+    try {
+      const [dirtyFileCount, refs, reviews] = await Promise.all([
+        new GitExecutor(item.worktree.path, this.logService, this.vscodeGitProvider).getDirtyFileCount(),
+        git.getAllRefListExtended(),
+        this.store.getForRepository({ repoKey: repositoryPath, repositoryPath }),
+      ]);
+      const ref = item.branch ? refs.find((entry) => !entry.remote && entry.name === item.branch) : undefined;
+      const isPrReview = reviews.some(
+        (review) => path.resolve(review.worktreePath) === path.resolve(item.worktree.path)
+      );
+
+      item.applyEnrichment({
+        isDirty: dirtyFileCount !== 0,
+        dirtyFileCount,
+        track: ref?.parsedUpstreamTrack,
+        isPrReview,
+      });
+    } catch (error) {
+      this.logService.warn(`Failed to enrich worktree ${item.worktree.path}: ${error}`);
+      item.applyEnrichment({ isDirty: false, dirtyFileCount: 0, isPrReview: false });
+    }
+    this.changeEmitter.fire(item);
   }
 }


### PR DESCRIPTION
## Summary

Feature 1 ("Worktree Explorer view") landed in #147, but auditing it against the full spec turned up several real gaps:

- **Duplicate `"view/title"` key in `package.json`** — the object literal had two `view/title` arrays; JSON silently keeps only the last one, so the "New Worktree" and "Remove Multiple…" title-bar buttons were defined but **never actually appeared** in the view. Merged into one array and added a **Refresh** button (there was none at all).
- **Missing inline/context actions** — spec calls for inline *Open in New Window, Open Dev Terminal, Copy WIP Here, Remove Worktree* and context-menu *Add to Workspace, Copy Path, Reveal in Finder/Explorer*. Only Open/Terminal/Remove existed; Copy WIP Here and all three context-menu actions were missing.
- **No `contextValue` differentiation** — items only distinguished `worktree` vs `worktree.prReview`, so menus couldn't gate actions like Remove/Copy WIP to linked (non-main) worktrees. `contextValue` is now a tag string, e.g. `worktree main clean` or `worktree linked dirty prReview`.
- **The inline Remove action duplicated logic and skipped dirty-worktree handling** — it called `git worktree remove --force=false` directly with a plain confirm dialog, bypassing `RemoveWorktreeCommand`'s stash/reset flow for dirty worktrees (which would just fail). It now delegates to `RemoveWorktreeCommand` (and `OpenWorktreeDevTerminalCommand` / `CopyWipChangesToWorktreeCommand`) with a pre-bound `preselectedWorktreePath` to skip the picker.
- **No two-phase async rendering** — `load()` awaited dirty-state/ahead-behind/PR-review for every worktree before returning anything. Items now render immediately from `worktreeListDetailed`, then are enriched asynchronously with one `onDidChangeTreeData` fire per item.
- **No auto-refresh** — the view only refreshed on workspace-folder changes and a non-debounced window-focus timer (multiple focus events could queue multiple reloads). Now `CommandManager` supports a `{ mutatesWorktrees: true }` flag + `setOnCommandCompleted` hook, `VscodeGitProvider` exposes `onDidChangeAnyRepositoryState` (vscode.git state changes), and all three sources call a real `refreshDebounced()` that coalesces bursts into one reload.

## Test plan
- [x] `yarn compile` (type check + lint) passes
- [x] `yarn test:unit` / `yarn test` pass (469 tests, including new coverage for tree-item enrichment/contextValue, refresh debouncing, the `CommandManager` mutation hook, and preselected-path picker bypass in Remove/Copy-WIP commands)
- [ ] Manual smoke test in the Extension Development Host (see below)

### How to test manually
1. Run `yarn dev` (or `yarn watch`) and launch the extension (F5) against a repo with at least one linked worktree.
2. Open the **Worktrees** view in the activity bar (`git-smart-checkout` container).
3. Confirm the title bar shows **Refresh**, **New Worktree**, and (once you have 2+ removable worktrees) **Remove Multiple…** buttons.
4. Hover a linked worktree item — confirm inline icons for **Open in New Window**, **Open Dev Terminal**, **Copy WIP Here**, **Remove Worktree**.
5. Right-click an item — confirm **Add to Workspace**, **Copy Path**, **Reveal in Finder/Explorer** in the context menu.
6. Make the main worktree dirty (edit a file) — confirm the item's description gains a `●` and the tooltip shows a non-zero dirty-file count, without blocking the initial list render.
7. Run `GSC: Move to New Worktree...` from the command palette — confirm the tree auto-refreshes (within ~2s) without manually clicking Refresh.
8. Click **Copy WIP Here** on a linked worktree while the main worktree has uncommitted changes — confirm changes land in that worktree without a picker prompt.
9. Click **Remove Worktree** on a dirty linked worktree — confirm you get the stash/reset/cancel prompt (not a bare "remove?" confirm that would fail on a dirty tree).