### PR TITLE
fix(checkout): close spec gaps in inline branch actions

### DIFF
--- a/src/commands/checkoutToCommand/branchActionButtons.ts
+++ b/src/commands/checkoutToCommand/branchActionButtons.ts
@@ -1,0 +1,46 @@
+import * as vscode from 'vscode';
+
+import { IGitRef } from '../../common/git/types';
+
+export type BranchItemAction = 'star' | 'delete' | 'rename' | 'push';
+
+export type BranchActionButton = vscode.QuickInputButton & { action: BranchItemAction };
+
+/**
+ * Builds the inline QuickPick buttons for a single ref, based on its type:
+ * - Tag: star + delete (tag).
+ * - Remote branch: star + delete (remote branch).
+ * - Local branch: star + delete + rename + push (push only when the branch
+ *   has no upstream or is ahead of it). Buttons are shown for the current
+ *   branch too — deleting it is blocked at action time with an explanatory
+ *   message rather than by hiding the button.
+ */
+export function buildRefActionButtons(ref: IGitRef, isPreferred: boolean): BranchActionButton[] {
+  const buttons: BranchActionButton[] = [
+    {
+      iconPath: new vscode.ThemeIcon(isPreferred ? 'star-full' : 'star'),
+      tooltip: isPreferred ? 'Unstar' : 'Star',
+      action: 'star',
+    },
+  ];
+
+  if (ref.isTag) {
+    buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete tag', action: 'delete' });
+    return buttons;
+  }
+
+  if (ref.remote) {
+    buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete remote branch', action: 'delete' });
+    return buttons;
+  }
+
+  buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete branch', action: 'delete' });
+  buttons.push({ iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Rename branch', action: 'rename' });
+
+  const canPush = !ref.upstreamTrack || Boolean(ref.parsedUpstreamTrack?.[0]);
+  if (canPush) {
+    buttons.push({ iconPath: new vscode.ThemeIcon('cloud-upload'), tooltip: 'Publish branch', action: 'push' });
+  }
+
+  return buttons;
+}

--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { AUTO_STASH_IGNORE } from './constants';
+import { BranchItemAction, buildRefActionButtons } from './branchActionButtons';
 import { GitExecutor } from '../../common/git/gitExecutor';
 import { getFullRefname } from '../../common/git/refName';
 import { IGitRef } from '../../common/git/types';
@@ -12,6 +13,7 @@ import { RefDetailsCache } from '../../services/refDetailsCache';
 import { getRepoId } from '../../utils/getRepoId';
 import { UserCancelledError } from '../../utils/userCancelledError';
 import { BaseCommand } from '../command';
+import { validateBranchName } from '../createBranchFromTemplateCommand/validateBranchName';
 import { attachLazyEnrichment } from '../utils/enrichOnActive';
 import { prepareInitialRefDetails, refreshRemainingRefDetails } from '../utils/refDetailsPrefetch';
 import { getMergedBranchLists } from '../utils/getMergedBranchLists';
@@ -162,23 +164,7 @@ export class CheckoutToCommand extends BaseCommand {
         .filter(Boolean)
         .join(' ');
 
-      const buttons: (vscode.QuickInputButton & { action?: string })[] = [{
-        iconPath: new vscode.ThemeIcon(
-          this.configManager.isPreferred(repoId, ref) ? 'star-full' : 'star'
-        ),
-        tooltip: this.configManager.isPreferred(repoId, ref) ? 'Unstar' : 'Star',
-        action: 'star',
-      }];
-      const canPush = !ref.isTag && !ref.remote && (!ref.upstreamTrack || Boolean(ref.parsedUpstreamTrack?.[0]));
-      if (ref.isTag) {
-        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete tag', action: 'delete' });
-      } else if (ref.remote) {
-        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete remote branch', action: 'delete' });
-      } else if (ref.name !== currentBranch) {
-        buttons.push({ iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Delete branch', action: 'delete' });
-        buttons.push({ iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Rename branch', action: 'rename' });
-        if (canPush) buttons.push({ iconPath: new vscode.ThemeIcon('cloud-upload'), tooltip: 'Publish branch', action: 'push' });
-      }
+      const buttons = buildRefActionButtons(ref, isPreferred);
       return {
         label,
         description: getRefDescription(ref),
@@ -238,39 +224,22 @@ export class CheckoutToCommand extends BaseCommand {
     }
 
     qp.onDidTriggerItemButton(async (e) => {
-      const ref = (e.item as any).ref as IGitRef | undefined;
+      const ref = (e.item as { ref?: IGitRef }).ref;
       if (!ref) {
         return;
       }
-      const action = (e.button as any).action ?? 'star';
+      const action = ((e.button as { action?: BranchItemAction }).action ?? 'star') as BranchItemAction;
       qp.busy = true;
       try {
-        if (action === 'star') {
-          await this.configManager.togglePreferred(repoId, ref, branchList);
-        } else if (action === 'rename') {
-          const name = await vscode.window.showInputBox({ value: ref.name, prompt: 'New branch name' });
-          if (!name) return;
-          if (!/^[A-Za-z0-9._/-]+$/.test(name) || name.includes('..')) {
-            await vscode.window.showErrorMessage('Invalid branch name.', 'OK');
-            return;
-          }
-          await git.renameBranch(ref.name, name);
-        } else if (action === 'push') {
-          await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: `Publishing ${ref.name}` }, () => git.pushSetUpstream(ref.name));
-        } else if (ref.isTag) {
-          const confirmed = await vscode.window.showWarningMessage(`Delete tag ${ref.name}?`, { modal: true }, 'Delete');
-          if (confirmed === 'Delete') await git.deleteTag(ref.name);
-        } else if (ref.remote) {
-          const confirmed = await vscode.window.showWarningMessage(`Delete remote branch ${ref.remote}/${ref.name}?`, { modal: true }, 'Delete');
-          if (confirmed === 'Delete') await git.deleteRemoteBranch(ref.remote, ref.name);
-        } else {
-          const merged = await git.getMergedBranches(this.configManager.get().defaultTargetBranch);
-          const force = !merged.includes(ref.name);
-          if (force) {
-            const confirmed = await vscode.window.showWarningMessage(`Branch ${ref.name} is not merged into ${this.configManager.get().defaultTargetBranch}. Delete anyway?`, { modal: true }, 'Delete');
-            if (confirmed !== 'Delete') return;
-          }
-          await git.deleteBranch(ref.name, force);
+        const mutated = await this.handleItemButtonAction(git, repoId, currentBranch, branchList, ref, action);
+        if (mutated) {
+          const [refreshedList, refreshedCurrentBranch] = await Promise.all([
+            this.refreshBranchList(git),
+            git.getCurrentBranch(),
+          ]);
+          branchList = refreshedList;
+          currentBranch = refreshedCurrentBranch;
+          void this.refDetailsCache?.upsertFromRefs(git.repositoryPath, branchList);
         }
       } finally {
         qp.busy = false;
@@ -371,6 +340,189 @@ export class CheckoutToCommand extends BaseCommand {
       selectedRef: picked.ref,
       branchList,
     };
+  }
+
+  /**
+   * Re-fetches the full ref list from git. Called after a mutating inline
+   * action (delete/rename/push) so the picker reflects the new state instead
+   * of the stale list captured when it was first opened.
+   */
+  protected async refreshBranchList(git: GitExecutor): Promise<IGitRef[]> {
+    return await git.getAllRefListExtended();
+  }
+
+  /**
+   * Routes an inline QuickPick button click to the appropriate action.
+   * Returns true when the ref list changed and should be re-fetched.
+   */
+  protected async handleItemButtonAction(
+    git: GitExecutor,
+    repoId: string,
+    currentBranch: string,
+    branchList: IGitRef[],
+    ref: IGitRef,
+    action: BranchItemAction
+  ): Promise<boolean> {
+    if (action === 'star') {
+      await this.configManager.togglePreferred(repoId, ref, branchList);
+      return false;
+    }
+    if (action === 'rename') {
+      return await this.renameBranchAction(git, ref);
+    }
+    if (action === 'push') {
+      return await this.publishBranchAction(git, ref);
+    }
+    if (ref.isTag) {
+      return await this.deleteTagAction(git, ref);
+    }
+    if (ref.remote) {
+      return await this.deleteRemoteBranchAction(git, ref);
+    }
+    return await this.deleteLocalBranchAction(git, ref, currentBranch);
+  }
+
+  protected async renameBranchAction(git: GitExecutor, ref: IGitRef): Promise<boolean> {
+    const newName = await this.showInputBox({
+      value: ref.name,
+      prompt: 'New branch name',
+      validateInput: (value) => validateBranchName(value),
+    });
+    if (!newName || newName === ref.name) {
+      // Escape, or unchanged name — silent no-op.
+      return false;
+    }
+
+    try {
+      await git.renameBranch(ref.name, newName);
+      await this.showInformationMessage(`Renamed branch ${ref.name} to ${newName}.`);
+      return true;
+    } catch (e) {
+      captureException(e);
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.showErrorMessage(`Failed to rename branch ${ref.name}: ${msg}`, 'OK');
+      return false;
+    }
+  }
+
+  protected async publishBranchAction(git: GitExecutor, ref: IGitRef): Promise<boolean> {
+    try {
+      await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: `Publishing ${ref.name}` },
+        () => git.pushSetUpstream(ref.name)
+      );
+      return true;
+    } catch (e) {
+      captureException(e);
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.showErrorMessage(`Failed to publish branch ${ref.name}: ${msg}`, 'OK');
+      return false;
+    }
+  }
+
+  protected async deleteTagAction(git: GitExecutor, ref: IGitRef): Promise<boolean> {
+    const confirmed = await vscode.window.showWarningMessage(
+      `Delete tag ${ref.name}? This cannot be undone.`,
+      { modal: true },
+      'Delete'
+    );
+    if (confirmed !== 'Delete') {
+      // Escape/Cancel — silent no-op.
+      return false;
+    }
+
+    try {
+      await git.deleteTag(ref.name);
+      await this.showInformationMessage(`Deleted tag ${ref.name}.`);
+      return true;
+    } catch (e) {
+      captureException(e);
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.showErrorMessage(`Failed to delete tag ${ref.name}: ${msg}`, 'OK');
+      return false;
+    }
+  }
+
+  protected async deleteRemoteBranchAction(git: GitExecutor, ref: IGitRef): Promise<boolean> {
+    const remote = ref.remote ?? 'origin';
+    const confirmed = await vscode.window.showWarningMessage(
+      `Delete branch ${ref.name} from remote "${remote}"? This removes it for everyone and cannot be undone.`,
+      { modal: true },
+      'Delete'
+    );
+    if (confirmed !== 'Delete') {
+      // Escape/Cancel — silent no-op.
+      return false;
+    }
+
+    try {
+      await git.deleteRemoteBranch(remote, ref.name);
+      await this.showInformationMessage(`Deleted remote branch ${remote}/${ref.name}.`);
+      return true;
+    } catch (e) {
+      captureException(e);
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.showErrorMessage(`Failed to delete remote branch ${remote}/${ref.name}: ${msg}`, 'OK');
+      return false;
+    }
+  }
+
+  protected async deleteLocalBranchAction(
+    git: GitExecutor,
+    ref: IGitRef,
+    currentBranch: string
+  ): Promise<boolean> {
+    if (ref.name === currentBranch) {
+      await this.showErrorMessage(
+        `Cannot delete ${ref.name} — it is the currently checked out branch. Switch to another branch first.`,
+        'OK'
+      );
+      return false;
+    }
+
+    const conflictWorktree = await findWorktreeForBranch(git, ref.name);
+    if (conflictWorktree) {
+      // Surface the existing worktree-conflict flow instead of a raw git
+      // error from `git branch -d/-D` on a branch checked out elsewhere.
+      await handleWorktreeBranchConflict(ref.fullName ?? ref.name, conflictWorktree.path);
+      return false;
+    }
+
+    let force = false;
+    let defaultBranch: string | undefined;
+    try {
+      defaultBranch = await git.getDefaultBranch();
+      const merged = await git.getMergedBranches(defaultBranch);
+      force = !merged.includes(ref.name);
+    } catch (e) {
+      captureException(e);
+      // Could not determine merge status — err on the side of asking for confirmation.
+      force = true;
+    }
+
+    if (force) {
+      const targetLabel = defaultBranch ?? 'the default branch';
+      const confirmed = await vscode.window.showWarningMessage(
+        `Branch ${ref.name} is not merged into ${targetLabel}. Delete anyway?`,
+        { modal: true },
+        'Delete'
+      );
+      if (confirmed !== 'Delete') {
+        // Escape/Cancel — silent no-op.
+        return false;
+      }
+    }
+
+    try {
+      await git.deleteBranch(ref.name, force);
+      await this.showInformationMessage(`Deleted branch ${ref.name}.`);
+      return true;
+    } catch (e) {
+      captureException(e);
+      const msg = e instanceof Error ? e.message : String(e);
+      await this.showErrorMessage(`Failed to delete branch ${ref.name}: ${msg}`, 'OK');
+      return false;
+    }
   }
 
   async getTargetBranch(

--- a/src/test/e2e/checkoutInlineActions.test.ts
+++ b/src/test/e2e/checkoutInlineActions.test.ts
@@ -1,0 +1,221 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { CheckoutToCommand } from '../../commands/checkoutToCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+
+import {
+  createTagTestRepo,
+  createTestRepo,
+  createWorktreeTestRepo,
+  TagTestRepo,
+  TestRepo,
+  WorktreeTestRepo,
+} from './helpers/gitTestRepo';
+import { mockLogService } from './helpers/mockLogService';
+
+function makeRef(name: string, overrides: Partial<IGitRef> = {}): IGitRef {
+  return { name, fullName: name, authorName: '', isTag: false, ...overrides };
+}
+
+/** Exposes the protected inline-action methods for direct e2e testing against a real repo. */
+class TestableCheckoutToCommand extends CheckoutToCommand {
+  infoMessages: string[] = [];
+  errorMessages: string[] = [];
+
+  constructor() {
+    super({} as ConfigurationManager, mockLogService, {} as AutoStashService);
+  }
+
+  protected async showInformationMessage(message: string): Promise<string | undefined> {
+    this.infoMessages.push(message);
+    return undefined;
+  }
+
+  protected async showErrorMessage(message: string): Promise<string | undefined> {
+    this.errorMessages.push(message);
+    return undefined;
+  }
+
+  callDelete(git: GitExecutor, ref: IGitRef, currentBranch: string) {
+    return this.handleItemButtonAction(git, 'repo', currentBranch, [ref], ref, 'delete');
+  }
+
+  callRename(git: GitExecutor, ref: IGitRef, currentBranch: string) {
+    return this.handleItemButtonAction(git, 'repo', currentBranch, [ref], ref, 'rename');
+  }
+
+  callPush(git: GitExecutor, ref: IGitRef, currentBranch: string) {
+    return this.handleItemButtonAction(git, 'repo', currentBranch, [ref], ref, 'push');
+  }
+}
+
+function stubDialog<T extends 'showWarningMessage' | 'showInputBox'>(
+  method: T,
+  value: unknown
+): () => void {
+  const original = vscode.window[method];
+  (vscode.window as any)[method] = async () => value;
+  return () => {
+    (vscode.window as any)[method] = original;
+  };
+}
+
+function branchExists(repo: TestRepo, branch: string): boolean {
+  const out = repo.exec(`git branch --list ${branch}`);
+  return out.trim().length > 0;
+}
+
+describe('CheckoutToCommand inline branch actions (e2e, real git repo)', () => {
+  describe('delete decision matrix', () => {
+    let repo: TestRepo;
+    beforeEach(() => {
+      repo = createTestRepo();
+    });
+    afterEach(() => repo.cleanup());
+
+    it('deletes a merged branch immediately, without any confirmation prompt', async () => {
+      repo.exec(`git checkout ${repo.mainBranch}`);
+      repo.exec('git checkout -b done');
+      repo.exec(`git checkout ${repo.mainBranch}`);
+      repo.exec('git merge --no-ff done -m "merge done"');
+
+      const command = new TestableCheckoutToCommand();
+      const restoreWarning = stubDialog('showWarningMessage', (() => {
+        throw new Error('should not prompt for a merged branch');
+      }) as unknown as string);
+
+      try {
+        const mutated = await command.callDelete(repo.git, makeRef('done'), repo.mainBranch);
+        assert.strictEqual(mutated, true);
+      } finally {
+        restoreWarning();
+      }
+
+      assert.strictEqual(branchExists(repo, 'done'), false, 'merged branch should be gone');
+      assert.ok(command.infoMessages.some((m) => m.includes('done')), 'a "Deleted branch" toast should be shown');
+    });
+
+    it('prompts before deleting an unmerged branch, and deletes on confirm', async () => {
+      // `feature` (from createTestRepo) has a commit not on main — unmerged.
+      const restoreWarning = stubDialog('showWarningMessage', 'Delete');
+      const command = new TestableCheckoutToCommand();
+
+      try {
+        const mutated = await command.callDelete(repo.git, makeRef(repo.featureBranch), repo.mainBranch);
+        assert.strictEqual(mutated, true);
+      } finally {
+        restoreWarning();
+      }
+
+      assert.strictEqual(branchExists(repo, repo.featureBranch), false, 'unmerged branch should be force-deleted');
+    });
+
+    it('leaves an unmerged branch untouched and shows no error toast when the confirmation is dismissed (Escape)', async () => {
+      const restoreWarning = stubDialog('showWarningMessage', undefined);
+      const command = new TestableCheckoutToCommand();
+
+      try {
+        const mutated = await command.callDelete(repo.git, makeRef(repo.featureBranch), repo.mainBranch);
+        assert.strictEqual(mutated, false);
+      } finally {
+        restoreWarning();
+      }
+
+      assert.strictEqual(branchExists(repo, repo.featureBranch), true, 'branch should still exist');
+      assert.deepStrictEqual(command.errorMessages, [], 'dismissing a confirmation must not show an error toast');
+    });
+
+    it('blocks deleting the currently checked out branch with an explanatory message, no git call', async () => {
+      const command = new TestableCheckoutToCommand();
+
+      const mutated = await command.callDelete(repo.git, makeRef(repo.mainBranch), repo.mainBranch);
+
+      assert.strictEqual(mutated, false);
+      assert.strictEqual(branchExists(repo, repo.mainBranch), true);
+      assert.strictEqual(command.errorMessages.length, 1);
+      assert.ok(command.errorMessages[0].includes(repo.mainBranch));
+    });
+  });
+
+  describe('worktree conflict on delete', () => {
+    let repo: WorktreeTestRepo;
+    beforeEach(() => {
+      repo = createWorktreeTestRepo();
+    });
+    afterEach(() => repo.cleanup());
+
+    it('surfaces the worktree-conflict flow instead of a raw git error, and does not delete the branch', async () => {
+      const restoreInfo = stubDialog('showWarningMessage', 'Delete');
+      // handleWorktreeBranchConflict uses showInformationMessage (not showWarningMessage);
+      // stub it to simulate the user dismissing that dialog (Escape).
+      const originalShowInformationMessage = vscode.window.showInformationMessage;
+      (vscode.window as any).showInformationMessage = async () => undefined;
+
+      const command = new TestableCheckoutToCommand();
+
+      try {
+        const mutated = await command.callDelete(repo.git, makeRef(repo.worktreeBranch), repo.mainBranch);
+        assert.strictEqual(mutated, false);
+      } finally {
+        restoreInfo();
+        (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+      }
+
+      assert.strictEqual(
+        branchExists(repo, repo.worktreeBranch),
+        true,
+        'branch checked out in another worktree must not be deleted'
+      );
+    });
+  });
+
+  describe('rename', () => {
+    let repo: TestRepo;
+    beforeEach(() => {
+      repo = createTestRepo();
+    });
+    afterEach(() => repo.cleanup());
+
+    it('renames the branch and the new name shows up in `git branch`', async () => {
+      const originalShowInputBox = vscode.window.showInputBox;
+      (vscode.window as any).showInputBox = async () => 'feature-renamed';
+
+      const command = new TestableCheckoutToCommand();
+      try {
+        const mutated = await command.callRename(repo.git, makeRef(repo.featureBranch), repo.mainBranch);
+        assert.strictEqual(mutated, true);
+      } finally {
+        (vscode.window as any).showInputBox = originalShowInputBox;
+      }
+
+      assert.strictEqual(branchExists(repo, repo.featureBranch), false);
+      assert.strictEqual(branchExists(repo, 'feature-renamed'), true);
+    });
+  });
+
+  describe('publish', () => {
+    let repo: TagTestRepo;
+    beforeEach(() => {
+      repo = createTagTestRepo();
+    });
+    afterEach(() => repo.cleanup());
+
+    it('pushes and sets upstream for a local-only branch', async () => {
+      repo.exec('git checkout -b publish-me');
+
+      const command = new TestableCheckoutToCommand();
+      const mutated = await command.callPush(repo.git, makeRef('publish-me'), 'publish-me');
+      assert.strictEqual(mutated, true);
+
+      const remoteBranches = repo.exec(`git ls-remote --heads "${repo.remoteRepoPath}" publish-me`);
+      assert.ok(remoteBranches.includes('publish-me'), 'branch should have been pushed to the remote');
+
+      const upstream = repo.exec('git for-each-ref --format="%(upstream:short)" refs/heads/publish-me').trim();
+      assert.strictEqual(upstream, 'origin/publish-me');
+    });
+  });
+});

--- a/src/test/unit/checkoutToInlineActions.test.ts
+++ b/src/test/unit/checkoutToInlineActions.test.ts
@@ -1,0 +1,354 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { buildRefActionButtons } from '../../commands/checkoutToCommand/branchActionButtons';
+import { CheckoutToCommand } from '../../commands/checkoutToCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const localRef: IGitRef = { name: 'feature-a', fullName: 'feature-a', authorName: '', isTag: false };
+const currentRef: IGitRef = { name: 'main', fullName: 'main', authorName: '', isTag: false };
+const remoteRef: IGitRef = {
+  name: 'feature-a',
+  fullName: 'origin/feature-a',
+  authorName: '',
+  isTag: false,
+  remote: 'origin',
+};
+const tagRef: IGitRef = { name: 'v1.0.0', fullName: 'v1.0.0', authorName: '', isTag: true };
+const upToDateLocalRef: IGitRef = {
+  name: 'feature-b',
+  fullName: 'feature-b',
+  authorName: '',
+  isTag: false,
+  upstreamTrack: '[ahead 0]',
+  parsedUpstreamTrack: [0, 0],
+};
+
+/** Exposes the protected action methods for direct unit testing. */
+class TestableCheckoutToCommand extends CheckoutToCommand {
+  infoMessages: string[] = [];
+
+  constructor() {
+    super({} as ConfigurationManager, mockLogService, {} as AutoStashService);
+  }
+
+  // Avoid popping a real (blocking) notification during tests — just record it.
+  protected async showInformationMessage(message: string): Promise<string | undefined> {
+    this.infoMessages.push(message);
+    return undefined;
+  }
+
+  callHandleItemButtonAction(
+    git: GitExecutor,
+    repoId: string,
+    currentBranch: string,
+    branchList: IGitRef[],
+    ref: IGitRef,
+    action: 'star' | 'delete' | 'rename' | 'push'
+  ) {
+    return this.handleItemButtonAction(git, repoId, currentBranch, branchList, ref, action);
+  }
+
+  callRefreshBranchList(git: GitExecutor) {
+    return this.refreshBranchList(git);
+  }
+}
+
+function withStubbedDialog<T extends keyof typeof vscode.window>(
+  method: T,
+  stub: (typeof vscode.window)[T],
+  fn: () => Promise<void>
+): Promise<void> {
+  const original = vscode.window[method];
+  (vscode.window as any)[method] = stub;
+  return fn().finally(() => {
+    (vscode.window as any)[method] = original;
+  });
+}
+
+describe('CheckoutToCommand inline actions — button assembly', () => {
+  it('shows star + delete for a tag', () => {
+    const buttons = buildRefActionButtons(tagRef, false);
+    assert.deepStrictEqual(
+      buttons.map((b) => b.action),
+      ['star', 'delete']
+    );
+  });
+
+  it('shows star + delete for a remote branch', () => {
+    const buttons = buildRefActionButtons(remoteRef, false);
+    assert.deepStrictEqual(
+      buttons.map((b) => b.action),
+      ['star', 'delete']
+    );
+  });
+
+  it('shows star + delete + rename + push for a local branch with no upstream', () => {
+    const buttons = buildRefActionButtons(localRef, false);
+    assert.deepStrictEqual(
+      buttons.map((b) => b.action),
+      ['star', 'delete', 'rename', 'push']
+    );
+  });
+
+  it('hides push for a local branch that is up to date with its upstream', () => {
+    const buttons = buildRefActionButtons(upToDateLocalRef, false);
+    assert.deepStrictEqual(
+      buttons.map((b) => b.action),
+      ['star', 'delete', 'rename']
+    );
+  });
+
+  it('still shows delete/rename/push for the current branch (delete is blocked at action time)', () => {
+    const buttons = buildRefActionButtons(currentRef, false);
+    assert.deepStrictEqual(
+      buttons.map((b) => b.action),
+      ['star', 'delete', 'rename', 'push']
+    );
+  });
+});
+
+describe('CheckoutToCommand inline actions — delete decision matrix', () => {
+  it('deletes a merged branch immediately with -d and no confirmation prompt', async () => {
+    const calls: string[][] = [];
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getDefaultBranch: async () => 'main',
+      getMergedBranches: async () => ['main', 'feature-a'],
+      deleteBranch: async (name: string, force: boolean) => {
+        calls.push(['deleteBranch', name, String(force)]);
+      },
+      worktreeListDetailed: async () => [],
+      repositoryPath: '/repo',
+    } as unknown as GitExecutor;
+
+    await withStubbedDialog('showWarningMessage', (async () => {
+      throw new Error('should not prompt for a merged branch');
+    }) as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'delete');
+      assert.strictEqual(mutated, true);
+    });
+
+    assert.deepStrictEqual(calls, [['deleteBranch', 'feature-a', 'false']]);
+  });
+
+  it('deletes an unmerged branch with -D after confirmation', async () => {
+    const calls: string[][] = [];
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getDefaultBranch: async () => 'main',
+      getMergedBranches: async () => ['main'],
+      deleteBranch: async (name: string, force: boolean) => {
+        calls.push(['deleteBranch', name, String(force)]);
+      },
+      worktreeListDetailed: async () => [],
+      repositoryPath: '/repo',
+    } as unknown as GitExecutor;
+
+    await withStubbedDialog('showWarningMessage', (async () => 'Delete') as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'delete');
+      assert.strictEqual(mutated, true);
+    });
+
+    assert.deepStrictEqual(calls, [['deleteBranch', 'feature-a', 'true']]);
+  });
+
+  it('does not call git when the unmerged-delete confirmation is dismissed', async () => {
+    const calls: string[][] = [];
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getDefaultBranch: async () => 'main',
+      getMergedBranches: async () => ['main'],
+      deleteBranch: async (name: string, force: boolean) => {
+        calls.push(['deleteBranch', name, String(force)]);
+      },
+      worktreeListDetailed: async () => [],
+      repositoryPath: '/repo',
+    } as unknown as GitExecutor;
+
+    await withStubbedDialog('showWarningMessage', (async () => undefined) as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'delete');
+      assert.strictEqual(mutated, false);
+    });
+
+    assert.deepStrictEqual(calls, []);
+  });
+
+  it('blocks deleting the currently checked out branch without calling git', async () => {
+    const calls: string[][] = [];
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getDefaultBranch: async () => 'main',
+      getMergedBranches: async () => ['main'],
+      deleteBranch: async (name: string, force: boolean) => {
+        calls.push(['deleteBranch', name, String(force)]);
+      },
+      worktreeListDetailed: async () => [],
+      repositoryPath: '/repo',
+    } as unknown as GitExecutor;
+
+    let errorShown = false;
+    await withStubbedDialog('showErrorMessage', (async () => {
+      errorShown = true;
+      return undefined;
+    }) as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [currentRef], currentRef, 'delete');
+      assert.strictEqual(mutated, false);
+    });
+
+    assert.deepStrictEqual(calls, []);
+    assert.strictEqual(errorShown, true, 'an explanatory message should be shown');
+  });
+
+  it('surfaces the worktree-conflict flow instead of a raw git error when the branch is checked out elsewhere', async () => {
+    const deleteCalls: string[] = [];
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getDefaultBranch: async () => 'main',
+      getMergedBranches: async () => ['main'],
+      deleteBranch: async (name: string) => {
+        deleteCalls.push(name);
+      },
+      worktreeListDetailed: async () => [
+        { path: '/other/worktree', branch: 'refs/heads/feature-a', bare: false, prunable: false },
+      ],
+      repositoryPath: '/repo',
+    } as unknown as GitExecutor;
+
+    let infoMessageShown: string | undefined;
+    await withStubbedDialog('showInformationMessage', (async (message: string) => {
+      infoMessageShown = message;
+      return undefined;
+    }) as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'delete');
+      assert.strictEqual(mutated, false);
+    });
+
+    assert.deepStrictEqual(deleteCalls, [], 'git should never be asked to delete a branch checked out elsewhere');
+    assert.ok(infoMessageShown?.includes('/other/worktree'), 'worktree-conflict dialog should be shown');
+  });
+});
+
+describe('CheckoutToCommand inline actions — rename validation', () => {
+  it('rejects an invalid new branch name with the shared validator message and does not call git', async () => {
+    const command = new TestableCheckoutToCommand();
+    let renameCalled = false;
+    const git = {
+      renameBranch: async () => {
+        renameCalled = true;
+      },
+    } as unknown as GitExecutor;
+
+    const originalShowInputBox = vscode.window.showInputBox;
+    (vscode.window as any).showInputBox = async (options: vscode.InputBoxOptions) => {
+      const err = options.validateInput?.('invalid name with spaces');
+      assert.ok(err, 'validateInput should reject a name containing whitespace');
+      return undefined;
+    };
+
+    try {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'rename');
+      assert.strictEqual(mutated, false);
+    } finally {
+      (vscode.window as any).showInputBox = originalShowInputBox;
+    }
+
+    assert.strictEqual(renameCalled, false);
+  });
+
+  it('renames the branch when a valid new name is provided', async () => {
+    const command = new TestableCheckoutToCommand();
+    const renameCalls: string[][] = [];
+    const git = {
+      renameBranch: async (oldName: string, newName: string) => {
+        renameCalls.push([oldName, newName]);
+      },
+    } as unknown as GitExecutor;
+
+    const originalShowInputBox = vscode.window.showInputBox;
+    (vscode.window as any).showInputBox = async () => 'feature-a-renamed';
+
+    try {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [localRef], localRef, 'rename');
+      assert.strictEqual(mutated, true);
+    } finally {
+      (vscode.window as any).showInputBox = originalShowInputBox;
+    }
+
+    assert.deepStrictEqual(renameCalls, [['feature-a', 'feature-a-renamed']]);
+  });
+});
+
+describe('CheckoutToCommand inline actions — remote branch delete confirmation', () => {
+  it('names the remote in the confirmation prompt and deletes on confirm', async () => {
+    const command = new TestableCheckoutToCommand();
+    const deleteCalls: string[][] = [];
+    const git = {
+      deleteRemoteBranch: async (remote: string, name: string) => {
+        deleteCalls.push([remote, name]);
+      },
+    } as unknown as GitExecutor;
+
+    let promptMessage: string | undefined;
+    await withStubbedDialog('showWarningMessage', (async (message: string) => {
+      promptMessage = message;
+      return 'Delete';
+    }) as any, async () => {
+      const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [remoteRef], remoteRef, 'delete');
+      assert.strictEqual(mutated, true);
+    });
+
+    assert.ok(promptMessage?.includes('origin'), 'confirmation should name the remote');
+    assert.ok(promptMessage?.includes('feature-a'), 'confirmation should name the branch');
+    assert.deepStrictEqual(deleteCalls, [['origin', 'feature-a']]);
+  });
+
+  it('is a silent no-op when the remote delete confirmation is dismissed', async () => {
+    const command = new TestableCheckoutToCommand();
+    const deleteCalls: string[][] = [];
+    const git = {
+      deleteRemoteBranch: async (remote: string, name: string) => {
+        deleteCalls.push([remote, name]);
+      },
+    } as unknown as GitExecutor;
+
+    let errorShown = false;
+    await Promise.all([]);
+    const originalShowErrorMessage = vscode.window.showErrorMessage;
+    (vscode.window as any).showErrorMessage = async () => {
+      errorShown = true;
+      return undefined;
+    };
+
+    try {
+      await withStubbedDialog('showWarningMessage', (async () => undefined) as any, async () => {
+        const mutated = await command.callHandleItemButtonAction(git, 'repo', 'main', [remoteRef], remoteRef, 'delete');
+        assert.strictEqual(mutated, false);
+      });
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    }
+
+    assert.deepStrictEqual(deleteCalls, []);
+    assert.strictEqual(errorShown, false, 'dismissal must not surface an error toast');
+  });
+});
+
+describe('CheckoutToCommand inline actions — picker refresh', () => {
+  it('re-fetches refs after a successful delete so the deleted branch is absent from the rebuilt list', async () => {
+    const command = new TestableCheckoutToCommand();
+    const git = {
+      getAllRefListExtended: async () => [currentRef],
+    } as unknown as GitExecutor;
+
+    const refreshed = await command.callRefreshBranchList(git);
+    assert.deepStrictEqual(
+      refreshed.map((r) => r.name),
+      ['main']
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Feature 3 (inline branch actions in the checkout picker, #149) already shipped, but a spec audit found several gaps against `NEW-FEATURES.md`:

- **Wrong default-branch source**: the "is this branch merged?" check used the `defaultTargetBranch` PR-clone setting (which is intentionally left empty by many users) instead of resolving the repo's real default branch via `GitExecutor.getDefaultBranch()` (origin/HEAD, with a `main`/`master` fallback). With an empty setting, `git branch --merged ''` would just fail.
- **No worktree-conflict handling on delete**: deleting a branch checked out in another worktree hit a raw git error instead of the existing `worktreeBranchConflict.ts` flow.
- **Silent failures, no success feedback**: the button handler had no `catch`, so a failed delete/rename/push disappeared with no toast at all; successful actions never showed a confirmation toast either (spec calls for e.g. "Deleted branch X").
- **Stale picker after actions**: the ref list was never re-fetched after a mutation, so a deleted or renamed branch stayed visible until the picker was closed and reopened.
- **Rename validation drift**: rename used an ad hoc regex instead of the shared `validateBranchName` used by branch creation elsewhere, and hid the rename/publish buttons for the current branch — only *delete* should be blocked for the current branch per spec.
- **Untestable**: button assembly and all the action logic lived inline in one large QuickPick closure, so none of the spec's listed unit-test scenarios (delete decision matrix, rename validation, remote-delete confirmation, picker refresh) could actually be tested.

### Changes
- `src/commands/checkoutToCommand/branchActionButtons.ts` (new): pure `buildRefActionButtons()` for per-ref-type button assembly.
- `src/commands/checkoutToCommand/index.ts`: extracts each action (delete/rename/push, per ref type) into dedicated, unit-testable `CheckoutToCommand` methods; fixes default-branch resolution, wires in worktree-conflict handling for delete, adds success/error toasts, re-fetches the ref list (and current branch) after a successful mutation, and switches rename validation to the shared `validateBranchName`.
- `src/test/unit/checkoutToInlineActions.test.ts` (new): button assembly per ref type, delete decision matrix (merged/unmerged-confirm/unmerged-cancel/current-branch-blocked/worktree-conflict), rename validation, remote-delete confirmation wording + dismissal.
- `src/test/e2e/checkoutInlineActions.test.ts` (new): same scenarios against real git fixture repos — merged/unmerged delete, worktree-conflict delete, rename, and publish (push -u).

### How to test manually
1. `yarn watch` + F5 to launch the extension host.
2. Open a repo with a merged branch and an unmerged branch. Run `GSC: Checkout to...`.
3. Click the trash icon on the merged branch — it should delete immediately with a "Deleted branch X" toast, no prompt.
4. Click the trash icon on the unmerged branch — confirm the modal names the branch and default branch; confirm deletes it, Escape leaves it untouched with no error toast.
5. Try deleting the current branch — it should show an explanatory error instead of touching git.
6. Check out a branch in a second worktree (`git worktree add ../wt <branch>`), then try deleting that branch from the picker in the main worktree — the existing worktree-conflict dialog (Open/Create Branch) should appear instead of a raw error.
7. Click the pencil icon to rename a branch — the input is pre-filled, invalid names are rejected inline, and the picker refreshes to show the new name.
8. Click the cloud-upload icon on a local-only branch — a progress notification shows `git push -u origin <branch>`.

## Test plan
- [x] `yarn compile` (type check + lint)
- [x] `yarn test:unit` — 470 passing
- [x] `yarn compile-tests` + targeted e2e run (`vscode-test --label e2e-ci`) — 175 passing, including 7 new inline-action e2e tests against real git fixtures
- [ ] Manual smoke test performed in VS Code extension host