### PR TITLE
feat(website): add v0.14.0 feature cards and clickable feature detail modals

### DIFF
--- a/website/src/components/FeatureCard/FeatureCard.module.css
+++ b/website/src/components/FeatureCard/FeatureCard.module.css
@@ -125,3 +125,25 @@
   text-overflow: ellipsis;
   min-width: 0;
 }
+
+.clickable {
+  position: relative;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+.clickable:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--border);
+  transform: translateY(-2px);
+}
+.cardButton { all: unset; font: inherit; color: inherit; cursor: pointer; }
+.cardButton::after { content: ''; position: absolute; inset: 0; }
+.cardButton:focus-visible::after {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-md);
+}
+@media (prefers-reduced-motion: reduce) {
+  .clickable { transition: none; }
+  .clickable:hover { transform: none; }
+}

--- a/website/src/components/FeatureCard/FeatureCard.tsx
+++ b/website/src/components/FeatureCard/FeatureCard.tsx
@@ -14,6 +14,7 @@ interface FeatureCardProps {
   tone?: FeatureCardTone;
   compact?: boolean;
   titleLevel?: 3 | 4;
+  onClick?: () => void;
 }
 
 export function FeatureCard({
@@ -25,6 +26,7 @@ export function FeatureCard({
   tone,
   compact = false,
   titleLevel = 3,
+  onClick,
 }: FeatureCardProps) {
   const commandPaletteShortcut = command ? getCommandPaletteShortcut() : undefined;
   const Title = titleLevel === 4 ? 'h4' : 'h3';
@@ -32,6 +34,7 @@ export function FeatureCard({
     styles.card,
     compact ? styles.compact : '',
     tone ? styles[tone] : '',
+    onClick ? styles.clickable : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -41,7 +44,20 @@ export function FeatureCard({
       <div className={styles.cardIcon}>{icon}</div>
       <div className={styles.cardBody}>
         <div className={styles.cardTitleRow}>
-          <Title className={styles.cardTitle}>{title}</Title>
+          <Title className={styles.cardTitle}>
+            {onClick ? (
+              <button
+                type="button"
+                className={styles.cardButton}
+                onClick={onClick}
+                aria-haspopup="dialog"
+              >
+                {title}
+              </button>
+            ) : (
+              title
+            )}
+          </Title>
           {tag && <span className={styles.tag}>{tag}</span>}
         </div>
         <p className={styles.cardDesc}>{description}</p>

--- a/website/src/components/FeatureModal/FeatureModal.module.css
+++ b/website/src/components/FeatureModal/FeatureModal.module.css
@@ -1,0 +1,196 @@
+.dialog {
+  padding: 0;
+  margin: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-lg);
+  width: min(820px, calc(100vw - 48px));
+  max-width: none;
+  max-height: min(85dvh, 860px);
+}
+.dialog::backdrop {
+  background: rgba(1, 4, 9, 0.7);
+}
+.inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-height: inherit;
+}
+.media {
+  aspect-ratio: 16 / 9;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.media video,
+.media iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  object-fit: contain;
+}
+.placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border);
+  color: var(--text-muted);
+  font-size: 14px;
+}
+.body {
+  overflow-y: auto;
+  padding: 28px;
+  display: grid;
+  gap: 18px;
+}
+.close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(13, 17, 23, 0.7);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.close:hover {
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .dialog[open] {
+    animation: modal-in 0.18s ease-out;
+  }
+  .dialog[open]::backdrop {
+    animation: backdrop-in 0.18s ease-out;
+  }
+}
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
+}
+@keyframes backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+@media (max-width: 768px) {
+  .dialog {
+    width: 100vw;
+    max-height: none;
+    height: 100dvh;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+  }
+  .body {
+    padding: 24px 16px;
+  }
+}
+@media (max-width: 480px) {
+  .body {
+    padding: 20px 12px;
+  }
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.icon {
+  font-size: 24px;
+  line-height: 1;
+}
+.titleRow h3 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+.tag {
+  padding: 2px 8px;
+  border-radius: 100px;
+  background: var(--orange-subtle);
+  color: var(--orange);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.longDesc {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.body section h4 {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+.body section ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.body section li::marker {
+  color: var(--accent);
+}
+.row {
+  display: grid;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  margin-bottom: 6px;
+  overflow: hidden;
+}
+.row:last-child {
+  margin-bottom: 0;
+}
+.row code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.settingCode {
+  color: var(--purple);
+}
+.docsLink {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+}
+.docsLink:hover {
+  color: var(--accent-hover);
+}
+.playCircle {
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+}

--- a/website/src/components/FeatureModal/FeatureModal.tsx
+++ b/website/src/components/FeatureModal/FeatureModal.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, type MouseEvent } from 'react';
+
+import type { Feature } from '../Features/featuresData';
+import styles from './FeatureModal.module.css';
+
+interface FeatureModalProps {
+  feature: Feature;
+  onClose: () => void;
+}
+
+export function FeatureModal({ feature, onClose }: FeatureModalProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const { details } = feature;
+  const { media } = details;
+
+  useEffect(() => {
+    ref.current?.showModal();
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDialogElement>) => {
+    if (e.target === e.currentTarget) {
+      ref.current?.close();
+    }
+  };
+
+  return (
+    <dialog
+      ref={ref}
+      className={styles.dialog}
+      onClose={onClose}
+      onClick={handleBackdropClick}
+      aria-labelledby="feature-modal-title"
+    >
+      <div className={styles.inner}>
+        <div className={styles.media}>
+          {media?.kind === 'video' ? (
+            <video src={media.src} poster={media.poster} controls playsInline preload="metadata" />
+          ) : media?.kind === 'youtube' ? (
+            <iframe
+              src={`https://www.youtube-nocookie.com/embed/${media.src}`}
+              title={`${feature.title} demo`}
+              allow="accelerometer; encrypted-media; picture-in-picture; fullscreen"
+              allowFullScreen
+              loading="lazy"
+            />
+          ) : (
+            <div className={styles.placeholder}>
+              <span className={styles.playCircle} aria-hidden="true">
+                <svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="11" stroke="currentColor" strokeWidth="1.5" />
+                  <path d="M10 8.5L16 12L10 15.5V8.5Z" fill="currentColor" />
+                </svg>
+              </span>
+              <span>Demo video coming soon</span>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.close}
+          onClick={() => ref.current?.close()}
+          aria-label="Close dialog"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M6 6L18 18M6 18L18 6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+        <div className={styles.body}>
+          <header className={styles.titleRow}>
+            <span className={styles.icon} aria-hidden="true">
+              {feature.icon}
+            </span>
+            <h3 id="feature-modal-title">{feature.title}</h3>
+            {feature.tag && <span className={styles.tag}>{feature.tag}</span>}
+          </header>
+          <div className={styles.longDesc}>{details.longDescription}</div>
+          <section>
+            <h4>Highlights</h4>
+            <ul>
+              {details.highlights.map((highlight) => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+            </ul>
+          </section>
+          {details.commands && (
+            <section>
+              <h4>Commands</h4>
+              {details.commands.map((command) => (
+                <div key={command} className={styles.row}>
+                  <code>{command}</code>
+                </div>
+              ))}
+            </section>
+          )}
+          {details.settings && (
+            <section>
+              <h4>Settings</h4>
+              {details.settings.map((setting) => (
+                <div key={setting} className={styles.row}>
+                  <code className={styles.settingCode}>{setting}</code>
+                </div>
+              ))}
+            </section>
+          )}
+          {details.docsUrl && (
+            <a href={details.docsUrl} target="_blank" rel="noreferrer" className={styles.docsLink}>
+              Read the docs →
+            </a>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/website/src/components/Features/Features.tsx
+++ b/website/src/components/Features/Features.tsx
@@ -1,155 +1,13 @@
-import type { ReactNode } from 'react';
+import { useState } from 'react';
 
-import { FeatureCard, type FeatureCardTone } from '../FeatureCard/FeatureCard';
+import { FeatureCard } from '../FeatureCard/FeatureCard';
+import { FeatureModal } from '../FeatureModal/FeatureModal';
+import { features, type Feature } from './featuresData';
 import styles from './Features.module.css';
 
-interface Feature {
-  icon: string;
-  title: string;
-  description: ReactNode;
-  command?: string;
-  tag?: string;
-  color: FeatureCardTone;
-}
-
-const features: Feature[] = [
-  {
-    icon: '🔄',
-    title: 'Smart Branch Checkout',
-    description:
-      'Switch branches without worrying about uncommitted changes. Choose your stash strategy once or per checkout — the extension handles everything else.',
-    command: 'GSC: Checkout to... (With Stash)',
-    color: 'blue',
-  },
-  {
-    icon: '📥',
-    title: 'Pull with Stash',
-    description:
-      'Pull the latest changes from remote without losing your local work. Changes are stashed before the pull and restored automatically after.',
-    command: 'GSC: Pull (With Stash)',
-    color: 'green',
-  },
-  {
-    icon: '🔃',
-    title: 'Pull with Rebase',
-    description:
-      'Pull with rebase while preserving local changes. The extension stashes your work, rebases onto the remote branch, and restores your changes afterward.',
-    command: 'GSC: Pull (Rebase With Stash)',
-    color: 'orange',
-  },
-  {
-    icon: '🔀',
-    title: 'Rebase with Stash',
-    description:
-      'Rebase the current branch onto any other branch, tag, or ref while your local changes are stashed and restored automatically — no need to commit or clean up first.',
-    command: 'GSC: Rebase (With Stash)',
-    color: 'purple',
-  },
-  {
-    icon: '⬅️',
-    title: 'Checkout Previous Branch',
-    description: (
-      <>
-        Instantly jump back to the branch you were on before, with the same auto-stash
-        magic. Think of it as <kbd>Ctrl + Z</kbd> for branch switching.
-      </>
-    ),
-    command: 'GSC: Checkout Previous Branch (With Stash)',
-    color: 'purple',
-  },
-  {
-    icon: '⭐',
-    title: 'Preferred Branches',
-    description:
-      'Star the branches, tags, and remotes you use most — they float to the top of the checkout picker, marked with a star. Toggle a star straight from the picker, no settings file to edit.',
-    command: 'GSC: Checkout to... (With Stash)',
-    tag: 'New',
-    color: 'blue',
-  },
-  {
-    icon: '🍒',
-    title: 'GitHub PR Clone',
-    description:
-      'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
-    command: 'GSC: Clone Pull Request...',
-    tag: 'Beta',
-    color: 'orange',
-  },
-  {
-    icon: '#️⃣',
-    title: 'Checkout by PR Number',
-    description:
-      "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
-    command: 'GSC: Checkout by PR Number... (With Stash)',
-    color: 'orange',
-  },
-  {
-    icon: '🔎',
-    title: 'PR Review in Worktree',
-    description:
-      'Open a GitHub PR in an isolated linked worktree, track its review metadata, and remove the review worktree later with dirty-state stash handling.',
-    command: 'GSC: PR Review in Worktree...',
-    color: 'purple',
-  },
-  {
-    icon: '🖥️',
-    title: 'Worktree Dev Terminal',
-    description:
-      'Open a new integrated terminal straight in any worktree directory. Pick a project, choose the worktree, and get a shell in the right working directory — no manual navigation.',
-    command: 'GSC: Open Worktree Dev Terminal...',
-    color: 'blue',
-  },
-  {
-    icon: '🏷️',
-    title: 'Tag from Template',
-    description:
-      'Generate version tags from a configurable template. Read values from package.json, extract ticket IDs from branch names, and auto-increment to avoid collisions.',
-    command: 'GSC: Create Tag from Template...',
-    color: 'blue',
-  },
-  {
-    icon: '🌿',
-    title: 'Branch from Template',
-    description:
-      'Create and check out a branch from a reusable template. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
-    command: 'GSC: Create Branch from Template...',
-    color: 'green',
-  },
-  {
-    icon: '🌲',
-    title: 'Worktree Workflows',
-    description:
-      'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
-    command: 'GSC: Move to New Worktree...',
-    color: 'green',
-  },
-  {
-    icon: '🛡️',
-    title: 'Conflict Prediction',
-    description:
-      'Before switching branches, the extension detects which files would conflict with your stash. No more surprise merge disasters mid-checkout.',
-    color: 'green',
-  },
-  {
-    icon: '📋',
-    title: 'Auto-Stash Manager',
-    description:
-      'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
-    command: 'GSC: Manage Auto-Stashes...',
-    tag: 'New',
-    color: 'green',
-  },
-  {
-    icon: '📊',
-    title: 'Status Bar Integration',
-    description:
-      "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",
-    command: 'GSC: Quick Actions...',
-    color: 'purple',
-  },
-];
-
 export function Features() {
+  const [active, setActive] = useState<Feature | null>(null);
+
   return (
     <section id="features" className={styles.section}>
       <div className="container">
@@ -164,16 +22,18 @@ export function Features() {
         <div className={styles.grid}>
           {features.map((f) => (
             <FeatureCard
-              key={f.title}
+              key={f.id}
               icon={f.icon}
               title={f.title}
               description={f.description}
               command={f.command}
               tag={f.tag}
+              onClick={() => setActive(f)}
             />
           ))}
         </div>
       </div>
+      {active && <FeatureModal feature={active} onClose={() => setActive(null)} />}
     </section>
   );
 }

--- a/website/src/components/Features/featuresData.tsx
+++ b/website/src/components/Features/featuresData.tsx
@@ -1,0 +1,548 @@
+import type { ReactNode } from 'react';
+
+import type { FeatureCardTone } from '../FeatureCard/FeatureCard';
+
+export interface FeatureMedia {
+  /** 'video' = self-hosted mp4 (primary); 'youtube' = YouTube video id */
+  kind: 'video' | 'youtube';
+  /** kind 'video': site-absolute path, e.g. '/videos/smart-checkout.mp4' (file in website/public/videos/).
+   *  kind 'youtube': the 11-char video id only. */
+  src: string;
+  poster?: string; // optional poster image for kind 'video'
+}
+
+export interface FeatureDetails {
+  longDescription: ReactNode; // 2–4 sentences, may include <kbd>/<code>
+  highlights: string[]; // 3–6 plain-string bullets
+  commands?: string[]; // exact palette titles, e.g. 'GSC: Checkout to... (With Stash)'
+  settings?: string[]; // exact ids, e.g. 'git-smart-checkout.recentBranchCount'
+  docsUrl?: string; // ONLY if the file exists in docs/ (allowed list in Section 5)
+  media?: FeatureMedia; // omit => "Demo video coming soon" placeholder
+}
+
+export interface Feature {
+  id: string; // unique kebab-case slug; used as React key
+  icon: string;
+  title: string;
+  description: ReactNode; // short card copy — unchanged from today
+  command?: string;
+  tag?: string;
+  color: FeatureCardTone; // kept but intentionally NOT forwarded to FeatureCard in the main grid (today's behavior) — do not "fix" this
+  details: FeatureDetails; // required — every main-grid card is clickable
+}
+
+const DOCS_BASE = 'https://github.com/zaknafeyn/git-smart-checkout/blob/main/docs/';
+
+export const features: Feature[] = [
+  {
+    id: 'smart-checkout',
+    icon: '🔄',
+    title: 'Smart Branch Checkout',
+    description:
+      'Switch branches without worrying about uncommitted changes. Choose your stash strategy once or per checkout — the extension handles everything else.',
+    command: 'GSC: Checkout to... (With Stash)',
+    color: 'blue',
+    details: {
+      longDescription:
+        'Pick a stash strategy globally or per checkout, then switch branches with your working tree carried along automatically. Conflict prediction runs before the switch so you never get a mid-checkout surprise.',
+      highlights: [
+        'Stash-mode choice per checkout or set globally in settings',
+        'Inline branch actions in the picker — delete, rename, or push a branch without leaving it',
+        '"Recent" section ranked by frequency and recency, sized by recentBranchCount (0 disables it)',
+        'Starred preferred branches, tags, and remotes float to the top',
+        'Conflict prediction warns about files that would clash with the stash before you switch',
+      ],
+      commands: ['GSC: Checkout to... (With Stash)', 'GSC: Switch Mode...'],
+      settings: ['git-smart-checkout.recentBranchCount', 'git-smart-checkout.useFastBranchList'],
+      docsUrl: `${DOCS_BASE}checkout-with-stash.md`,
+    },
+  },
+  {
+    id: 'pull-with-stash',
+    icon: '📥',
+    title: 'Pull with Stash',
+    description:
+      'Pull the latest changes from remote without losing your local work. Changes are stashed before the pull and restored automatically after.',
+    command: 'GSC: Pull (With Stash)',
+    color: 'green',
+    details: {
+      longDescription:
+        'Your local changes are stashed before the pull, then restored the moment it completes — no manual stash juggling required.',
+      highlights: [
+        'Stash → pull → restore in a single command',
+        'Respects the resolved remote, including a configured defaultRemote',
+        'A conflicting restore hands off to guided Stash-Conflict Rescue',
+      ],
+      commands: ['GSC: Pull (With Stash)'],
+      docsUrl: `${DOCS_BASE}pull-with-stash.md`,
+    },
+  },
+  {
+    id: 'pull-with-rebase',
+    icon: '🔃',
+    title: 'Pull with Rebase',
+    description:
+      'Pull with rebase while preserving local changes. The extension stashes your work, rebases onto the remote branch, and restores your changes afterward.',
+    command: 'GSC: Pull (Rebase With Stash)',
+    color: 'orange',
+    details: {
+      longDescription:
+        'Same safe stash-and-restore flow as Pull with Stash, but rebases onto the remote branch instead of merging — so history stays linear without ever committing your work in progress.',
+      highlights: [
+        'Stash, rebase onto the remote branch, restore — one command',
+        'Keeps history linear without committing WIP just to rebase',
+        'Same stash-mode and conflict handling as every other stash-carrying command',
+      ],
+      commands: ['GSC: Pull (Rebase With Stash)'],
+      docsUrl: `${DOCS_BASE}pull-rebase-with-stash.md`,
+    },
+  },
+  {
+    id: 'rebase-with-stash',
+    icon: '🔀',
+    title: 'Rebase with Stash',
+    description:
+      'Rebase the current branch onto any other branch, tag, or ref while your local changes are stashed and restored automatically — no need to commit or clean up first.',
+    command: 'GSC: Rebase (With Stash)',
+    color: 'purple',
+    details: {
+      longDescription:
+        'Rebase onto any branch, tag, or ref you pick from the same picker used for checkout — your local changes are stashed first and restored once the rebase lands.',
+      highlights: [
+        'Rebase onto any branch, tag, or arbitrary ref',
+        'Auto-stash before, auto-restore after',
+        'Conflicts during the rebase or the restore are surfaced clearly',
+      ],
+      commands: ['GSC: Rebase (With Stash)'],
+      docsUrl: `${DOCS_BASE}rebase-with-stash.md`,
+    },
+  },
+  {
+    id: 'checkout-previous',
+    icon: '⬅️',
+    title: 'Checkout Previous Branch',
+    description: (
+      <>
+        Instantly jump back to the branch you were on before, with the same auto-stash
+        magic. Think of it as <kbd>Ctrl + Z</kbd> for branch switching.
+      </>
+    ),
+    command: 'GSC: Checkout Previous Branch (With Stash)',
+    color: 'purple',
+    details: {
+      longDescription:
+        'One keystroke bounces you between your current branch and the previous one, with the same stash mode handling every other checkout command uses.',
+      highlights: [
+        'One-keystroke bounce between the last two branches you worked on',
+        'Same stash-mode handling as a regular checkout',
+      ],
+      commands: ['GSC: Checkout Previous Branch (With Stash)'],
+      docsUrl: `${DOCS_BASE}checkout-previous-branch-with-stash.md`,
+    },
+  },
+  {
+    id: 'preferred-branches',
+    icon: '⭐',
+    title: 'Preferred Branches',
+    description:
+      'Star the branches, tags, and remotes you use most — they float to the top of the checkout picker, marked with a star. Toggle a star straight from the picker, no settings file to edit.',
+    command: 'GSC: Checkout to... (With Stash)',
+    tag: 'New',
+    color: 'blue',
+    details: {
+      longDescription:
+        'Star the branches, tags, and remote refs you switch to most often, and they always show up first in the checkout picker — no configuration file to hand-edit.',
+      highlights: [
+        'Star or unstar any branch, tag, or remote ref straight from the picker',
+        'Starred refs float to the top, marked with a star',
+      ],
+      commands: ['GSC: Checkout to... (With Stash)'],
+      docsUrl: `${DOCS_BASE}checkout-with-stash.md`,
+    },
+  },
+  {
+    id: 'delete-merged-branches',
+    icon: '🧹',
+    title: 'Delete Merged Branches',
+    description:
+      'Sweep away branches already merged or whose upstream is gone, in one multi-select pass.',
+    command: 'GSC: Delete Merged Branches...',
+    tag: 'New',
+    color: 'green',
+    details: {
+      longDescription:
+        'Clear out stale local branches in one pass — the picker groups branches that are already merged separately from ones whose upstream disappeared, so you always know why a branch is on the list.',
+      highlights: [
+        'Grouped picker: merged branches vs. gone-upstream branches',
+        'Protects the current branch and the repo\'s default branch',
+        'Shows an undo hint right after deletion',
+        'Reachable straight from Quick Actions',
+      ],
+      commands: ['GSC: Delete Merged Branches...'],
+    },
+  },
+  {
+    id: 'pr-clone',
+    icon: '🍒',
+    title: 'GitHub PR Clone',
+    description:
+      'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
+    command: 'GSC: Clone Pull Request...',
+    tag: 'Beta',
+    color: 'orange',
+    details: {
+      longDescription:
+        'Cherry-pick just the commits you want from any GitHub PR into a brand-new branch, then open a fresh pull request with a GitHub-Flavored Markdown preview that can pre-fill from the repo\'s PR template.',
+      highlights: [
+        'Pick exactly which commits to cherry-pick from the source PR',
+        'Full GFM description preview, pre-filled from the repo PR template',
+        'Configurable checkoutAfterClone behavior: ask, always, or never',
+        'Set a branch prefix and a default target branch',
+        'Cancel mid-clone, or resolve conflicts and continue',
+      ],
+      commands: ['GSC: Clone Pull Request...'],
+      settings: [
+        'git-smart-checkout.prClone.checkoutAfterClone',
+        'git-smart-checkout.defaultTargetBranch',
+        'git-smart-checkout.prBranchPrefix',
+      ],
+      docsUrl: `${DOCS_BASE}github-pr-clone.md`,
+    },
+  },
+  {
+    id: 'checkout-by-pr',
+    icon: '#️⃣',
+    title: 'Checkout by PR Number',
+    description:
+      "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
+    command: 'GSC: Checkout by PR Number... (With Stash)',
+    color: 'orange',
+    details: {
+      longDescription:
+        'Paste a PR number or URL and land straight on that branch — the extension fetches it for you, with the same stash handling as a regular checkout.',
+      highlights: [
+        'Accepts a bare PR number or a full GitHub URL',
+        'Auto-stash handling identical to a regular checkout',
+        'Aware of GitHub Enterprise hosts and multi-remote resolution',
+      ],
+      commands: ['GSC: Checkout by PR Number... (With Stash)'],
+      docsUrl: `${DOCS_BASE}checkout-by-pr-number-with-stash.md`,
+    },
+  },
+  {
+    id: 'multi-remote',
+    icon: '🛰️',
+    title: 'Multi-Remote Support',
+    description:
+      'Fork-friendly — the right remote is picked automatically for fetch and push, or pin one with defaultRemote.',
+    color: 'blue',
+    details: {
+      longDescription:
+        'Working across a fork and upstream? The extension resolves the right remote for every fetch and push automatically, or you can pin one explicitly with defaultRemote.',
+      highlights: [
+        'Resolution chain: branch upstream → defaultRemote → the repo\'s only remote → a picker',
+        'Picker choice is remembered per repo for the session',
+        'Threads through pulls, checkout by PR number, and tag push',
+      ],
+      settings: ['git-smart-checkout.defaultRemote'],
+    },
+  },
+  {
+    id: 'pr-review-worktree',
+    icon: '🔎',
+    title: 'PR Review in Worktree',
+    description:
+      'Open a GitHub PR in an isolated linked worktree, track its review metadata, and remove the review worktree later with dirty-state stash handling.',
+    command: 'GSC: PR Review in Worktree...',
+    color: 'purple',
+    details: {
+      longDescription:
+        'Review a GitHub PR in its own linked worktree so it never disturbs your main working tree. Review metadata is tracked automatically, and removal handles any leftover dirty state.',
+      highlights: [
+        'Isolated linked worktree per PR review',
+        'Review metadata tracked across sessions',
+        'Removal handles dirty-state stashing',
+        'See also Review PR by Number for a faster entry point',
+      ],
+      commands: [
+        'GSC: PR Review in Worktree...',
+        'GSC: Remove PR Review in Worktree...',
+      ],
+      settings: ['git-smart-checkout.defaultWorktreeDirectory'],
+      docsUrl: `${DOCS_BASE}pr-review-in-worktree.md`,
+    },
+  },
+  {
+    id: 'review-pr-by-number',
+    icon: '👀',
+    title: 'Review PR by Number',
+    description:
+      'Type a PR number or URL and land in an isolated review worktree in one step.',
+    command: 'GSC: Review PR by Number...',
+    tag: 'New',
+    color: 'orange',
+    details: {
+      longDescription:
+        'Skip the PR list picker entirely — type a PR number or paste a URL and go straight into an isolated review worktree.',
+      highlights: [
+        'Skips the PR list picker for a faster entry point',
+        'Works with GitHub Enterprise Server',
+        'The review worktree is tracked for later removal',
+      ],
+      commands: ['GSC: Review PR by Number...'],
+      docsUrl: `${DOCS_BASE}pr-review-in-worktree.md`,
+    },
+  },
+  {
+    id: 'github-enterprise',
+    icon: '🏢',
+    title: 'GitHub Enterprise',
+    description: 'All PR features work against GitHub Enterprise Server, not just github.com.',
+    color: 'purple',
+    details: {
+      longDescription:
+        'Every PR-related feature works the same way against a GitHub Enterprise Server instance as it does on github.com — the extension detects which host a repo belongs to and talks to the right API.',
+      highlights: [
+        'Host detection matches the repo remote to your configured base URL',
+        'PR Clone, Checkout by PR Number, PR Review in Worktree, and Review PR by Number all use <baseUrl>/api/v3',
+        'Web and compare links are built on the Enterprise host',
+      ],
+      settings: ['git-smart-checkout.githubEnterpriseBaseUrl'],
+    },
+  },
+  {
+    id: 'worktree-terminal',
+    icon: '🖥️',
+    title: 'Worktree Dev Terminal',
+    description:
+      'Open a new integrated terminal straight in any worktree directory. Pick a project, choose the worktree, and get a shell in the right working directory — no manual navigation.',
+    command: 'GSC: Open Worktree Dev Terminal...',
+    color: 'blue',
+    details: {
+      longDescription:
+        'Pick a project, choose a worktree, and get a shell already sitting in the right directory — no cd, no hunting through folders.',
+      highlights: [
+        'Pick a project, then a worktree, then get a shell in the right cwd',
+      ],
+      commands: ['GSC: Open Worktree Dev Terminal...'],
+      docsUrl: `${DOCS_BASE}open-worktree-dev-terminal.md`,
+    },
+  },
+  {
+    id: 'tag-template',
+    icon: '🏷️',
+    title: 'Tag from Template',
+    description:
+      'Generate version tags from a configurable template. Read values from package.json, extract ticket IDs from branch names, and auto-increment to avoid collisions.',
+    command: 'GSC: Create Tag from Template...',
+    color: 'blue',
+    details: {
+      longDescription:
+        'Build version tags from a reusable template — pull tokens from package.json or a branch-name regex, auto-increment to dodge collisions, and preview the result before creating anything.',
+      highlights: [
+        'Tokens sourced from package.json or branch-name regex',
+        'Auto-increment avoids tag collisions',
+        'Optional push via the resolved remote',
+        'Dry-run the result first with Template Preview',
+      ],
+      commands: [
+        'GSC: Create Tag from Template...',
+        'GSC: Preview Branch/Tag Template...',
+      ],
+      docsUrl: `${DOCS_BASE}create-tag-from-template.md`,
+    },
+  },
+  {
+    id: 'branch-template',
+    icon: '🌿',
+    title: 'Branch from Template',
+    description:
+      'Create and check out a branch from a reusable template. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
+    command: 'GSC: Create Branch from Template...',
+    color: 'green',
+    details: {
+      longDescription:
+        'Generate a branch name from a template populated by a Jira ticket\'s key and title, package.json values, a branch-name regex, or a custom script — then preview it before creating anything.',
+      highlights: [
+        'Jira key/title resolvers, with a guided Init Jira setup and the token in Secret Storage',
+        'package.json, regex, and custom-script resolvers',
+        'Dry-run the result first with Template Preview',
+      ],
+      commands: [
+        'GSC: Create Branch from Template...',
+        'GSC: Init Jira...',
+        'GSC: Set Jira Token...',
+      ],
+      docsUrl: `${DOCS_BASE}create-branch-from-template.md`,
+    },
+  },
+  {
+    id: 'template-preview',
+    icon: '🧪',
+    title: 'Branch/Tag Template Preview',
+    description:
+      'Dry-run your branch and tag templates — see exactly what each resolves to before creating anything.',
+    command: 'GSC: Preview Branch/Tag Template...',
+    color: 'blue',
+    details: {
+      longDescription:
+        'See exactly what a branch or tag template resolves to before it touches your repo — every resolver runs against your current context, and the output is shown for review only.',
+      highlights: [
+        'Shows resolver output — package.json, Jira, regex, scripts — without touching the repo',
+        'Great for debugging template configuration before you commit to it',
+      ],
+      commands: ['GSC: Preview Branch/Tag Template...'],
+      docsUrl: `${DOCS_BASE}create-branch-from-template.md`,
+    },
+  },
+  {
+    id: 'worktree-workflows',
+    icon: '🌲',
+    title: 'Worktree Workflows',
+    description:
+      'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
+    command: 'GSC: Move to New Worktree...',
+    color: 'green',
+    details: {
+      longDescription:
+        'A full toolkit for working across worktrees: spin up a new one and carry your WIP with it, copy staged or WIP changes between worktrees on demand, move WIP back to where you started, and clear out several worktrees at once.',
+      highlights: [
+        'Move to a new worktree, carrying WIP via your stash mode',
+        'Copy staged or WIP changes between worktrees',
+        'Move WIP changes back to the original worktree',
+        'Remove several worktrees at once with a single confirmation',
+        'New worktrees can run setup hooks automatically on creation',
+      ],
+      commands: [
+        'GSC: Move to New Worktree...',
+        'GSC: Copy Staged Changes to Worktree...',
+        'GSC: Copy WIP Changes to Worktree...',
+        'GSC: Move WIP from Worktree...',
+        'GSC: Remove Multiple Worktrees...',
+      ],
+      settings: ['git-smart-checkout.defaultWorktreeDirectory'],
+      docsUrl: `${DOCS_BASE}copy-changes-to-worktree.md`,
+    },
+  },
+  {
+    id: 'worktrees-explorer',
+    icon: '🗂️',
+    title: 'Worktrees Explorer',
+    description:
+      'A dedicated Worktrees view showing every worktree across your open repos with live status.',
+    tag: 'New',
+    color: 'purple',
+    details: {
+      longDescription:
+        'A dedicated view in the activity bar lists every worktree across your open repositories, with live status badges and one-click actions for the things you do most.',
+      highlights: [
+        'Dirty, ahead/behind, and PR-review status badges per worktree',
+        'Inline actions: Open in New Window, Dev Terminal, Copy WIP Here, Remove',
+        'Context menu: Add to Workspace, Copy Path, Reveal in Finder/Explorer',
+      ],
+    },
+  },
+  {
+    id: 'worktree-setup-hooks',
+    icon: '🪝',
+    title: 'Post-Worktree Setup Hooks',
+    description:
+      'New worktrees arrive ready to work — copy .env-style ignored files in and run your install command automatically.',
+    tag: 'New',
+    color: 'orange',
+    details: {
+      longDescription:
+        'Every new worktree can run a setup step automatically — copying over untracked config files and running whatever install or bootstrap command your project needs, so you\'re never left staring at a half-configured checkout.',
+      highlights: [
+        'Glob-based copy of untracked/ignored files, like .env',
+        'Runs a shell command after worktree creation',
+        'Opt-in separately for PR-clone worktrees',
+        'Workspace-provided values require explicit consent before running',
+      ],
+      settings: [
+        'git-smart-checkout.worktreeSetup.copyFiles',
+        'git-smart-checkout.worktreeSetup.command',
+        'git-smart-checkout.worktreeSetup.applyToPrCloneWorktrees',
+      ],
+    },
+  },
+  {
+    id: 'conflict-prediction',
+    icon: '🛡️',
+    title: 'Conflict Prediction',
+    description:
+      'Before switching branches, the extension detects which files would conflict with your stash. No more surprise merge disasters mid-checkout.',
+    color: 'green',
+    details: {
+      longDescription:
+        'Before any checkout carries your stash across, the extension checks which files would actually conflict — so you find out before the switch, not in the middle of it.',
+      highlights: [
+        'Detects conflicting files before the checkout happens',
+        'Feeds directly into Stash-Conflict Rescue if a conflict does slip through',
+      ],
+      docsUrl: `${DOCS_BASE}checkout-with-stash.md`,
+    },
+  },
+  {
+    id: 'stash-rescue',
+    icon: '🚑',
+    title: 'Stash-Conflict Rescue',
+    description:
+      'When restoring a stash conflicts, get guided rescue actions instead of a cryptic Git error.',
+    tag: 'New',
+    color: 'green',
+    details: {
+      longDescription:
+        'If restoring an auto-stash ever conflicts, you get clear reporting on exactly what clashed and a guided set of actions to resolve or recover — never a raw Git error to decode on your own.',
+      highlights: [
+        'Clear reporting on exactly what conflicted',
+        'Guided resolve/recover choices instead of a raw Git error',
+        'Your changes always survive safely in the auto-stash while you decide',
+        'Pairs with Conflict Prediction and the Auto-Stash Manager',
+      ],
+    },
+  },
+  {
+    id: 'auto-stash-manager',
+    icon: '📋',
+    title: 'Auto-Stash Manager',
+    description:
+      'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
+    command: 'GSC: Manage Auto-Stashes...',
+    tag: 'New',
+    color: 'green',
+    details: {
+      longDescription:
+        'Every auto-stash the extension creates is inspectable and recoverable — see the branch it came from, its age, file count, and a diff preview, then Apply, Pop, or Drop it with a single click.',
+      highlights: [
+        'Branch, age, file-count, and diff preview per stash',
+        'Apply, Pop, or Drop with one click',
+        'A safety net for every stash the extension ever creates',
+      ],
+      commands: ['GSC: Manage Auto-Stashes...'],
+      docsUrl: `${DOCS_BASE}manage-auto-stashes.md`,
+    },
+  },
+  {
+    id: 'status-bar',
+    icon: '📊',
+    title: 'Status Bar Integration',
+    description:
+      "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",
+    command: 'GSC: Quick Actions...',
+    color: 'purple',
+    details: {
+      longDescription:
+        'The status bar always shows your current stash mode at a glance. Click it to open a quick-actions menu covering checkout, pull/rebase, worktree commands, PR clone, and settings — each entry gated to what makes sense for your repo\'s current state.',
+      highlights: [
+        'Current stash mode visible at a glance',
+        'Quick Actions menu gated to repo state',
+        'A What\'s New notification appears after updates',
+        'Hide the status bar item entirely if you prefer',
+      ],
+      commands: ['GSC: Quick Actions...', 'GSC: Open Settings'],
+      settings: ['git-smart-checkout.showWhatsNew', 'git-smart-checkout.showStatusBar'],
+      docsUrl: `${DOCS_BASE}status-bar-quick-actions.md`,
+    },
+  },
+];

--- a/website/src/components/PlannedFeatures/PlannedFeatures.tsx
+++ b/website/src/components/PlannedFeatures/PlannedFeatures.tsx
@@ -10,20 +10,6 @@ interface PlannedFeature {
 
 const planned: PlannedFeature[] = [
   {
-    icon: '🕒',
-    tier: 1,
-    title: 'Recent Branches',
-    description:
-      'Automatically surface the last 5–10 branches you visited using reflog data, so your most relevant branches are always first.',
-  },
-  {
-    icon: '⚡',
-    tier: 1,
-    title: 'Inline Branch Actions',
-    description:
-      'Delete, rename, and push branches right from the checkout quick-pick using VS Code\'s per-item buttons — no terminal needed.',
-  },
-  {
     icon: '📡',
     tier: 1,
     title: 'Upstream Indicator',
@@ -42,7 +28,7 @@ const planned: PlannedFeature[] = [
     tier: 2,
     title: 'GitLab & Bitbucket',
     description:
-      'Extend PR Clone to support non-GitHub providers. GitLab (glab) and Bitbucket adapters behind a shared PrProvider interface.',
+      'The provider abstraction and host detection groundwork has shipped — GitLab (glab) and Bitbucket adapters behind that shared PrProvider interface are still planned.',
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds 8 new Features cards for everything shipped in v0.14.0 (Worktrees Explorer, Review PR by Number, Delete Merged Branches, Branch/Tag Template Preview, Post-Worktree Setup Hooks, Multi-Remote Support, GitHub Enterprise, Stash-Conflict Rescue), and folds the remaining 0.14.0 enhancements into the highlights of their existing card's new detail modal.
- Every card in the main Features grid is now clickable — opens an accessible `<dialog>`-based modal with a long description, highlights, commands/settings, docs link, and a reserved 16:9 media slot ("Demo video coming soon" placeholder until videos are recorded). `PlannedFeatures` cards are untouched (no `onClick`, stay non-interactive).
- Roadmap housekeeping: removes "Recent Branches" and "Inline Branch Actions" (shipped in 0.14.0), rewords "GitLab & Bitbucket" now that the provider-abstraction groundwork has landed.

## Test plan
- [x] `yarn build` (`tsc -b && vite build`) passes in `website/`
- [ ] Manual smoke test in a browser: click a feature card, confirm the modal opens with the placeholder video slot, Escape/backdrop-click/✕ all close it, and `#roadmap` cards remain non-clickable
- [ ] Check mobile layout (≤768px) renders the modal as a full-screen sheet

Note: I could not drive a real browser in this sandboxed environment, so the manual/browser checklist items above are unverified beyond static code review and the production build succeeding — please spot-check locally with `yarn dev` before merging.