### PR TITLE
fix(worktrees): fix delete crash and move title buttons into the tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
       {
         "command": "git-smart-checkout.worktree.open",
         "title": "Open Worktree in New Window",
+        "icon": "$(folder-opened)",
         "category": "GSC"
       },
       {
@@ -328,16 +329,6 @@
           "command": "git-smart-checkout.worktree.refresh",
           "when": "view == git-smart-checkout.worktrees",
           "group": "navigation@1"
-        },
-        {
-          "command": "git-smart-checkout.moveToNewWorktree",
-          "when": "view == git-smart-checkout.worktrees",
-          "group": "navigation@2"
-        },
-        {
-          "command": "git-smart-checkout.removeMultipleWorktrees",
-          "when": "view == git-smart-checkout.worktrees && git-smart-checkout.hasMultipleRemovableWorktrees",
-          "group": "navigation@3"
         },
         {
           "command": "git-smart-checkout.prCancelCloneMenu",

--- a/src/commands/utils/resolveWorktreeArg.ts
+++ b/src/commands/utils/resolveWorktreeArg.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+
+export interface ResolvedWorktreeArg {
+  worktreePath: string;
+  repositoryPath?: string;
+}
+
+/**
+ * `view/item/context` (including `inline`) commands are invoked by VS Code with the tree
+ * element itself as the first argument, not `TreeItem.command.arguments` (those only apply
+ * to the row's default click command). Normalizes whatever shape shows up — a plain string,
+ * a Uri, or a WorktreeTreeItem — into a path string.
+ */
+export function resolveWorktreeArg(arg: unknown, repositoryPath?: string): ResolvedWorktreeArg | undefined {
+  if (typeof arg === 'string') {
+    return arg ? { worktreePath: arg, repositoryPath } : undefined;
+  }
+  if (arg instanceof vscode.Uri) {
+    return { worktreePath: arg.fsPath, repositoryPath };
+  }
+  if (isWorktreeTreeItemLike(arg)) {
+    return { worktreePath: arg.worktree.path, repositoryPath: arg.repositoryPath ?? repositoryPath };
+  }
+  return undefined;
+}
+
+function isWorktreeTreeItemLike(
+  arg: unknown
+): arg is { worktree: { path: string }; repositoryPath?: string } {
+  if (typeof arg !== 'object' || arg === null) {
+    return false;
+  }
+  const candidate = arg as { worktree?: unknown; repositoryPath?: unknown };
+  return (
+    typeof candidate.worktree === 'object' &&
+    candidate.worktree !== null &&
+    typeof (candidate.worktree as { path?: unknown }).path === 'string' &&
+    (candidate.repositoryPath === undefined || typeof candidate.repositoryPath === 'string')
+  );
+}

--- a/src/commands/utils/worktreeRemoval.ts
+++ b/src/commands/utils/worktreeRemoval.ts
@@ -27,6 +27,9 @@ export function isSameOrChildPath(candidatePath: string, parentPath: string): bo
 }
 
 export function normalizePathForComparison(targetPath: string): string {
+  if (typeof targetPath !== 'string') {
+    return '';
+  }
   try {
     return fs.realpathSync.native(targetPath);
   } catch {

--- a/src/commands/worktreeTreeActionCommand.ts
+++ b/src/commands/worktreeTreeActionCommand.ts
@@ -5,6 +5,7 @@ import { RemoveWorktreeCommand } from './removeWorktreeCommand';
 import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
 import { LoggingService } from '../logging/loggingService';
 import { addToWorkspace } from './utils/worktreeCompletionActions';
+import { resolveWorktreeArg } from './utils/resolveWorktreeArg';
 import { BaseCommand } from './command';
 
 export type WorktreeTreeAction =
@@ -31,8 +32,12 @@ export class WorktreeTreeActionCommand extends BaseCommand {
     super(logService);
   }
 
-  async execute(worktreePath?: string, repositoryPath?: string): Promise<void> {
-    if (!worktreePath) return;
+  async execute(arg?: unknown, repositoryPathArg?: string): Promise<void> {
+    const resolved = resolveWorktreeArg(arg, repositoryPathArg);
+    if (!resolved) {
+      return;
+    }
+    const { worktreePath, repositoryPath } = resolved;
 
     switch (this.action) {
       case 'open':

--- a/src/test/unit/resolveWorktreeArg.test.ts
+++ b/src/test/unit/resolveWorktreeArg.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { resolveWorktreeArg } from '../../commands/utils/resolveWorktreeArg';
+
+describe('resolveWorktreeArg', () => {
+  it('passes through a plain string path', () => {
+    assert.deepStrictEqual(resolveWorktreeArg('/repo/feature', '/repo'), {
+      worktreePath: '/repo/feature',
+      repositoryPath: '/repo',
+    });
+  });
+
+  it('extracts fsPath from a Uri', () => {
+    const uri = vscode.Uri.file('/repo/feature');
+    assert.deepStrictEqual(resolveWorktreeArg(uri, '/repo'), {
+      worktreePath: '/repo/feature',
+      repositoryPath: '/repo',
+    });
+  });
+
+  it('extracts the path from a WorktreeTreeItem-shaped object, the argument VS Code actually sends for inline/context-menu commands', () => {
+    const fakeTreeItem = {
+      worktree: { path: '/repo/feature' },
+      repositoryPath: '/repo',
+      contextValue: 'worktree linked clean',
+    };
+    assert.deepStrictEqual(resolveWorktreeArg(fakeTreeItem), {
+      worktreePath: '/repo/feature',
+      repositoryPath: '/repo',
+    });
+  });
+
+  it('falls back to a separately passed repositoryPath when the tree item has none', () => {
+    const fakeTreeItem = { worktree: { path: '/repo/feature' } };
+    assert.deepStrictEqual(resolveWorktreeArg(fakeTreeItem, '/repo'), {
+      worktreePath: '/repo/feature',
+      repositoryPath: '/repo',
+    });
+  });
+
+  it('returns undefined for unrecognized shapes', () => {
+    assert.strictEqual(resolveWorktreeArg(undefined), undefined);
+    assert.strictEqual(resolveWorktreeArg(null), undefined);
+    assert.strictEqual(resolveWorktreeArg(''), undefined);
+    assert.strictEqual(resolveWorktreeArg(42), undefined);
+    assert.strictEqual(resolveWorktreeArg({}), undefined);
+    assert.strictEqual(resolveWorktreeArg({ worktree: {} }), undefined);
+  });
+});

--- a/src/test/unit/worktreeTreeDataProvider.test.ts
+++ b/src/test/unit/worktreeTreeDataProvider.test.ts
@@ -1,6 +1,11 @@
 import * as assert from 'assert';
 import * as os from 'os';
-import { WorktreeTreeDataProvider, WorktreeTreeItem } from '../../view/WorktreeTreeDataProvider';
+import {
+  WorktreeActionTreeItem,
+  WorktreeRepositoryTreeItem,
+  WorktreeTreeDataProvider,
+  WorktreeTreeItem,
+} from '../../view/WorktreeTreeDataProvider';
 import { PRReviewWorktreeStore } from '../../services/prReviewWorktreeStore';
 import { mockLogService } from '../e2e/helpers/mockLogService';
 
@@ -71,6 +76,35 @@ describe('WorktreeTreeItem', () => {
     item.applyEnrichment({ isDirty: false, dirtyFileCount: 0, isPrReview: false });
 
     assert.strictEqual(item.description, '~/projects/repo-review');
+  });
+});
+
+describe('WorktreeRepositoryTreeItem', () => {
+  it('uses a contextValue that does not collide with the \\bworktree\\b menu matcher', () => {
+    const item = new WorktreeRepositoryTreeItem('/repo', []);
+    assert.strictEqual(item.contextValue, 'worktreeRepository');
+    assert.ok(!/\bworktree\b/.test(item.contextValue));
+  });
+});
+
+describe('WorktreeTreeDataProvider.getChildren action rows', () => {
+  function makeProvider() {
+    const store = { getForRepository: async () => [] } as unknown as PRReviewWorktreeStore;
+    return new WorktreeTreeDataProvider(mockLogService, store);
+  }
+
+  it('lists a "Move to New Worktree" action row before any worktrees, with no "Remove Multiple" row when there are none to remove', async () => {
+    const provider = makeProvider();
+    const children = await provider.getChildren();
+
+    const actionRows = children.filter((child) => child instanceof WorktreeActionTreeItem);
+    assert.strictEqual(actionRows.length, 1);
+    assert.strictEqual(actionRows[0].label, 'Move to New Worktree…');
+    assert.strictEqual(
+      (actionRows[0].command as { command: string }).command,
+      'git-smart-checkout.moveToNewWorktree'
+    );
+    assert.ok(!/\bworktree\b/.test(String(actionRows[0].contextValue)));
   });
 });
 

--- a/src/view/WorktreeTreeDataProvider.ts
+++ b/src/view/WorktreeTreeDataProvider.ts
@@ -92,12 +92,26 @@ export class WorktreeRepositoryTreeItem extends vscode.TreeItem {
   constructor(public readonly repositoryPath: string, public readonly children: WorktreeTreeItem[]) {
     super(path.basename(repositoryPath) || repositoryPath, vscode.TreeItemCollapsibleState.Expanded);
     this.description = repositoryPath;
-    this.contextValue = 'worktree.repository';
+    this.contextValue = 'worktreeRepository';
     this.iconPath = new vscode.ThemeIcon('repo');
   }
 }
 
-type WorktreeNode = WorktreeTreeItem | WorktreeRepositoryTreeItem;
+/**
+ * Full-width action row rendered at the top of the tree, replacing the text buttons that
+ * used to live in the view/title toolbar (VS Code renders title-bar buttons without an
+ * icon as text, which crowded out the view header).
+ */
+export class WorktreeActionTreeItem extends vscode.TreeItem {
+  constructor(label: string, icon: string, command: string) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.contextValue = 'worktreeAction';
+    this.command = { command, title: label };
+  }
+}
+
+type WorktreeNode = WorktreeTreeItem | WorktreeRepositoryTreeItem | WorktreeActionTreeItem;
 
 const DEFAULT_DEBOUNCE_MS = 2000;
 
@@ -119,17 +133,39 @@ export class WorktreeTreeDataProvider implements vscode.TreeDataProvider<Worktre
     return item;
   }
 
-  async getChildren(element?: WorktreeRepositoryTreeItem): Promise<WorktreeNode[]> {
+  async getChildren(element?: WorktreeNode): Promise<WorktreeNode[]> {
     if (!this.loaded) {
       await this.load();
     }
-    if (element) {
+    if (element instanceof WorktreeRepositoryTreeItem) {
       return element.children;
     }
-    if (this.repositories.length > 1) {
-      return this.repositories;
+    if (element) {
+      return [];
     }
-    return this.items;
+    const nodes = this.repositories.length > 1 ? this.repositories : this.items;
+    return [...this.getActionItems(), ...nodes];
+  }
+
+  private getActionItems(): WorktreeActionTreeItem[] {
+    const removableCount = this.items.filter((item) => !item.isMain).length;
+    const actions = [
+      new WorktreeActionTreeItem(
+        'Move to New Worktree…',
+        'new-folder',
+        'git-smart-checkout.moveToNewWorktree'
+      ),
+    ];
+    if (removableCount >= 2) {
+      actions.push(
+        new WorktreeActionTreeItem(
+          'Remove Multiple Worktrees…',
+          'trash',
+          'git-smart-checkout.removeMultipleWorktrees'
+        )
+      );
+    }
+    return actions;
   }
 
   /** Reloads immediately. Used for explicit user-triggered refreshes. */


### PR DESCRIPTION
## Summary
- Fixes a crash when clicking the trash/delete icon on a worktree row in the "GIT SMART CHECKOUT: WORKTREES" view: `The "paths[0]" argument must be of type string. Received an instance of r0`. VS Code invokes `view/item/context` (including inline) commands with the tree element itself as the argument, not the path string from `TreeItem.command.arguments` — every action in `WorktreeTreeActionCommand` (open/terminal/copyWip/**remove**/copyPath/reveal/addToWorkspace) assumed a string and broke or silently misbehaved on the object. Added `resolveWorktreeArg()` to normalize string/`Uri`/tree-item argument shapes, plus a defensive string guard in `normalizePathForComparison`.
- Moves "Move to New Worktree" and "Remove Multiple Worktrees" out of the view's title-bar toolbar (they had no icon, so VS Code rendered them as text buttons that crowded out the "GIT SMART CHECKOUT: WORKTREES" header) into a labelled action-row section at the top of the tree itself.
- Renamed `WorktreeRepositoryTreeItem`'s `contextValue` from `worktree.repository` to `worktreeRepository` — the old value spuriously matched the `/\bworktree\b/` menu regex (`\b` matches at `.`), leaking per-worktree row actions onto repository group rows.

## How to test manually
1. Open a workspace with at least 2 git worktrees (main + 1 linked).
2. Open the "GIT SMART CHECKOUT: WORKTREES" view.
3. Confirm the header reads "GIT SMART CHECKOUT: WORKTREES" in full, with only the refresh icon in the title bar.
4. Confirm "Move to New Worktree…" (and, with ≥2 removable worktrees, "Remove Multiple Worktrees…") appear as labelled rows at the top of the tree, and that clicking them launches the corresponding command.
5. Click the trash icon on a linked worktree row — the Remove Worktree progress/confirmation flow should run with no `paths[0]` error.
6. Exercise Open / Terminal / Copy WIP / Copy Path / Reveal / Add to Workspace from the row and its right-click context menu.
7. Right-click a repository group row in a multi-root workspace — per-worktree actions should no longer appear there.

## Test plan
- [x] `yarn compile` (type check + lint) passes
- [x] `yarn test:unit` passes (685 tests, including new `resolveWorktreeArg` and tree-provider action-row tests)
- [ ] Manual smoke test performed in VS Code extension host