### PR TITLE
fix(stash): close gaps in the stash-pop conflict rescue flow

### DIFF
--- a/src/commands/manageAutoStashesCommand/index.ts
+++ b/src/commands/manageAutoStashesCommand/index.ts
@@ -66,11 +66,12 @@ export class ManageAutoStashesCommand extends BaseCommand {
           continue;
         }
 
-        await this.runAction(git, stash, action);
+        const stashConflict = await this.runAction(git, stash, action);
         capture(AnalyticsEvent.AutoStashManaged, {
           action,
           file_count: stash.files.length,
           had_changes: hadChanges,
+          ...(stashConflict ? { stashConflict: true } : {}),
         });
       }
     } catch (error) {
@@ -154,11 +155,16 @@ export class ManageAutoStashesCommand extends BaseCommand {
     return choice === ACTION_DROP;
   }
 
+  /**
+   * Runs the selected stash action. Returns true when the action ended in a
+   * conflict-rescue path (so the caller can tag analytics instead of reporting
+   * a plain success) and false otherwise.
+   */
   private async runAction(
     git: GitExecutor,
     stash: IGitStash,
     action: StashAction
-  ): Promise<void> {
+  ): Promise<boolean> {
     switch (action) {
       case 'apply': {
         const selector = await git.resolveStashSelector(stash.selector, stash.hash);
@@ -168,10 +174,10 @@ export class ManageAutoStashesCommand extends BaseCommand {
           const conflicts = await git.getConflictedFiles();
           if (conflicts.length === 0) throw error;
           await offerConflictRescue(git, conflicts, 'apply');
-          return;
+          return true;
         }
         await vscode.window.showInformationMessage('Auto-stash applied.', 'OK');
-        return;
+        return false;
       }
       case 'pop': {
         const selector = await git.resolveStashSelector(stash.selector, stash.hash);
@@ -181,22 +187,22 @@ export class ManageAutoStashesCommand extends BaseCommand {
           const conflicts = await git.getConflictedFiles();
           if (conflicts.length === 0) throw error;
           await offerConflictRescue(git, conflicts, 'pop');
-          return;
+          return true;
         }
         await vscode.window.showInformationMessage('Auto-stash popped.', 'OK');
-        return;
+        return false;
       }
       case 'drop': {
         const selector = await git.resolveStashSelector(stash.selector, stash.hash);
         await git.dropStash(selector);
         await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
-        return;
+        return false;
       }
       case 'diff': {
         const patch = await git.getStashPatch(stash.selector);
         if (!patch) {
           await vscode.window.showInformationMessage('This auto-stash has no diff to display.', 'OK');
-          return;
+          return false;
         }
 
         const document = await vscode.workspace.openTextDocument({
@@ -204,6 +210,7 @@ export class ManageAutoStashesCommand extends BaseCommand {
           language: 'diff',
         });
         await vscode.window.showTextDocument(document, { preview: true });
+        return false;
       }
     }
   }

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -15,7 +15,7 @@ import { offerConflictRescue } from './stashConflictRescue';
 
 export type TPullWithStashStrategy = 'merge' | 'rebase';
 
-export type CheckoutOutcome = 'completed' | 'cancelled';
+export type CheckoutOutcome = 'completed' | 'cancelled' | 'rescued';
 
 export class AutoStashService {
   
@@ -296,6 +296,10 @@ export class AutoStashService {
 
     if (outcome === 'completed') {
       capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges });
+    } else if (outcome === 'rescued') {
+      // Checkout happened, but the stash pop/apply conflicted and a rescue notification
+      // was already shown in place of a generic error — tag instead of double-reporting success.
+      capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges, stashConflict: true });
     }
 
     return outcome;
@@ -335,6 +339,11 @@ export class AutoStashService {
         await git.popStash(message);
       }
     } catch (e) {
+      const conflicts = await git.getConflictedFiles();
+      if (conflicts.length > 0) {
+        await offerConflictRescue(git, conflicts, 'pop');
+        return 'rescued';
+      }
       handleErrorMessage(
         e,
         'No stash found',
@@ -408,16 +417,13 @@ export class AutoStashService {
     } catch (e) {
       const conflicts = await git.getConflictedFiles();
       if (conflicts.length > 0) {
+        // Replace the generic error with the rescue notification — checkout already
+        // happened and the stash was already applied/popped (with conflict markers left
+        // in the working tree), so surfacing a second generic failure would be misleading.
         await offerConflictRescue(git, conflicts, operation);
-        handleErrorMessage(
-          e,
-          'No stash found',
-          `No stash to ${operation} on the new branch.`,
-          `Failed to ${operation} the stash on the new branch.`
-        );
-      } else {
-        handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
+        return 'rescued';
       }
+      handleErrorMessage(e, 'No stash found', `No stash to ${operation} on the new branch.`, `Failed to ${operation} the stash on the new branch.`);
     }
 
     return 'completed';

--- a/src/services/stashConflictRescue.ts
+++ b/src/services/stashConflictRescue.ts
@@ -9,7 +9,10 @@ export async function offerConflictRescue(
   files: string[],
   operation: StashOperation
 ): Promise<void> {
-  const canUndo = !(await git.isMergeInProgress());
+  // A conflicted pop/apply does not itself start a merge/cherry-pick operation tracked by
+  // MERGE_HEAD/CHERRY_PICK_HEAD, but `git reset --merge` is only safe to offer when no other
+  // merge-like operation (e.g. an in-progress rebase/cherry-pick/merge) is layered on top of it.
+  const canUndo = !(await git.isMergeInProgress()) && !(await git.isCherryPickInProgress());
   const message = `Stash restored with conflicts: ${files.length} file(s) need resolution. ${
     operation === 'pop' ? 'The stash was preserved because pop conflicted.' : 'The stash is preserved because apply never removes it.'
   }`;
@@ -19,9 +22,13 @@ export async function offerConflictRescue(
     await vscode.commands.executeCommand('workbench.view.scm');
     const uri = vscode.Uri.file(path.resolve(git.repositoryPath, files[0]));
     try {
-      await vscode.commands.executeCommand('vscode.openWith', uri, 'workbench.editors.textFileEditor');
+      await vscode.commands.executeCommand('git.openMergeEditor', uri);
     } catch {
-      await vscode.commands.executeCommand('vscode.open', uri);
+      try {
+        await vscode.commands.executeCommand('vscode.openWith', uri, 'mergeEditor.input');
+      } catch {
+        await vscode.commands.executeCommand('vscode.open', uri);
+      }
     }
   } else if (choice === 'Open files') {
     await Promise.all(files.map((file) => vscode.commands.executeCommand(

--- a/src/test/e2e/conflict.test.ts
+++ b/src/test/e2e/conflict.test.ts
@@ -30,63 +30,93 @@ function stubConflictDialog(answer: string | undefined): () => void {
   return () => { (vscode.window as any).showWarningMessage = original; };
 }
 
+/**
+ * Stubs window.showWarningMessage to answer each successive call with the next
+ * entry in `answers` (the last entry repeats once exhausted), while recording
+ * every message shown so tests can assert on rescue-notification wording.
+ */
+function stubWarningSequence(answers: (string | undefined)[]): {
+  messages: string[];
+  restore: () => void;
+} {
+  const original = vscode.window.showWarningMessage.bind(vscode.window);
+  const messages: string[] = [];
+  let call = 0;
+  (vscode.window as any).showWarningMessage = async (message: string) => {
+    messages.push(message);
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call++;
+    return answer;
+  };
+  return {
+    messages,
+    restore: () => { (vscode.window as any).showWarningMessage = original; },
+  };
+}
+
 describe('AutoStashService — stash pop/apply conflicts', () => {
 
   /**
    * AUTO_STASH_AND_POP_IN_NEW_BRANCH: stash from main contains a change to file1.txt
    * (based on "initial content"). feature has file1.txt = "feature version of file1".
-   * Popping the stash on feature conflicts → checkoutAndStashChanges throws, stash
-   * entry is retained because git stash pop does not drop the entry on conflict.
-   * Dialog is stubbed to 'Continue' so the user proceeds past the warning.
+   * Popping the stash on feature conflicts. Per the stash-pop conflict rescue flow,
+   * checkoutAndStashChanges no longer throws a generic error — it resolves with
+   * outcome "rescued" and shows the rescue notification instead. The stash entry is
+   * retained because git stash pop does not drop the entry on conflict.
+   * The first dialog (predicted-conflict warning) is answered 'Continue'; the second
+   * (rescue notification) is answered with nothing selected.
    */
   describe('AUTO_STASH_AND_POP_IN_NEW_BRANCH: conflicting changes — user continues', () => {
     let repo: TestRepo;
-    let restoreDialog: () => void;
+    let dialog: { messages: string[]; restore: () => void };
     before(() => {
       repo = createConflictTestRepo();
-      restoreDialog = stubConflictDialog('Continue');
+      dialog = stubWarningSequence(['Continue', undefined]);
     });
-    after(() => { restoreDialog(); repo.cleanup(); });
+    after(() => { dialog.restore(); repo.cleanup(); });
 
-    it('throws an error, checkout still happened, stash entry is retained', async () => {
+    it('does not throw, checkout happened, rescue notification shown, stash entry retained', async () => {
       repo.makeChange('file1.txt', 'main dirty change\n');
 
-      await assert.rejects(
-        () => sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH),
-        /Failed to pop the stash on the new branch/
-      );
+      const outcome = await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH);
 
-      assert.strictEqual(await repo.git.getCurrentBranch(), repo.featureBranch, 'checkout happened before the pop error');
+      assert.strictEqual(outcome, 'rescued');
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.featureBranch, 'checkout happened before the pop conflict');
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'conflict markers left in working dir');
       assert.strictEqual(repo.stashCount(), 1, 'stash entry retained because pop failed on conflict');
+
+      const rescueMessage = dialog.messages[dialog.messages.length - 1];
+      assert.match(rescueMessage, /Stash restored with conflicts: \d+ file\(s\) need resolution/);
+      assert.match(rescueMessage, /stash was preserved because pop conflicted/);
     });
   });
 
   /**
    * AUTO_STASH_AND_APPLY_IN_NEW_BRANCH: same conflict scenario.
    * apply always retains the stash entry regardless of success or failure.
-   * Dialog is stubbed to 'Continue' so the user proceeds past the warning.
    */
   describe('AUTO_STASH_AND_APPLY_IN_NEW_BRANCH: conflicting changes — user continues', () => {
     let repo: TestRepo;
-    let restoreDialog: () => void;
+    let dialog: { messages: string[]; restore: () => void };
     before(() => {
       repo = createConflictTestRepo();
-      restoreDialog = stubConflictDialog('Continue');
+      dialog = stubWarningSequence(['Continue', undefined]);
     });
-    after(() => { restoreDialog(); repo.cleanup(); });
+    after(() => { dialog.restore(); repo.cleanup(); });
 
-    it('throws an error, checkout still happened, stash entry is retained', async () => {
+    it('does not throw, checkout happened, rescue notification shown (apply wording), stash retained', async () => {
       repo.makeChange('file1.txt', 'main dirty change\n');
 
-      await assert.rejects(
-        () => sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_APPLY_IN_NEW_BRANCH),
-        /Failed to apply the stash on the new branch/
-      );
+      const outcome = await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_APPLY_IN_NEW_BRANCH);
 
-      assert.strictEqual(await repo.git.getCurrentBranch(), repo.featureBranch, 'checkout happened before the apply error');
+      assert.strictEqual(outcome, 'rescued');
+      assert.strictEqual(await repo.git.getCurrentBranch(), repo.featureBranch, 'checkout happened before the apply conflict');
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'conflict markers left in working dir');
       assert.strictEqual(repo.stashCount(), 1, 'stash entry retained (apply never removes it)');
+
+      const rescueMessage = dialog.messages[dialog.messages.length - 1];
+      assert.match(rescueMessage, /Stash restored with conflicts: \d+ file\(s\) need resolution/);
+      assert.match(rescueMessage, /stash is preserved because apply never removes it/);
     });
   });
 
@@ -106,8 +136,9 @@ describe('AutoStashService — stash pop/apply conflicts', () => {
     it('stays on original branch, working tree unchanged, no stash created', async () => {
       repo.makeChange('file1.txt', 'main dirty change\n');
 
-      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH);
+      const outcome = await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH);
 
+      assert.strictEqual(outcome, 'cancelled');
       assert.strictEqual(await repo.git.getCurrentBranch(), repo.mainBranch, 'still on main — checkout was aborted');
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'local changes preserved');
       assert.strictEqual(repo.stashCount(), 0, 'no stash was created');
@@ -129,8 +160,9 @@ describe('AutoStashService — stash pop/apply conflicts', () => {
     it('stays on original branch, working tree unchanged, no stash created', async () => {
       repo.makeChange('file1.txt', 'main dirty change\n');
 
-      await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_APPLY_IN_NEW_BRANCH);
+      const outcome = await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_APPLY_IN_NEW_BRANCH);
 
+      assert.strictEqual(outcome, 'cancelled');
       assert.strictEqual(await repo.git.getCurrentBranch(), repo.mainBranch, 'still on main — checkout was aborted');
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'local changes preserved');
       assert.strictEqual(repo.stashCount(), 0, 'no stash was created');
@@ -163,6 +195,41 @@ describe('AutoStashService — stash pop/apply conflicts', () => {
       assert.strictEqual(await repo.git.getCurrentBranch(), repo.mainBranch);
       assert.strictEqual(await repo.git.isWorkdirHasChanges(), true, 'original changes restored on main');
       assert.strictEqual(repo.stashCount(), 0, 'stash entry removed after successful pop');
+    });
+  });
+
+  /**
+   * "Undo (keep stash)": after a conflicted pop, choosing Undo runs `git reset --merge`,
+   * leaving the working tree clean while the stash entry (the auto-stash) remains
+   * available via "GSC: Manage auto-stashes...".
+   */
+  describe('AUTO_STASH_AND_POP_IN_NEW_BRANCH: conflicting changes — Undo (keep stash)', () => {
+    let repo: TestRepo;
+    let dialog: { messages: string[]; restore: () => void };
+    let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+    before(() => {
+      repo = createConflictTestRepo();
+      // First dialog: predicted-conflict warning -> Continue. Second: rescue notification -> Undo.
+      dialog = stubWarningSequence(['Continue', 'Undo (keep stash)']);
+      // Undo shows a follow-up information message; stub it so the promise resolves
+      // instead of waiting indefinitely for a real UI dismissal.
+      originalShowInformationMessage = vscode.window.showInformationMessage;
+      (vscode.window as any).showInformationMessage = async () => undefined;
+    });
+    after(() => {
+      dialog.restore();
+      (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+      repo.cleanup();
+    });
+
+    it('cleans the working tree via reset --merge and keeps the auto-stash entry', async () => {
+      repo.makeChange('file1.txt', 'main dirty change\n');
+
+      const outcome = await sut.checkoutAndStashChanges(repo.git, repo.mainBranch, makeRef(repo.featureBranch), AUTO_STASH_AND_POP_IN_NEW_BRANCH);
+
+      assert.strictEqual(outcome, 'rescued');
+      assert.strictEqual(await repo.git.isWorkdirHasChanges(), false, 'working tree cleaned up by reset --merge');
+      assert.strictEqual(repo.stashCount(), 1, 'auto-stash is preserved and reachable via Manage auto-stashes');
     });
   });
 });

--- a/src/test/e2e/manageAutoStashes.test.ts
+++ b/src/test/e2e/manageAutoStashes.test.ts
@@ -12,7 +12,7 @@ import {
   stubWarningMessages,
   withRepoWorkspace,
 } from './helpers/commandHarness';
-import { createTestRepo, TestRepo } from './helpers/gitTestRepo';
+import { createConflictTestRepo, createTestRepo, TestRepo } from './helpers/gitTestRepo';
 
 type ManagerQuickPickItem = vscode.QuickPickItem & {
   stash?: IGitStash;
@@ -237,6 +237,48 @@ describe('Manage auto-stashes command', () => {
         assert.strictEqual(repo.readFile('unrelated.txt'), 'keep this dirty change\n');
         assert.strictEqual(repo.stashCount(), 1);
         assert.deepStrictEqual(errors.messages, []);
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      warnings.restore();
+      restoreQuickPick();
+      repo.cleanup();
+    }
+  });
+
+  it('shows a rescue notification (not a generic error) when popping a conflicting auto-stash', async () => {
+    // A real 3-way-merge conflict (with conflict markers, not just a "would be
+    // overwritten" refusal) requires the stash to be popped against a commit that
+    // diverged from its base — so stash on main, then switch to feature (which
+    // already modifies the same line of file1.txt) before popping.
+    const repo = createConflictTestRepo();
+    repo.makeChange('file1.txt', 'main dirty change\n');
+    await repo.git.createStash('auto-stash-main-2026-06-14T12:34:56');
+    repo.exec(`git checkout ${repo.featureBranch}`);
+
+    let stashPickerCount = 0;
+    const restoreQuickPick = stubShowQuickPick((items, options) => {
+      const managerItems = items as readonly ManagerQuickPickItem[];
+      if (options?.placeHolder === 'Select an auto-stash') {
+        stashPickerCount++;
+        return stashPickerCount === 1 ? managerItems[0] : undefined;
+      }
+      return managerItems.find((item) => item.action === 'pop');
+    });
+    const warnings = stubWarningMessages(() => undefined);
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('manageAutoStashes'));
+
+        const rescueMessage = warnings.messages.find((message) => message.includes('Stash restored with conflicts'));
+        assert.ok(rescueMessage, 'rescue notification should be shown instead of a generic error');
+        assert.match(rescueMessage as string, /stash was preserved because pop conflicted/);
+        assert.strictEqual(repo.stashCount(), 1, 'stash retained because pop conflicted');
+        assert.deepStrictEqual(errors.messages, [], 'no generic error should be shown');
       });
     } finally {
       errors.restore();

--- a/src/test/unit/stashConflictRescue.test.ts
+++ b/src/test/unit/stashConflictRescue.test.ts
@@ -2,8 +2,10 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { GitExecutor } from '../../common/git/gitExecutor';
 import { LoggingService } from '../../logging/loggingService';
+import { offerConflictRescue } from '../../services/stashConflictRescue';
 import { mockLogService } from '../e2e/helpers/mockLogService';
 
 describe('GitExecutor stash conflict recovery', () => {
@@ -23,5 +25,158 @@ describe('GitExecutor stash conflict recovery', () => {
       if (oldLog === undefined) delete process.env.GSC_LOG; else process.env.GSC_LOG = oldLog;
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('offerConflictRescue', () => {
+  function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+    return {
+      repositoryPath: '/repo',
+      isMergeInProgress: async () => false,
+      isCherryPickInProgress: async () => false,
+      resetMerge: async () => {},
+      ...overrides,
+    } as unknown as GitExecutor;
+  }
+
+  let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
+  let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+  let originalExecuteCommand: typeof vscode.commands.executeCommand;
+
+  beforeEach(() => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    originalShowInformationMessage = vscode.window.showInformationMessage;
+    originalExecuteCommand = vscode.commands.executeCommand;
+  });
+
+  afterEach(() => {
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+  });
+
+  it('wording distinguishes pop (stash preserved because pop conflicted) from apply', async () => {
+    const messages: string[] = [];
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      messages.push(message);
+      return undefined;
+    };
+    (vscode.commands as any).executeCommand = async () => undefined;
+
+    await offerConflictRescue(makeGitStub(), ['a.txt', 'b.txt'], 'pop');
+    await offerConflictRescue(makeGitStub(), ['a.txt', 'b.txt'], 'apply');
+
+    assert.match(messages[0], /Stash restored with conflicts: 2 file\(s\) need resolution/);
+    assert.match(messages[0], /preserved because pop conflicted/);
+    assert.match(messages[1], /preserved because apply never removes it/);
+  });
+
+  it('"Resolve conflicts" focuses SCM view and opens the first file with the merge editor', async () => {
+    const calls: Array<{ command: string; args: unknown[] }> = [];
+    (vscode.window as any).showWarningMessage = async () => 'Resolve conflicts';
+    (vscode.commands as any).executeCommand = async (command: string, ...args: unknown[]) => {
+      calls.push({ command, args });
+      if (command === 'git.openMergeEditor') {
+        return undefined;
+      }
+      return undefined;
+    };
+
+    await offerConflictRescue(makeGitStub(), ['a.txt', 'b.txt'], 'pop');
+
+    assert.strictEqual(calls[0].command, 'workbench.view.scm');
+    assert.strictEqual(calls[1].command, 'git.openMergeEditor');
+    const uri = calls[1].args[0] as vscode.Uri;
+    assert.strictEqual(uri.fsPath, path.resolve('/repo', 'a.txt'));
+    // Only the first conflicted file is opened for resolution.
+    assert.strictEqual(calls.length, 2);
+  });
+
+  it('"Resolve conflicts" falls back to vscode.open when merge editor commands are unavailable', async () => {
+    const calls: string[] = [];
+    (vscode.window as any).showWarningMessage = async () => 'Resolve conflicts';
+    (vscode.commands as any).executeCommand = async (command: string) => {
+      calls.push(command);
+      if (command === 'git.openMergeEditor' || command === 'vscode.openWith') {
+        throw new Error('command not found');
+      }
+      return undefined;
+    };
+
+    await offerConflictRescue(makeGitStub(), ['a.txt'], 'pop');
+
+    assert.deepStrictEqual(calls, ['workbench.view.scm', 'git.openMergeEditor', 'vscode.openWith', 'vscode.open']);
+  });
+
+  it('"Open files" opens every conflicted file as a regular editor', async () => {
+    const openedUris: string[] = [];
+    (vscode.window as any).showWarningMessage = async () => 'Open files';
+    (vscode.commands as any).executeCommand = async (command: string, uri: vscode.Uri) => {
+      assert.strictEqual(command, 'vscode.open');
+      openedUris.push(uri.fsPath);
+    };
+
+    await offerConflictRescue(makeGitStub(), ['a.txt', 'b.txt', 'c.txt'], 'apply');
+
+    assert.strictEqual(openedUris.length, 3);
+    assert.deepStrictEqual(
+      openedUris.sort(),
+      ['a.txt', 'b.txt', 'c.txt'].map((f) => path.resolve('/repo', f)).sort()
+    );
+  });
+
+  it('"Undo (keep stash)" runs resetMerge and informs the user the stash is preserved', async () => {
+    let resetMergeCalled = false;
+    const infoMessages: string[] = [];
+    (vscode.window as any).showWarningMessage = async () => 'Undo (keep stash)';
+    (vscode.window as any).showInformationMessage = async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    };
+
+    const git = makeGitStub({ resetMerge: async () => { resetMergeCalled = true; } });
+    await offerConflictRescue(git, ['a.txt'], 'pop');
+
+    assert.strictEqual(resetMergeCalled, true);
+    assert.match(infoMessages[0], /stash is preserved/i);
+    assert.match(infoMessages[0], /Manage auto-stashes/);
+  });
+
+  it('does not offer Undo when a merge is already in progress (MERGE_HEAD present)', async () => {
+    let actionsOffered: (string | undefined)[] = [];
+    (vscode.window as any).showWarningMessage = async (_message: string, ...actions: string[]) => {
+      actionsOffered = actions;
+      return undefined;
+    };
+
+    const git = makeGitStub({ isMergeInProgress: async () => true });
+    await offerConflictRescue(git, ['a.txt'], 'pop');
+
+    assert.deepStrictEqual(actionsOffered, ['Resolve conflicts', 'Open files']);
+  });
+
+  it('does not offer Undo when a cherry-pick is in progress (CHERRY_PICK_HEAD present)', async () => {
+    let actionsOffered: (string | undefined)[] = [];
+    (vscode.window as any).showWarningMessage = async (_message: string, ...actions: string[]) => {
+      actionsOffered = actions;
+      return undefined;
+    };
+
+    const git = makeGitStub({ isCherryPickInProgress: async () => true });
+    await offerConflictRescue(git, ['a.txt'], 'pop');
+
+    assert.deepStrictEqual(actionsOffered, ['Resolve conflicts', 'Open files']);
+  });
+
+  it('offers Undo when no other merge-like operation is in progress', async () => {
+    let actionsOffered: (string | undefined)[] = [];
+    (vscode.window as any).showWarningMessage = async (_message: string, ...actions: string[]) => {
+      actionsOffered = actions;
+      return undefined;
+    };
+
+    await offerConflictRescue(makeGitStub(), ['a.txt'], 'pop');
+
+    assert.deepStrictEqual(actionsOffered, ['Resolve conflicts', 'Open files', 'Undo (keep stash)']);
   });
 });

--- a/src/test/unit/stashConflictRouting.test.ts
+++ b/src/test/unit/stashConflictRouting.test.ts
@@ -1,0 +1,126 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { AUTO_STASH_AND_POP_IN_NEW_BRANCH, AUTO_STASH_CURRENT_BRANCH } from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const nextBranch: IGitRef = {
+  name: 'feature-x',
+  fullName: 'feature-x',
+  remote: false,
+  isTag: false,
+} as unknown as IGitRef;
+
+function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    isWorkdirHasChanges: async () => true,
+    getStashConflictPreview: async () => [],
+    createStash: async () => {},
+    checkout: async () => {},
+    hasUpstreamBranch: async () => false,
+    isStashWithMessageExists: async () => true,
+    popStash: async () => { throw new Error('conflict during pop'); },
+    getConflictedFiles: async () => [],
+    isMergeInProgress: async () => false,
+    isCherryPickInProgress: async () => false,
+    resetMerge: async () => {},
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+function makeConfigManagerStub(): ConfigurationManager {
+  return {
+    get: () => ({ pullAfterCheckout: 'ffOnly' }),
+  } as unknown as ConfigurationManager;
+}
+
+describe('AutoStashService — conflict rescue routing', () => {
+  let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
+
+  afterEach(() => {
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+  });
+
+  it('AUTO_STASH_AND_POP_IN_NEW_BRANCH: 3 conflicted files → rescue notification, no throw, outcome "rescued"', async () => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    const warnings: string[] = [];
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnings.push(message);
+      return undefined;
+    };
+
+    const git = makeGitStub({ getConflictedFiles: async () => ['a.txt', 'b.txt', 'c.txt'] });
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_AND_POP_IN_NEW_BRANCH);
+
+    assert.strictEqual(outcome, 'rescued');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /Stash restored with conflicts: 3 file\(s\) need resolution/);
+  });
+
+  it('AUTO_STASH_AND_POP_IN_NEW_BRANCH: no conflicted files → generic error path preserved', async () => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async () => undefined;
+
+    const git = makeGitStub({ getConflictedFiles: async () => [] });
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    await assert.rejects(
+      () => service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_AND_POP_IN_NEW_BRANCH),
+      /Failed to pop the stash on the new branch/
+    );
+  });
+
+  it('AUTO_STASH_CURRENT_BRANCH: conflicted pop on the new branch → rescue notification, no throw, outcome "rescued"', async () => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    const warnings: string[] = [];
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnings.push(message);
+      return undefined;
+    };
+
+    const git = makeGitStub({ getConflictedFiles: async () => ['a.txt'] });
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_CURRENT_BRANCH);
+
+    assert.strictEqual(outcome, 'rescued');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /Stash restored with conflicts: 1 file\(s\) need resolution/);
+  });
+
+  it('AUTO_STASH_CURRENT_BRANCH: no conflicted files → generic error path preserved', async () => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async () => undefined;
+
+    const git = makeGitStub({ getConflictedFiles: async () => [] });
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    await assert.rejects(
+      () => service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_CURRENT_BRANCH),
+      /Failed to pop the stash on the new branch/
+    );
+  });
+
+  it('apply mode: rescue wording says stash preserved because apply never removes it', async () => {
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    const warnings: string[] = [];
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnings.push(message);
+      return undefined;
+    };
+
+    const git = makeGitStub({ getConflictedFiles: async () => ['a.txt'] });
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.doAutoStashAndPopInNewBranch(git, 'main', 'feature-x', true, true, 'feature-x');
+
+    assert.strictEqual(outcome, 'rescued');
+    assert.match(warnings[0], /preserved because apply never removes it/);
+  });
+});


### PR DESCRIPTION
## Summary

Feature 4 (#148) wired most of the stash-pop conflict rescue flow, but auditing it against the full spec turned up a few real gaps:

- `doAutoStashAndPopInNewBranch` showed the rescue notification on a conflicted pop/apply, but then **still threw the generic "Failed to pop/apply the stash..." error**, which `checkoutToCommand`'s outer catch surfaced as a second, contradictory error toast — the spec calls for the rescue notification to *replace* the generic error, not sit alongside it.
- `doAutoStashCurrentBranch` (the `autoStashForBranch` mode's own stash pop) never checked for conflicts at all — a conflicted pop there fell straight through to the plain "Failed to pop the stash" error with no rescue offered.
- No `stashConflict: true` analytics tag existed anywhere, so a rescued checkout was indistinguishable from a normal successful one in analytics.
- The Undo guard only checked `MERGE_HEAD`, ignoring an in-progress cherry-pick (`CHERRY_PICK_HEAD`) per the spec's explicit guidance.
- "Resolve conflicts" opened the file as a plain text editor (`workbench.editors.textFileEditor`) rather than attempting the real merge editor.
- No unit tests existed for `offerConflictRescue`'s action dispatch/wording/guard, and the existing `conflict.test.ts` e2e suite asserted the old (buggy) throwing behavior.

## Changes

- `src/services/autoStashService.ts`: `doAutoStashAndPopInNewBranch` and `doAutoStashCurrentBranch` now return a new `'rescued'` outcome instead of throwing when a conflict is detected; `checkoutAndStashChanges` tags the checkout analytics event with `stashConflict: true` for that outcome instead of firing the normal success event.
- `src/commands/manageAutoStashesCommand/index.ts`: `runAction` reports whether the rescue path fired so `AutoStashManaged` analytics gets the same tag.
- `src/services/stashConflictRescue.ts`: Undo is hidden when either a merge or cherry-pick is in progress; "Resolve conflicts" now tries `git.openMergeEditor` first, falling back through `vscode.openWith` to `vscode.open`.
- Tests: rewrote `src/test/e2e/conflict.test.ts` to match the new no-throw behavior and added an Undo-flow case; added a conflict-rescue case to `src/test/e2e/manageAutoStashes.test.ts`; added `src/test/unit/stashConflictRouting.test.ts` (routing: conflicts vs. no conflicts, pop vs. apply wording) and expanded `src/test/unit/stashConflictRescue.test.ts` (action dispatch, merge-editor fallback chain, Undo guard for MERGE_HEAD/CHERRY_PICK_HEAD).

## How to test manually

1. In a repo with two branches that both modify the same line of a tracked file, set `gitSmartCheckout.mode` to `autoStashAndPopInNewBranch`.
2. Make an uncommitted change to that file, then run `GSC: Checkout to...` and switch to the other branch, confirming the predicted-conflict warning.
3. Confirm you now see exactly one notification: "Stash restored with conflicts: N file(s) need resolution. The stash was preserved because pop conflicted." with actions `Resolve conflicts` / `Open files` / `Undo (keep stash)` — no separate generic error toast.
4. Try `Resolve conflicts` (focuses SCM view, opens the first conflicted file), `Open files` (opens every conflicted file), and `Undo (keep stash)` (working tree resets cleanly; run `GSC: Manage auto-stashes...` to confirm the stash is still listed).
5. Repeat with `gitSmartCheckout.mode` set to `autoStashCurrentBranch` — checkout back to the original branch should trigger the same rescue flow if the pop conflicts.
6. From `GSC: Manage auto-stashes...`, pick a stash whose pop/apply will conflict and confirm the same rescue notification appears instead of a generic error.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (468 passing)
- [x] `yarn compile-tests` + targeted e2e runs of `conflict.test.ts`, `manageAutoStashes.test.ts`, `checkout.test.ts`, `rebaseWithStash.test.ts`, `checkoutByPR.test.ts` (all green; `xvfb-run` unavailable locally so the full `test:e2e:ci` grouping wasn't run, but these cover every file touched by this change)