### PR TITLE
fix(branches): close cleanup-command gaps vs spec

### DIFF
--- a/src/commands/cleanupBranchesCommand/candidates.ts
+++ b/src/commands/cleanupBranchesCommand/candidates.ts
@@ -1,0 +1,129 @@
+import { formatDistanceToNow } from 'date-fns';
+import * as vscode from 'vscode';
+import { IGitRef } from '../../common/git/types';
+
+export type TCleanupGroup = 'merged' | 'gone';
+
+export interface ICleanupCandidate {
+  ref: IGitRef;
+  /** `merged` deletes with `-d`; `gone` (unmerged, upstream deleted) deletes with `-D`. */
+  group: TCleanupGroup;
+}
+
+export interface ICleanupQuickPickItem extends vscode.QuickPickItem {
+  candidate: ICleanupCandidate;
+}
+
+export type TCleanupPickItem = ICleanupQuickPickItem | (vscode.QuickPickItem & { candidate?: undefined });
+
+export interface ICleanupDeletionResult {
+  name: string;
+  /** Tip SHA captured before deletion, used to build the recovery document. */
+  sha: string;
+  success: boolean;
+}
+
+/**
+ * Local branches merged into `base` OR whose upstream is `[gone]`, excluding the
+ * current branch, the default branch itself, and any branch checked out in a
+ * worktree. A branch that is both merged and gone is classified as `merged`
+ * (safe `-d` delete still applies).
+ */
+export function computeCleanupCandidates(
+  localRefs: IGitRef[],
+  mergedNames: Set<string>,
+  worktreeBranches: Set<string>,
+  current: string,
+  base: string
+): ICleanupCandidate[] {
+  return localRefs
+    .filter((ref) => ref.name !== current && ref.name !== base && !worktreeBranches.has(ref.name))
+    .filter((ref) => mergedNames.has(ref.name) || ref.upstreamTrack === '[gone]')
+    .map((ref) => ({ ref, group: mergedNames.has(ref.name) ? 'merged' as const : 'gone' as const }));
+}
+
+function describeCandidate(candidate: ICleanupCandidate): string {
+  const { ref, group } = candidate;
+  const relativeDate = ref.committerDate
+    ? formatDistanceToNow(Number(ref.committerDate) * 1000, { addSuffix: true })
+    : undefined;
+  const sha = ref.hash;
+  const parts = [relativeDate, sha].filter((part): part is string => !!part && part.length > 0);
+
+  if (group === 'gone') {
+    parts.push('not merged — force delete');
+  }
+
+  return parts.join(' • ');
+}
+
+/**
+ * Builds the multi-select QuickPick items, grouped by separators
+ * "Merged into <base>" and "Upstream deleted". Merged items are pre-checked;
+ * unmerged-gone items are unchecked by default since they require a force delete.
+ */
+export function buildCleanupQuickPickItems(
+  candidates: ICleanupCandidate[],
+  base: string
+): TCleanupPickItem[] {
+  const merged = candidates.filter((candidate) => candidate.group === 'merged');
+  const gone = candidates.filter((candidate) => candidate.group === 'gone');
+  const items: TCleanupPickItem[] = [];
+
+  if (merged.length > 0) {
+    items.push({ label: `Merged into ${base}`, kind: vscode.QuickPickItemKind.Separator });
+    items.push(...merged.map((candidate) => ({
+      label: candidate.ref.name,
+      description: describeCandidate(candidate),
+      picked: true,
+      candidate,
+    })));
+  }
+
+  if (gone.length > 0) {
+    items.push({ label: 'Upstream deleted', kind: vscode.QuickPickItemKind.Separator });
+    items.push(...gone.map((candidate) => ({
+      label: candidate.ref.name,
+      description: describeCandidate(candidate),
+      picked: false,
+      candidate,
+    })));
+  }
+
+  return items;
+}
+
+/** Narrows selected QuickPick items down to the actual deletion candidates. */
+export function toSelectedCandidates(selected: readonly TCleanupPickItem[] | undefined): ICleanupCandidate[] {
+  return (selected ?? [])
+    .filter((item): item is ICleanupQuickPickItem => item.candidate !== undefined)
+    .map((item) => item.candidate);
+}
+
+/**
+ * Builds a "Undo hint" recovery document: one `git branch <name> <sha>` line
+ * per successfully deleted branch, using the tip SHA captured before deletion.
+ */
+export function buildRecoveryDocument(deletions: ICleanupDeletionResult[]): string {
+  const successful = deletions.filter((deletion) => deletion.success);
+  const lines = [
+    '# Branch cleanup recovery',
+    '',
+    'Run any of the commands below to restore a deleted branch at its previous tip.',
+    'This works for as long as the commit stays reachable via the reflog (~30 days by default).',
+    '',
+    ...successful.map((deletion) => `git branch ${deletion.name} ${deletion.sha}`),
+    '',
+  ];
+
+  return lines.join('\n');
+}
+
+export function summarizeDeletions(deletions: ICleanupDeletionResult[]): string {
+  const deletedCount = deletions.filter((deletion) => deletion.success).length;
+  const failedCount = deletions.length - deletedCount;
+
+  return failedCount > 0
+    ? `Deleted ${deletedCount} branches, ${failedCount} failed`
+    : `Deleted ${deletedCount} branches`;
+}

--- a/src/commands/cleanupBranchesCommand/index.ts
+++ b/src/commands/cleanupBranchesCommand/index.ts
@@ -2,30 +2,86 @@ import * as vscode from 'vscode';
 import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
 import { LoggingService } from '../../logging/loggingService';
 import { BaseCommand } from '../command';
+import {
+  buildCleanupQuickPickItems,
+  buildRecoveryDocument,
+  computeCleanupCandidates,
+  ICleanupDeletionResult,
+  summarizeDeletions,
+  toSelectedCandidates,
+} from './candidates';
+
+const UNDO_HINT_ACTION = 'Undo hint';
 
 export class CleanupBranchesCommand extends BaseCommand {
-  constructor(logService: LoggingService, private readonly provider?: VscodeGitProvider) { super(logService); }
+  constructor(logService: LoggingService, private readonly provider?: VscodeGitProvider) {
+    super(logService);
+  }
 
   async execute(): Promise<void> {
     const git = await this.getGitExecutor(this.provider, 'Delete merged branches');
     const current = await git.getCurrentBranch();
-    const base = await git.getDefaultBranch();
-    const merged = new Set(await git.getMergedBranches(base));
-    const worktreeBranches = new Set((await git.worktreeListDetailed(true)).map((item) => item.branch?.replace(/^refs\/heads\//, '')));
-    const refs = (await git.getAllRefListExtended()).filter((ref) => !ref.remote && !ref.isTag);
-    const candidates = refs.filter((ref) => ref.name !== current && ref.name !== base && !worktreeBranches.has(ref.name) && merged.has(ref.name));
+
+    let base: string;
+    try {
+      base = await git.getDefaultBranch();
+    } catch (error) {
+      await vscode.window.showErrorMessage(
+        `Could not determine the default branch: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    const mergedNames = new Set(await git.getMergedBranches(base));
+    const worktreeBranches = new Set(
+      (await git.worktreeListDetailed(true))
+        .map((worktree) => worktree.branch?.replace(/^refs\/heads\//, ''))
+        .filter((name): name is string => !!name)
+    );
+    const localRefs = (await git.getAllRefListExtended()).filter((ref) => !ref.remote && !ref.isTag);
+    const candidates = computeCleanupCandidates(localRefs, mergedNames, worktreeBranches, current, base);
+
     if (candidates.length === 0) {
       await vscode.window.showInformationMessage('No merged or orphaned branches to clean up.', 'OK');
       return;
     }
-    const selected = await vscode.window.showQuickPick(candidates.map((ref) => ({ label: ref.name, picked: true, ref })), { canPickMany: true, title: `Delete merged branches (base: ${base})` });
-    if (!selected?.length) return;
-    const confirmed = await vscode.window.showWarningMessage(`Delete ${selected.length} branches? They can be recovered from the reflog for ~30 days.`, { modal: true }, 'Delete');
+
+    const items = buildCleanupQuickPickItems(candidates, base);
+    const selected = await vscode.window.showQuickPick(items, {
+      canPickMany: true,
+      title: `Delete merged branches (base: ${base})`,
+    });
+    const selectedCandidates = toSelectedCandidates(selected);
+    if (selectedCandidates.length === 0) return;
+
+    const confirmed = await vscode.window.showWarningMessage(
+      `Delete ${selectedCandidates.length} branches? They can be recovered from the reflog for ~30 days.`,
+      { modal: true },
+      'Delete'
+    );
     if (confirmed !== 'Delete') return;
-    let deleted = 0;
-    for (const item of selected) {
-      try { await git.deleteBranch(item.ref.name, false); deleted += 1; } catch (error) { this.logService.warn(`Failed to delete ${item.ref.name}: ${error}`); }
+
+    const results: ICleanupDeletionResult[] = [];
+    for (const candidate of selectedCandidates) {
+      const { ref, group } = candidate;
+      try {
+        // Tip SHA is captured up-front (before any deletion) via getAllRefListExtended.
+        await git.deleteBranch(ref.name, group === 'gone');
+        results.push({ name: ref.name, sha: ref.hash ?? '', success: true });
+      } catch (error) {
+        this.logService.warn(`Failed to delete ${ref.name}: ${error}`);
+        results.push({ name: ref.name, sha: ref.hash ?? '', success: false });
+      }
     }
-    await vscode.window.showInformationMessage(`Deleted ${deleted} branches`, 'OK');
+
+    const summary = summarizeDeletions(results);
+    const action = await vscode.window.showInformationMessage(summary, UNDO_HINT_ACTION);
+    if (action === UNDO_HINT_ACTION) {
+      const document = await vscode.workspace.openTextDocument({
+        content: buildRecoveryDocument(results),
+        language: 'shellscript',
+      });
+      await vscode.window.showTextDocument(document);
+    }
   }
 }

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -90,6 +90,8 @@ export function buildQuickActionItems(
     },
     { label: '$(git-branch) Create branch from template…', commandId: command('createBranchFromTemplate') },
     { label: '$(tag) Create tag from template…', commandId: command('createTagFromTemplate') },
+    { label: 'Branches', kind: QuickPickItemKind.Separator },
+    { label: '$(trash) Delete merged branches…', commandId: command('cleanupBranches') },
     { label: 'Update branch', kind: QuickPickItemKind.Separator },
     { label: '$(repo-pull) Pull (With Stash)', commandId: command('pullWithStash') },
     { label: '$(repo-pull) Pull (Rebase With Stash)', commandId: command('pullRebaseWithStash') },

--- a/src/test/e2e/cleanupBranches.test.ts
+++ b/src/test/e2e/cleanupBranches.test.ts
@@ -1,0 +1,211 @@
+import * as assert from 'assert';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import {
+  commandId,
+  delay,
+  ensureExtensionActivated,
+  stubErrorMessages,
+  stubInformationMessages,
+  stubShowQuickPickMany,
+  stubWarningMessages,
+  withRepoWorkspace,
+} from './helpers/commandHarness';
+import { createTestRepo, TestRepo } from './helpers/gitTestRepo';
+
+type CleanupQuickPickLikeItem = vscode.QuickPickItem & {
+  candidate?: { ref: { name: string; hash?: string }; group: 'merged' | 'gone' };
+  picked?: boolean;
+};
+
+function execIn(cwd: string, command: string): string {
+  return execSync(command, { cwd, encoding: 'utf-8' });
+}
+
+function branchExists(repo: TestRepo, branch: string): boolean {
+  return execIn(repo.repoPath, `git branch --list ${branch}`).trim().length > 0;
+}
+
+function addWorktree(repo: TestRepo, branch: string, createFrom: string): string {
+  const worktreePath = path.join(path.dirname(repo.repoPath), `${path.basename(repo.repoPath)}-${branch}`);
+  execIn(repo.repoPath, `git worktree add "${worktreePath}" -b ${branch} ${createFrom}`);
+  return worktreePath;
+}
+
+function cleanupWorktree(repo: TestRepo, worktreePath: string): void {
+  try {
+    execIn(repo.repoPath, `git worktree remove "${worktreePath}" --force`);
+  } catch {
+    // The worktree may already be gone.
+  }
+  fs.rmSync(worktreePath, { recursive: true, force: true });
+}
+
+/**
+ * Builds: `merged-1`/`merged-2` (merged into main, no upstream), `orphan`
+ * (ahead of main so NOT merged, upstream deleted + pruned so `[gone]`),
+ * `feature` (from {@link createTestRepo}, ahead of main, no upstream — an
+ * "active" branch that must survive), and a worktree checked out on a branch
+ * that would otherwise qualify as merged.
+ */
+function setupCleanupFixtures(repo: TestRepo): { worktreePath: string; remoteRepoPath: string } {
+  execIn(repo.repoPath, 'git branch merged-1');
+  execIn(repo.repoPath, 'git branch merged-2');
+
+  const remoteRepoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-cleanup-remote-'));
+  execSync('git init -q --bare -b main', { cwd: remoteRepoPath });
+  execIn(repo.repoPath, `git remote add origin "${remoteRepoPath}"`);
+  execIn(repo.repoPath, 'git push -q -u origin main');
+
+  execIn(repo.repoPath, 'git checkout -q -b orphan');
+  fs.writeFileSync(path.join(repo.repoPath, 'orphan.txt'), 'orphan content\n');
+  execIn(repo.repoPath, 'git add orphan.txt');
+  execIn(repo.repoPath, 'git commit -q -m "feat: orphan work"');
+  execIn(repo.repoPath, 'git push -q -u origin orphan');
+  execIn(repo.repoPath, 'git checkout -q main');
+  execIn(repo.repoPath, 'git push -q origin --delete orphan');
+  execIn(repo.repoPath, 'git fetch -q --prune');
+
+  const worktreePath = addWorktree(repo, 'checked-out-elsewhere', 'main');
+
+  return { worktreePath, remoteRepoPath };
+}
+
+function cleanupFixtures(repo: TestRepo, fixtures: { worktreePath: string; remoteRepoPath: string }): void {
+  cleanupWorktree(repo, fixtures.worktreePath);
+  fs.rmSync(fixtures.remoteRepoPath, { recursive: true, force: true });
+}
+
+describe('Cleanup branches command', () => {
+  before(async () => {
+    await ensureExtensionActivated();
+  });
+
+  it('computes merged ∪ gone-upstream candidates, grouped and pre-checked, excluding current/default/active/worktree branches', async () => {
+    const repo = createTestRepo();
+    const fixtures = setupCleanupFixtures(repo);
+    let items: CleanupQuickPickLikeItem[] = [];
+    const restoreQuickPick = stubShowQuickPickMany((rawItems, options) => {
+      assert.strictEqual(options?.canPickMany, true);
+      assert.ok(options?.title?.includes('base: main'));
+      items = rawItems as CleanupQuickPickLikeItem[];
+      return undefined; // dismiss: nothing should be deleted
+    });
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('cleanupBranches'));
+
+        const separators = items
+          .filter((item) => item.kind === vscode.QuickPickItemKind.Separator)
+          .map((item) => item.label);
+        assert.deepStrictEqual(separators, ['Merged into main', 'Upstream deleted']);
+
+        const candidateLabels = items.filter((item) => item.candidate).map((item) => item.label);
+        assert.deepStrictEqual(candidateLabels.sort(), ['merged-1', 'merged-2', 'orphan'].sort());
+        assert.ok(!candidateLabels.includes('feature'), 'unmerged active branch must not be a candidate');
+        assert.ok(!candidateLabels.includes('main'), 'default branch must be excluded');
+        assert.ok(
+          !candidateLabels.includes('checked-out-elsewhere'),
+          'a branch checked out in a worktree must never appear, even though otherwise merged'
+        );
+
+        const merged1 = items.find((item) => item.label === 'merged-1');
+        const orphan = items.find((item) => item.label === 'orphan');
+        assert.strictEqual(merged1?.picked, true, 'merged branches are pre-checked');
+        assert.strictEqual(orphan?.picked, false, 'unmerged-gone branches are unchecked by default');
+        assert.ok(orphan?.description?.includes('not merged'));
+
+        assert.ok(branchExists(repo, 'merged-1'), 'dismissing the picker must not delete anything');
+        assert.deepStrictEqual(errors.messages, []);
+      });
+    } finally {
+      errors.restore();
+      restoreQuickPick();
+      cleanupFixtures(repo, fixtures);
+      repo.cleanup();
+    }
+  });
+
+  it('deletes checked candidates, keeps the unchecked one, reports a partial failure, and offers an undo-hint recovery document', async () => {
+    const repo = createTestRepo();
+    const fixtures = setupCleanupFixtures(repo);
+    const restoreQuickPick = stubShowQuickPickMany((rawItems) => {
+      const cleanupItems = (rawItems as CleanupQuickPickLikeItem[]).filter((item) => item.candidate);
+      // Simulate a concurrent external deletion of merged-2 right before the batch runs.
+      execIn(repo.repoPath, 'git branch -D merged-2');
+      // "Accept" merged-1 and merged-2 (still shows as selected from the earlier state);
+      // leave `orphan` unchecked, matching its default unchecked state.
+      return cleanupItems.filter((item) => item.label === 'merged-1' || item.label === 'merged-2');
+    });
+    const warnings = stubWarningMessages((message, actionItems) => {
+      assert.ok(message.includes('reflog for ~30 days'));
+      return actionItems.includes('Delete') ? 'Delete' : undefined;
+    });
+    const info = stubInformationMessages((message) =>
+      message.startsWith('Deleted') ? 'Undo hint' : undefined
+    );
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('cleanupBranches'));
+
+        assert.ok(!branchExists(repo, 'merged-1'), 'merged-1 should be deleted');
+        assert.ok(branchExists(repo, 'orphan'), 'unchecked orphan branch must survive');
+        assert.ok(
+          info.messages.includes('Deleted 1 branches, 1 failed'),
+          `expected a partial-failure summary, got: ${JSON.stringify(info.messages)}`
+        );
+        assert.deepStrictEqual(errors.messages, [], 'a per-branch delete failure must not surface as a command error');
+
+        await delay();
+        const document = vscode.window.activeTextEditor?.document;
+        assert.ok(document, 'the "Undo hint" action should open a recovery document');
+        const text = document!.getText();
+        assert.ok(text.includes('git branch merged-1 '), 'recovery doc should list the successfully deleted branch');
+        assert.ok(!text.includes('merged-2'), 'the failed deletion must not appear in the recovery doc');
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      warnings.restore();
+      restoreQuickPick();
+      cleanupFixtures(repo, fixtures);
+      repo.cleanup();
+    }
+  });
+
+  it('shows an info toast and never opens a picker when there is nothing to clean up', async () => {
+    const repo = createTestRepo();
+    execIn(repo.repoPath, 'git branch -D feature');
+    let quickPickShown = false;
+    const restoreQuickPick = stubShowQuickPickMany(() => {
+      quickPickShown = true;
+      return undefined;
+    });
+    const info = stubInformationMessages(() => undefined);
+    const errors = stubErrorMessages();
+
+    try {
+      await withRepoWorkspace(repo, async () => {
+        await vscode.commands.executeCommand(commandId('cleanupBranches'));
+
+        assert.strictEqual(quickPickShown, false);
+        assert.deepStrictEqual(info.messages, ['No merged or orphaned branches to clean up.']);
+        assert.deepStrictEqual(errors.messages, []);
+      });
+    } finally {
+      errors.restore();
+      info.restore();
+      restoreQuickPick();
+      repo.cleanup();
+    }
+  });
+});

--- a/src/test/e2e/helpers/commandHarness.ts
+++ b/src/test/e2e/helpers/commandHarness.ts
@@ -220,6 +220,25 @@ export function stubShowQuickPick(
   };
 }
 
+/** Like {@link stubShowQuickPick}, but for `canPickMany` pickers that resolve an array. */
+export function stubShowQuickPickMany(
+  pick: (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options: vscode.QuickPickOptions | undefined
+  ) => vscode.QuickPickItem[] | undefined
+): () => void {
+  const original = vscode.window.showQuickPick.bind(vscode.window);
+
+  (vscode.window as any).showQuickPick = async (
+    items: readonly (vscode.QuickPickItem | string)[],
+    options?: vscode.QuickPickOptions
+  ) => pick(items, options);
+
+  return () => {
+    (vscode.window as any).showQuickPick = original;
+  };
+}
+
 export function stubInputBox(
   ...answers: Array<string | ((options: vscode.InputBoxOptions) => string | undefined)>
 ): () => void {

--- a/src/test/unit/cleanupBranches.test.ts
+++ b/src/test/unit/cleanupBranches.test.ts
@@ -1,0 +1,285 @@
+import * as assert from 'assert';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { QuickPickItemKind } from 'vscode';
+
+import {
+  buildCleanupQuickPickItems,
+  buildRecoveryDocument,
+  computeCleanupCandidates,
+  ICleanupQuickPickItem,
+  summarizeDeletions,
+  toSelectedCandidates,
+} from '../../commands/cleanupBranchesCommand/candidates';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { LoggingService } from '../../logging/loggingService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function ref(name: string, overrides: Partial<IGitRef> = {}): IGitRef {
+  return {
+    authorName: 'Test',
+    name,
+    fullName: name,
+    hash: `${name}-sha`,
+    committerDate: '1700000000',
+    ...overrides,
+  };
+}
+
+describe('computeCleanupCandidates', () => {
+  it('unions merged branches with gone-upstream branches, excluding current/default/worktree-checked-out', () => {
+    const refs = [
+      ref('merged-1'),
+      ref('merged-2'),
+      ref('active'), // unmerged, no gone upstream -> excluded
+      ref('orphan', { upstreamTrack: '[gone]' }),
+      ref('current-branch'),
+      ref('main'),
+      ref('checked-out-elsewhere'),
+    ];
+    const mergedNames = new Set(['merged-1', 'merged-2', 'current-branch', 'main']);
+    const worktreeBranches = new Set(['checked-out-elsewhere']);
+
+    const candidates = computeCleanupCandidates(refs, mergedNames, worktreeBranches, 'current-branch', 'main');
+
+    assert.deepStrictEqual(
+      candidates.map((candidate) => candidate.ref.name).sort(),
+      ['merged-1', 'merged-2', 'orphan'].sort()
+    );
+  });
+
+  it('classifies merged branches as "merged" and gone-only branches as "gone"', () => {
+    const refs = [ref('merged-1'), ref('orphan', { upstreamTrack: '[gone]' })];
+    const candidates = computeCleanupCandidates(
+      refs,
+      new Set(['merged-1']),
+      new Set(),
+      'unrelated',
+      'main'
+    );
+
+    assert.strictEqual(candidates.find((c) => c.ref.name === 'merged-1')?.group, 'merged');
+    assert.strictEqual(candidates.find((c) => c.ref.name === 'orphan')?.group, 'gone');
+  });
+
+  it('classifies a branch that is both merged and gone as "merged"', () => {
+    const refs = [ref('both', { upstreamTrack: '[gone]' })];
+    const candidates = computeCleanupCandidates(refs, new Set(['both']), new Set(), 'unrelated', 'main');
+
+    assert.strictEqual(candidates[0].group, 'merged');
+  });
+});
+
+describe('buildCleanupQuickPickItems', () => {
+  it('groups items under "Merged into <base>" and "Upstream deleted" separators', () => {
+    const candidates = computeCleanupCandidates(
+      [ref('merged-1'), ref('orphan', { upstreamTrack: '[gone]' })],
+      new Set(['merged-1']),
+      new Set(),
+      'unrelated',
+      'main'
+    );
+
+    const items = buildCleanupQuickPickItems(candidates, 'main');
+    const separatorLabels = items
+      .filter((item) => item.kind === QuickPickItemKind.Separator)
+      .map((item) => item.label);
+
+    assert.deepStrictEqual(separatorLabels, ['Merged into main', 'Upstream deleted']);
+  });
+
+  it('pre-checks merged items and leaves unmerged-gone items unchecked', () => {
+    const candidates = computeCleanupCandidates(
+      [ref('merged-1'), ref('orphan', { upstreamTrack: '[gone]' })],
+      new Set(['merged-1']),
+      new Set(),
+      'unrelated',
+      'main'
+    );
+
+    const items = buildCleanupQuickPickItems(candidates, 'main') as ICleanupQuickPickItem[];
+    const merged = items.find((item) => item.candidate?.ref.name === 'merged-1');
+    const gone = items.find((item) => item.candidate?.ref.name === 'orphan');
+
+    assert.strictEqual(merged?.picked, true);
+    assert.strictEqual(gone?.picked, false);
+  });
+
+  it('describes unmerged-gone items with a force-delete warning', () => {
+    const candidates = computeCleanupCandidates(
+      [ref('orphan', { upstreamTrack: '[gone]' })],
+      new Set(),
+      new Set(),
+      'unrelated',
+      'main'
+    );
+
+    const items = buildCleanupQuickPickItems(candidates, 'main') as ICleanupQuickPickItem[];
+    const gone = items.find((item) => item.candidate?.ref.name === 'orphan');
+
+    assert.ok(gone?.description?.includes('not merged — force delete'));
+    assert.ok(gone?.description?.includes('orphan-sha'));
+  });
+
+  it('omits a group separator entirely when that group has no candidates', () => {
+    const candidates = computeCleanupCandidates([ref('merged-1')], new Set(['merged-1']), new Set(), 'unrelated', 'main');
+    const items = buildCleanupQuickPickItems(candidates, 'main');
+    const separatorLabels = items
+      .filter((item) => item.kind === QuickPickItemKind.Separator)
+      .map((item) => item.label);
+
+    assert.deepStrictEqual(separatorLabels, ['Merged into main']);
+  });
+});
+
+describe('toSelectedCandidates', () => {
+  it('filters out separators and keeps only actionable candidates', () => {
+    const candidates = computeCleanupCandidates([ref('merged-1')], new Set(['merged-1']), new Set(), 'unrelated', 'main');
+    const items = buildCleanupQuickPickItems(candidates, 'main');
+
+    assert.strictEqual(toSelectedCandidates(items).length, 1);
+    assert.strictEqual(toSelectedCandidates(undefined).length, 0);
+  });
+});
+
+describe('buildRecoveryDocument', () => {
+  it('emits one "git branch <name> <sha>" line per successfully deleted branch', () => {
+    const doc = buildRecoveryDocument([
+      { name: 'merged-1', sha: 'aaa1111', success: true },
+      { name: 'merged-2', sha: 'bbb2222', success: true },
+      { name: 'orphan', sha: 'ccc3333', success: true },
+    ]);
+
+    assert.ok(doc.includes('git branch merged-1 aaa1111'));
+    assert.ok(doc.includes('git branch merged-2 bbb2222'));
+    assert.ok(doc.includes('git branch orphan ccc3333'));
+  });
+
+  it('excludes failed deletions from the recovery document', () => {
+    const doc = buildRecoveryDocument([
+      { name: 'merged-1', sha: 'aaa1111', success: true },
+      { name: 'merged-2', sha: 'bbb2222', success: false },
+    ]);
+
+    assert.ok(doc.includes('git branch merged-1 aaa1111'));
+    assert.ok(!doc.includes('merged-2'));
+  });
+});
+
+describe('summarizeDeletions', () => {
+  it('reports a clean summary when everything succeeds', () => {
+    assert.strictEqual(
+      summarizeDeletions([
+        { name: 'a', sha: '1', success: true },
+        { name: 'b', sha: '2', success: true },
+      ]),
+      'Deleted 2 branches'
+    );
+  });
+
+  it('reports partial failures without aborting the batch', () => {
+    assert.strictEqual(
+      summarizeDeletions([
+        { name: 'a', sha: '1', success: true },
+        { name: 'b', sha: '2', success: false },
+        { name: 'c', sha: '3', success: true },
+      ]),
+      'Deleted 2 branches, 1 failed'
+    );
+  });
+});
+
+describe('GitExecutor.getDefaultBranch', () => {
+  function initRepo(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email "test@test.local"', { cwd: dir });
+    execSync('git config user.name "Test"', { cwd: dir });
+    return dir;
+  }
+
+  function commit(dir: string, message: string) {
+    fs.writeFileSync(path.join(dir, 'file.txt'), `${message}\n`);
+    execSync('git add file.txt', { cwd: dir });
+    execSync(`git commit -q -m "${message}"`, { cwd: dir });
+  }
+
+  it('resolves via origin/HEAD when present', async () => {
+    const remoteDir = initRepo('gsc-default-remote-');
+    execSync('git checkout -q -b trunk', { cwd: remoteDir });
+    commit(remoteDir, 'init');
+
+    const dir = initRepo('gsc-default-local-');
+    execSync('git checkout -q -b unrelated', { cwd: dir });
+    commit(dir, 'init');
+    execSync(`git remote add origin "${remoteDir}"`, { cwd: dir });
+    execSync('git fetch -q origin', { cwd: dir });
+    execSync('git remote set-head origin trunk', { cwd: dir });
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    assert.strictEqual(await git.getDefaultBranch(), 'trunk');
+    fs.rmSync(remoteDir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('falls back to a local "main" branch when origin/HEAD is absent', async () => {
+    const dir = initRepo('gsc-default-main-');
+    execSync('git checkout -q -b main', { cwd: dir });
+    commit(dir, 'init');
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    assert.strictEqual(await git.getDefaultBranch(), 'main');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('falls back to a local "master" branch when origin/HEAD and "main" are absent', async () => {
+    const dir = initRepo('gsc-default-master-');
+    execSync('git checkout -q -b master', { cwd: dir });
+    commit(dir, 'init');
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    assert.strictEqual(await git.getDefaultBranch(), 'master');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throws a descriptive error when no default branch can be determined', async () => {
+    const dir = initRepo('gsc-default-none-');
+    execSync('git checkout -q -b develop', { cwd: dir });
+    commit(dir, 'init');
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    await assert.rejects(() => git.getDefaultBranch(), /Could not determine the default branch/);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('GitExecutor.getMergedBranches', () => {
+  it('lists local branches merged into the given base, excluding still-unmerged branches', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-merged-'));
+    execSync('git init -q -b main', { cwd: dir });
+    execSync('git config user.email "test@test.local"', { cwd: dir });
+    execSync('git config user.name "Test"', { cwd: dir });
+    fs.writeFileSync(path.join(dir, 'file.txt'), 'a\n');
+    execSync('git add file.txt', { cwd: dir });
+    execSync('git commit -q -m init', { cwd: dir });
+    execSync('git checkout -q -b merged-branch', { cwd: dir });
+    execSync('git checkout -q main', { cwd: dir });
+    execSync('git merge -q merged-branch --ff-only', { cwd: dir });
+    execSync('git checkout -q -b unmerged-branch', { cwd: dir });
+    fs.writeFileSync(path.join(dir, 'file2.txt'), 'b\n');
+    execSync('git add file2.txt', { cwd: dir });
+    execSync('git commit -q -m more', { cwd: dir });
+    execSync('git checkout -q main', { cwd: dir });
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    const merged = await git.getMergedBranches('main');
+
+    assert.ok(merged.includes('merged-branch'));
+    assert.ok(merged.includes('main'));
+    assert.ok(!merged.includes('unmerged-branch'));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/test/unit/quickActions.test.ts
+++ b/src/test/unit/quickActions.test.ts
@@ -54,6 +54,7 @@ const ALWAYS_VISIBLE_COMMANDS = [
   'checkoutPrevious',
   'createBranchFromTemplate',
   'createTagFromTemplate',
+  'cleanupBranches',
   'pullWithStash',
   'pullRebaseWithStash',
   'rebaseWithStash',
@@ -138,6 +139,7 @@ describe('filterVisibleQuickActions', () => {
     // Sections that still have items keep their separators.
     assert.ok(separators.includes('Worktree'));
     assert.ok(separators.includes('Checkout'));
+    assert.ok(separators.includes('Branches'));
   });
 
   it('keeps a section separator when at least one item remains', () => {


### PR DESCRIPTION
## Summary

PR #153 shipped `GSC: Delete merged branches...`, but an audit against the Feature 7 spec found it only implemented the "merged branches" half. This PR closes the remaining gaps:

- **Missing upstream-`[gone]` candidates.** The command filtered to `merged.has(ref.name)` only, so branches whose upstream was deleted never appeared, contradicting the spec's "merged ∪ gone" candidate set.
- **No picker grouping/pre-check rules.** Items were a flat, unlabeled list with every item pre-checked — no `"Merged into <base>"` / `"Upstream deleted"` separators, and unmerged-gone items weren't left unchecked with a force-delete warning.
- **Wrong delete mode.** Every branch was deleted with `-d`, so it would silently fail for the (previously absent) gone/unmerged group. Merged branches now use `-d`; unmerged-gone use `-D`.
- **No partial-failure handling.** A failed delete was logged but never surfaced; the summary always said `"Deleted N branches"` even when some failed. Now reports `"Deleted N branches, M failed"` and continues the batch.
- **No "Undo hint."** The summary toast had no way to recover deleted branches. It now offers an `"Undo hint"` action that opens a document with `git branch <name> <sha>` lines, using the tip SHA captured before deletion.
- **`getDefaultBranch()` failures were unhandled**, so an unresolvable default branch surfaced as a generic command error instead of a clear message.
- **Missing from the quick-actions menu.** The spec calls for "palette + quick-actions menu"; the command was palette-only. Added under a new "Branches" section.
- **No tests at all** existed for this command or for `GitExecutor.getMergedBranches`/`getDefaultBranch`.

## Changes

- `src/commands/cleanupBranchesCommand/candidates.ts` (new): pure, unit-tested helpers — `computeCleanupCandidates`, `buildCleanupQuickPickItems`, `toSelectedCandidates`, `buildRecoveryDocument`, `summarizeDeletions`.
- `src/commands/cleanupBranchesCommand/index.ts`: rewritten to use the helpers above, handle `getDefaultBranch()` failure, delete with the correct force flag per group, and show the undo-hint recovery document.
- `src/statusBar/statusBarManager.ts`: added a "Branches" section with "Delete merged branches…" to the quick-actions menu.
- `src/test/unit/cleanupBranches.test.ts` (new): candidate computation (merged/gone/current/default/worktree fixtures), grouping/pre-check state, recovery document contents, partial-failure summaries, and `GitExecutor.getDefaultBranch` resolution (origin/HEAD, main fallback, master fallback, unresolvable) / `getMergedBranches`.
- `src/test/unit/quickActions.test.ts`: covers the new "Branches" menu section.
- `src/test/e2e/cleanupBranches.test.ts` (new): candidate grouping/exclusion (worktree-checked-out, active/unmerged, default branch), a partial-failure run with the undo-hint recovery document, and the zero-candidates empty state.
- `src/test/e2e/helpers/commandHarness.ts`: added a reusable `stubShowQuickPickMany` helper for `canPickMany` pickers.

## How to test manually

1. In a repo with a few local branches, some merged into `main`/`master` and at least one whose remote branch was deleted (`git push origin --delete <branch>` then `git fetch --prune`), run **GSC: Delete merged branches...** from the command palette (or the status-bar quick-actions menu, under "Branches").
2. Confirm the picker shows two groups — "Merged into `<base>`" and "Upstream deleted" — with merged items pre-checked and gone items unchecked (description says "not merged — force delete").
3. Uncheck one merged item, confirm the modal, and verify only the checked branches are deleted (`-d` for merged, `-D` for gone).
4. Click "Undo hint" on the summary toast and verify the opened document lists `git branch <name> <sha>` for each deleted branch; running one restores that branch at the right commit.
5. With no eligible branches, run the command again and confirm the info toast "No merged or orphaned branches to clean up." appears without opening a picker.

## Test plan

- [x] `yarn compile` (check-types + lint + esbuild)
- [x] `yarn test:unit` — 472 passing, including all new tests
- [x] Targeted e2e: `Cleanup branches command` suite and `status bar quick actions menu` suite — both green