### PR TITLE
fix(checkout): restore a branch's auto-stash when returning to it

### DIFF
--- a/docs/checkout-with-stash.md
+++ b/docs/checkout-with-stash.md
@@ -26,7 +26,7 @@ If a branch is already checked out in another Git worktree, the checkout picker 
 
 | Mode | Behavior |
 | --- | --- |
-| Auto stash in current branch | Stashes changes for the current branch before checkout. When you later return to that branch with the same mode, the matching stash is popped automatically. |
+| Auto stash in current branch | Stashes changes for the current branch (as `auto-stash-<branch>`) before checkout. When you later return to that branch the matching stash is restored — see [Restoring a branch's stash on return](#restoring-a-branchs-stash-on-return). |
 | Auto stash and pop in new branch | Stashes current changes, checks out the target branch, then pops the stash onto the target branch. |
 | Auto stash and apply in new branch | Stashes current changes, checks out the target branch, then applies the stash onto the target branch while keeping the stash entry available. |
 | No auto stash | Runs checkout without automatic stash handling. Git may block the checkout if local changes would be overwritten. |
@@ -40,6 +40,15 @@ Temporary stashes used by the pop/apply flows are named `auto-stash-<branch>-<yy
 > Stashes created by "Auto stash and apply in new branch" are not used by the automatic branch-restore flow. They remain available for manual stash access.
 
 Stashes are matched by their complete message after Git's `On <branch>: ` subject prefix. Message text containing `: ` is preserved when the extension locates a stash to pop or apply.
+
+## Restoring a Branch's Stash on Return
+
+A stash named `auto-stash-<branch>` (created by "Auto stash in current branch") belongs to that branch. Whenever you check out **to** that branch again — through any checkout command, in any mode, and even when your working tree is clean — Git Smart Checkout restores it:
+
+- In **Auto stash in current branch** mode the stash is popped automatically.
+- In every other mode (including **Manual**) you are prompted with **Pop** (restore and remove the stash) or **Apply (keep stash)** (restore but leave the stash in place). Dismiss the notification to leave the changes stashed.
+
+This is what lets you recover a branch's stashed work even when you return to it with a clean working tree, or in a mode where you are not asked to choose stash handling at checkout time. If restoring conflicts with the target branch, the extension shows the conflict-rescue notification instead of a generic error, and the stash is preserved.
 
 ## Pull After Checkout
 

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -33,6 +33,7 @@ export enum AnalyticsEvent {
   JiraTokenSet = 'jira_token_set',
   JiraInitialized = 'jira_initialized',
   AutoStashManaged = 'auto_stash_managed',
+  BranchStashRestored = 'branch_stash_restored',
   StatusBarMenuOpened = 'status_bar_menu_opened',
   SettingsOpened = 'settings_opened',
 }

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -302,6 +302,23 @@ export class AutoStashService {
         break;
     }
 
+    // Whenever we land on a branch that owns an `auto-stash-<branch>` stash, restore
+    // it — regardless of the mode used or whether the source tree was dirty. This is
+    // what makes returning to a branch with a clean tree (or in Manual / pop / apply
+    // modes) still recover that branch's stashed WIP. Only the explicit
+    // `autoStashForBranch` mode restores silently (its advertised contract); every
+    // other path prompts the user first.
+    if (outcome === 'completed') {
+      const restoreOutcome = await this.#restoreBranchOwnedStash(
+        git,
+        nextBranchName,
+        autoStashMode === AUTO_STASH_CURRENT_BRANCH
+      );
+      if (restoreOutcome === 'rescued') {
+        outcome = 'rescued';
+      }
+    }
+
     if (outcome === 'completed') {
       capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges });
 
@@ -345,31 +362,77 @@ export class AutoStashService {
     }
     await this.#maybePullAfterCheckout(git, nextBranch);
 
+    // NB: restoring the target branch's own `auto-stash-<branch>` stash is no
+    // longer done here. It is centralized in `checkoutAndStashChanges` so it runs
+    // after every checkout path (all modes, clean or dirty tree), not just this one.
+    return 'completed';
+  }
+
+  /**
+   * After landing on `branchName`, look for the branch's own un-dated
+   * `auto-stash-<branch>` stash and, if present, restore it. When `silent` is true
+   * (the explicit `autoStashForBranch` mode) it is popped without asking, preserving
+   * that mode's advertised auto-pop. Otherwise the user is prompted to Pop (restore
+   * and remove) or Apply (restore and keep) before anything is applied.
+   */
+  async #restoreBranchOwnedStash(
+    git: GitExecutor,
+    branchName: string,
+    silent: boolean
+  ): Promise<'restored' | 'none' | 'dismissed' | 'rescued'> {
+    const message = `${AUTO_STASH_PREFIX}-${branchName}`;
+
+    let stashExists: boolean;
     try {
-      const message = `${AUTO_STASH_PREFIX}-${nextBranch}`;
-      const isStashWithMessageExists = await git.isStashWithMessageExists(message);
-      this.logService.info(
-        `Stash is ${isStashWithMessageExists ? 'found' : 'not found'} for stash with message: '${message}'`
+      stashExists = await git.isStashWithMessageExists(message);
+    } catch (e) {
+      this.logService.info(`Failed to check for auto-stash '${message}': ${e instanceof Error ? e.message : String(e)}`);
+      return 'none';
+    }
+    this.logService.info(`Stash is ${stashExists ? 'found' : 'not found'} for stash with message: '${message}'`);
+    if (!stashExists) {
+      return 'none';
+    }
+
+    // Decide how to restore: silently pop for the auto mode, otherwise ask.
+    let apply = false;
+    if (!silent) {
+      const POP = 'Pop';
+      const APPLY = 'Apply (keep stash)';
+      const choice = await window.showInformationMessage(
+        `Branch '${branchName}' has auto-stashed changes. Restore them?`,
+        POP,
+        APPLY
       );
-      if (isStashWithMessageExists) {
-        await git.popStash(message);
+      if (choice === POP) {
+        apply = false;
+      } else if (choice === APPLY) {
+        apply = true;
+      } else {
+        // Notification dismissed — leave the stash untouched.
+        return 'dismissed';
       }
+    }
+
+    try {
+      await git.popStash(message, apply);
+      capture(AnalyticsEvent.BranchStashRestored, { silent, apply });
+      return 'restored';
     } catch (e) {
       const conflicts = await git.getConflictedFiles();
       if (conflicts.length > 0) {
-        await offerConflictRescue(git, conflicts, 'pop');
+        await offerConflictRescue(git, conflicts, apply ? 'apply' : 'pop');
         return 'rescued';
       }
       handleErrorMessage(
         e,
         'No stash found',
-        'No stash to pop on the new branch.',
-        'Failed to pop the stash on the new branch.',
+        'No auto-stash to restore on this branch.',
+        'Failed to restore the auto-stash on this branch.',
         this.logService
       );
+      return 'none';
     }
-
-    return 'completed';
   }
 
   async #confirmStashConflicts(files: string[], operation: string): Promise<boolean> {

--- a/src/test/unit/restoreBranchOwnedStash.test.ts
+++ b/src/test/unit/restoreBranchOwnedStash.test.ts
@@ -1,0 +1,167 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import {
+  AUTO_STASH_CURRENT_BRANCH,
+  AUTO_STASH_IGNORE,
+} from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { IGitRef } from '../../common/git/types';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const nextBranch: IGitRef = {
+  name: 'feature-x',
+  fullName: 'feature-x',
+  remote: false,
+  isTag: false,
+} as unknown as IGitRef;
+
+// The branch-owned stash for `feature-x` is the un-dated `auto-stash-<branch>`.
+const EXPECTED_STASH_MESSAGE = 'auto-stash-feature-x';
+
+interface PopCall {
+  name: string;
+  apply: boolean;
+}
+
+function makeGitStub(popCalls: PopCall[], overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    // Default to a clean tree — the reported scenario is returning to a branch
+    // with no local changes.
+    isWorkdirHasChanges: async () => false,
+    getStashConflictPreview: async () => [],
+    createStash: async () => {},
+    checkout: async () => {},
+    hasUpstreamBranch: async () => false,
+    isStashWithMessageExists: async () => true,
+    popStash: async (name: string, apply = false) => {
+      popCalls.push({ name, apply });
+    },
+    getConflictedFiles: async () => [],
+    isMergeInProgress: async () => false,
+    isCherryPickInProgress: async () => false,
+    resetMerge: async () => {},
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+function makeConfigManagerStub(): ConfigurationManager {
+  return {
+    get: () => ({ pullAfterCheckout: 'ffOnly' }),
+  } as unknown as ConfigurationManager;
+}
+
+describe('AutoStashService — branch-owned auto-stash restore on return', () => {
+  let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+  let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
+  let infoPrompts: string[];
+
+  beforeEach(() => {
+    originalShowInformationMessage = vscode.window.showInformationMessage;
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    infoPrompts = [];
+  });
+
+  afterEach(() => {
+    (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+  });
+
+  function stubInfoPrompt(response: string | undefined) {
+    (vscode.window as any).showInformationMessage = async (message: string) => {
+      infoPrompts.push(message);
+      return response;
+    };
+  }
+
+  it('reported bug: clean tree + AUTO_STASH_IGNORE + existing branch stash → prompts, and "Pop" restores it', async () => {
+    stubInfoPrompt('Pop');
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(makeGitStub(popCalls), 'main', nextBranch, AUTO_STASH_IGNORE);
+
+    assert.strictEqual(outcome, 'completed');
+    assert.strictEqual(infoPrompts.length, 1);
+    assert.match(infoPrompts[0], /Branch 'feature-x' has auto-stashed changes/);
+    assert.deepStrictEqual(popCalls, [{ name: EXPECTED_STASH_MESSAGE, apply: false }]);
+  });
+
+  it('no branch stash present → no prompt and no restore', async () => {
+    stubInfoPrompt('Pop');
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(
+      makeGitStub(popCalls, { isStashWithMessageExists: async () => false }),
+      'main',
+      nextBranch,
+      AUTO_STASH_IGNORE
+    );
+
+    assert.strictEqual(outcome, 'completed');
+    assert.strictEqual(infoPrompts.length, 0);
+    assert.strictEqual(popCalls.length, 0);
+  });
+
+  it('AUTO_STASH_CURRENT_BRANCH restores silently (no prompt) — preserves the existing auto-pop contract', async () => {
+    stubInfoPrompt('Pop');
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(makeGitStub(popCalls), 'main', nextBranch, AUTO_STASH_CURRENT_BRANCH);
+
+    assert.strictEqual(outcome, 'completed');
+    assert.strictEqual(infoPrompts.length, 0, 'auto mode must not prompt');
+    assert.deepStrictEqual(popCalls, [{ name: EXPECTED_STASH_MESSAGE, apply: false }]);
+  });
+
+  it('prompt "Apply (keep stash)" restores via apply (keeps the stash)', async () => {
+    stubInfoPrompt('Apply (keep stash)');
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(makeGitStub(popCalls), 'main', nextBranch, AUTO_STASH_IGNORE);
+
+    assert.strictEqual(outcome, 'completed');
+    assert.deepStrictEqual(popCalls, [{ name: EXPECTED_STASH_MESSAGE, apply: true }]);
+  });
+
+  it('dismissed prompt leaves the stash untouched', async () => {
+    stubInfoPrompt(undefined);
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const outcome = await service.checkoutAndStashChanges(makeGitStub(popCalls), 'main', nextBranch, AUTO_STASH_IGNORE);
+
+    assert.strictEqual(outcome, 'completed');
+    assert.strictEqual(infoPrompts.length, 1);
+    assert.strictEqual(popCalls.length, 0);
+  });
+
+  it('conflict while restoring → rescue notification, outcome "rescued"', async () => {
+    stubInfoPrompt('Pop');
+    const warnings: string[] = [];
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnings.push(message);
+      return undefined;
+    };
+    const popCalls: PopCall[] = [];
+    const service = new AutoStashService(makeConfigManagerStub(), mockLogService);
+
+    const git = makeGitStub(popCalls, {
+      popStash: async () => {
+        throw new Error('conflict during pop');
+      },
+      getConflictedFiles: async () => ['a.txt'],
+    });
+
+    const outcome = await service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_IGNORE);
+
+    assert.strictEqual(outcome, 'rescued');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /Stash restored with conflicts: 1 file\(s\) need resolution/);
+  });
+});

--- a/src/test/unit/stashConflictRouting.test.ts
+++ b/src/test/unit/stashConflictRouting.test.ts
@@ -72,7 +72,7 @@ describe('AutoStashService — conflict rescue routing', () => {
 
     await assert.rejects(
       () => service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_AND_POP_IN_NEW_BRANCH),
-      /Failed to pop the stash on the new branch/
+      /Failed to (pop the stash on the new branch|restore the auto-stash on this branch)/
     );
   });
 
@@ -103,7 +103,7 @@ describe('AutoStashService — conflict rescue routing', () => {
 
     await assert.rejects(
       () => service.checkoutAndStashChanges(git, 'main', nextBranch, AUTO_STASH_CURRENT_BRANCH),
-      /Failed to pop the stash on the new branch/
+      /Failed to (pop the stash on the new branch|restore the auto-stash on this branch)/
     );
   });
 


### PR DESCRIPTION
## Summary
- **Bug:** with Manual mode, stashing changes into `auto-stash-main` on the way out (via "Auto stash in current branch") and later returning to `main` with a **clean** working tree did **not** restore the stash, and gave no prompt. The WIP was stranded, recoverable only through `GSC: Manage Auto-Stashes...`.
- **Root cause:** the `auto-stash-<branch>` restore step lived inside `doAutoStashCurrentBranch` and only ran in `AUTO_STASH_CURRENT_BRANCH` mode. A clean tree forces `AUTO_STASH_IGNORE` in both checkout commands, which does a plain checkout and never reaches the restore.
- **Fix:** the restore is centralized in `AutoStashService.checkoutAndStashChanges`, so it runs after **every** completed checkout — any mode, clean or dirty tree, and for both `Checkout to…` and `Checkout previous branch`.
- **UX:** `autoStashForBranch` mode keeps its existing **silent** auto-pop (advertised contract, zero regression). Every other mode (including **Manual**) now shows a non-modal **Pop / Apply (keep stash)** prompt; dismissing leaves the stash in place. Restore conflicts route to the existing conflict-rescue notification.

## How to verify manually
1. Set mode to **Manual**. On `main`, edit a tracked file.
2. `GSC: Checkout to…` → pick `branch1` → choose **Auto stash in current branch**. Tree is now clean; `auto-stash-main` exists.
3. `GSC: Checkout previous branch` (or `Checkout to… → main`).
   - **Expected:** notification "Branch 'main' has auto-stashed changes. Restore them?" with **Pop** / **Apply (keep stash)**. Pop restores the edit and removes the stash (`git stash list` confirms).
4. Regression: set mode to **Auto stash in current branch** and repeat the round-trip — the stash is restored **silently** (no prompt), as before.

## Test plan
- [x] Type check + lint (`yarn compile`) — 0 errors
- [x] Unit tests (`yarn test:unit`) — 678 passing, incl. new `restoreBranchOwnedStash.test.ts` (6 cases: clean-tree prompt+Pop, no-stash no-op, silent auto mode, Apply-keeps-stash, dismissal, conflict→rescue) and updated `stashConflictRouting.test.ts`
- [ ] Manual smoke test in the VS Code extension host