### PR TITLE
fix(website): use Font Awesome free icons for feature cards

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,9 @@
     "deploy": "bash scripts/deploy.sh"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.3.1",
+    "@fortawesome/free-solid-svg-icons": "^7.3.1",
+    "@fortawesome/react-fontawesome": "^3.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/website/src/components/FeatureCard/FeatureCard.module.css
+++ b/website/src/components/FeatureCard/FeatureCard.module.css
@@ -34,15 +34,20 @@
 }
 
 .cardIcon {
-  font-size: 28px;
+  font-size: 24px;
   line-height: 1;
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: 4px;
+  width: 1.25em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
 }
 
 .compact .cardIcon {
-  font-size: 22px;
-  margin-top: 1px;
+  font-size: 20px;
+  margin-top: 3px;
 }
 
 .cardBody {

--- a/website/src/components/FeatureCard/FeatureCard.tsx
+++ b/website/src/components/FeatureCard/FeatureCard.tsx
@@ -1,3 +1,5 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import type { ReactNode } from 'react';
 
 import { getCommandPaletteShortcut } from '../../utils/shortcuts';
@@ -6,7 +8,7 @@ import styles from './FeatureCard.module.css';
 export type FeatureCardTone = 'blue' | 'green' | 'purple' | 'orange';
 
 interface FeatureCardProps {
-  icon: string;
+  icon: IconDefinition;
   title: string;
   description: ReactNode;
   command?: string;
@@ -41,7 +43,9 @@ export function FeatureCard({
 
   return (
     <article className={className}>
-      <div className={styles.cardIcon}>{icon}</div>
+      <div className={styles.cardIcon} aria-hidden="true">
+        <FontAwesomeIcon icon={icon} />
+      </div>
       <div className={styles.cardBody}>
         <div className={styles.cardTitleRow}>
           <Title className={styles.cardTitle}>

--- a/website/src/components/FeatureModal/FeatureModal.module.css
+++ b/website/src/components/FeatureModal/FeatureModal.module.css
@@ -115,8 +115,9 @@
   gap: 10px;
 }
 .icon {
-  font-size: 24px;
+  font-size: 22px;
   line-height: 1;
+  color: var(--accent);
 }
 .titleRow h3 {
   font-size: 20px;

--- a/website/src/components/FeatureModal/FeatureModal.tsx
+++ b/website/src/components/FeatureModal/FeatureModal.tsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useRef, type MouseEvent } from 'react';
 
 import type { Feature } from '../Features/featuresData';
@@ -77,7 +78,7 @@ export function FeatureModal({ feature, onClose }: FeatureModalProps) {
         <div className={styles.body}>
           <header className={styles.titleRow}>
             <span className={styles.icon} aria-hidden="true">
-              {feature.icon}
+              <FontAwesomeIcon icon={feature.icon} />
             </span>
             <h3 id="feature-modal-title">{feature.title}</h3>
             {feature.tag && <span className={styles.tag}>{feature.tag}</span>}

--- a/website/src/components/Features/featuresData.tsx
+++ b/website/src/components/Features/featuresData.tsx
@@ -1,3 +1,30 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faArrowRotateLeft,
+  faArrowsRotate,
+  faBoxArchive,
+  faBroom,
+  faBuilding,
+  faClone,
+  faCodeBranch,
+  faCodeMerge,
+  faCodePullRequest,
+  faEye,
+  faFlask,
+  faFolderTree,
+  faHashtag,
+  faMagnifyingGlass,
+  faPlug,
+  faSatelliteDish,
+  faSeedling,
+  faShieldHalved,
+  faStar,
+  faTag,
+  faTerminal,
+  faTree,
+  faTruckMedical,
+  faWindowMaximize,
+} from '@fortawesome/free-solid-svg-icons';
 import type { ReactNode } from 'react';
 
 import type { FeatureCardTone } from '../FeatureCard/FeatureCard';
@@ -22,7 +49,7 @@ export interface FeatureDetails {
 
 export interface Feature {
   id: string; // unique kebab-case slug; used as React key
-  icon: string;
+  icon: IconDefinition; // Font Awesome free (solid) icon definition
   title: string;
   description: ReactNode; // short card copy — unchanged from today
   command?: string;
@@ -36,7 +63,7 @@ const DOCS_BASE = 'https://github.com/zaknafeyn/git-smart-checkout/blob/main/doc
 export const features: Feature[] = [
   {
     id: 'smart-checkout',
-    icon: '🔄',
+    icon: faCodeBranch,
     title: 'Smart Branch Checkout',
     description:
       'Switch branches without worrying about uncommitted changes. Choose your stash strategy once or per checkout — the extension handles everything else.',
@@ -59,7 +86,7 @@ export const features: Feature[] = [
   },
   {
     id: 'pull-with-stash',
-    icon: '📥',
+    icon: faClone,
     title: 'Pull with Stash',
     description:
       'Pull the latest changes from remote without losing your local work. Changes are stashed before the pull and restored automatically after.',
@@ -79,7 +106,7 @@ export const features: Feature[] = [
   },
   {
     id: 'pull-with-rebase',
-    icon: '🔃',
+    icon: faArrowsRotate,
     title: 'Pull with Rebase',
     description:
       'Pull with rebase while preserving local changes. The extension stashes your work, rebases onto the remote branch, and restores your changes afterward.',
@@ -99,7 +126,7 @@ export const features: Feature[] = [
   },
   {
     id: 'rebase-with-stash',
-    icon: '🔀',
+    icon: faCodeMerge,
     title: 'Rebase with Stash',
     description:
       'Rebase the current branch onto any other branch, tag, or ref while your local changes are stashed and restored automatically — no need to commit or clean up first.',
@@ -119,7 +146,7 @@ export const features: Feature[] = [
   },
   {
     id: 'checkout-previous',
-    icon: '⬅️',
+    icon: faArrowRotateLeft,
     title: 'Checkout Previous Branch',
     description: (
       <>
@@ -142,7 +169,7 @@ export const features: Feature[] = [
   },
   {
     id: 'preferred-branches',
-    icon: '⭐',
+    icon: faStar,
     title: 'Preferred Branches',
     description:
       'Star the branches, tags, and remotes you use most — they float to the top of the checkout picker, marked with a star. Toggle a star straight from the picker, no settings file to edit.',
@@ -162,7 +189,7 @@ export const features: Feature[] = [
   },
   {
     id: 'delete-merged-branches',
-    icon: '🧹',
+    icon: faBroom,
     title: 'Delete Merged Branches',
     description:
       'Sweep away branches already merged or whose upstream is gone, in one multi-select pass.',
@@ -183,7 +210,7 @@ export const features: Feature[] = [
   },
   {
     id: 'pr-clone',
-    icon: '🍒',
+    icon: faCodePullRequest,
     title: 'GitHub PR Clone',
     description:
       'Cherry-pick individual commits from any GitHub PR into a new branch and open a new pull request — without merging the entire PR. The description preview renders full GitHub-Flavored Markdown and can pre-fill from the repo PR template.',
@@ -211,7 +238,7 @@ export const features: Feature[] = [
   },
   {
     id: 'checkout-by-pr',
-    icon: '#️⃣',
+    icon: faHashtag,
     title: 'Checkout by PR Number',
     description:
       "Check out any GitHub pull request's branch by its PR number or URL, with the same auto-stash handling as a regular checkout. No more copying branch names by hand.",
@@ -231,7 +258,7 @@ export const features: Feature[] = [
   },
   {
     id: 'multi-remote',
-    icon: '🛰️',
+    icon: faSatelliteDish,
     title: 'Multi-Remote Support',
     description:
       'Fork-friendly — the right remote is picked automatically for fetch and push, or pin one with defaultRemote.',
@@ -249,7 +276,7 @@ export const features: Feature[] = [
   },
   {
     id: 'pr-review-worktree',
-    icon: '🔎',
+    icon: faMagnifyingGlass,
     title: 'PR Review in Worktree',
     description:
       'Open a GitHub PR in an isolated linked worktree, track its review metadata, and remove the review worktree later with dirty-state stash handling.',
@@ -274,7 +301,7 @@ export const features: Feature[] = [
   },
   {
     id: 'review-pr-by-number',
-    icon: '👀',
+    icon: faEye,
     title: 'Review PR by Number',
     description:
       'Type a PR number or URL and land in an isolated review worktree in one step.',
@@ -299,7 +326,7 @@ export const features: Feature[] = [
   },
   {
     id: 'github-enterprise',
-    icon: '🏢',
+    icon: faBuilding,
     title: 'GitHub Enterprise',
     description: 'All PR features work against GitHub Enterprise Server, not just github.com.',
     color: 'purple',
@@ -316,7 +343,7 @@ export const features: Feature[] = [
   },
   {
     id: 'worktree-terminal',
-    icon: '🖥️',
+    icon: faTerminal,
     title: 'Worktree Dev Terminal',
     description:
       'Open a new integrated terminal straight in any worktree directory. Pick a project, choose the worktree, and get a shell in the right working directory — no manual navigation.',
@@ -334,7 +361,7 @@ export const features: Feature[] = [
   },
   {
     id: 'tag-template',
-    icon: '🏷️',
+    icon: faTag,
     title: 'Tag from Template',
     description:
       'Generate version tags from configurable, named templates. Read values from package.json, extract ticket IDs from branch names, and auto-increment to avoid collisions.',
@@ -359,7 +386,7 @@ export const features: Feature[] = [
   },
   {
     id: 'branch-template',
-    icon: '🌿',
+    icon: faSeedling,
     title: 'Branch from Template',
     description:
       'Create and check out a branch from reusable, named templates. Pull the key and title straight from a Jira ticket, or fill values from package.json, branch-name regex, and custom scripts.',
@@ -384,7 +411,7 @@ export const features: Feature[] = [
   },
   {
     id: 'template-preview',
-    icon: '🧪',
+    icon: faFlask,
     title: 'Branch/Tag Template Preview',
     description:
       'Dry-run your branch and tag templates — see exactly what each resolves to before creating anything.',
@@ -403,7 +430,7 @@ export const features: Feature[] = [
   },
   {
     id: 'worktree-workflows',
-    icon: '🌲',
+    icon: faTree,
     title: 'Worktree Workflows',
     description:
       'Create a new branch worktree, carry local changes with your stash mode, copy staged or WIP changes between worktrees, move WIP back, and remove several worktrees at once with a single confirmation.',
@@ -432,7 +459,7 @@ export const features: Feature[] = [
   },
   {
     id: 'worktrees-explorer',
-    icon: '🗂️',
+    icon: faFolderTree,
     title: 'Worktrees Explorer',
     description:
       'A dedicated Worktrees view showing every worktree across your open repos with live status.',
@@ -450,7 +477,7 @@ export const features: Feature[] = [
   },
   {
     id: 'worktree-setup-hooks',
-    icon: '🪝',
+    icon: faPlug,
     title: 'Post-Worktree Setup Hooks',
     description:
       'New worktrees arrive ready to work — copy .env-style ignored files in and run your install command automatically.',
@@ -474,7 +501,7 @@ export const features: Feature[] = [
   },
   {
     id: 'conflict-prediction',
-    icon: '🛡️',
+    icon: faShieldHalved,
     title: 'Conflict Prediction',
     description:
       'Before switching branches, the extension detects which files would conflict with your stash. No more surprise merge disasters mid-checkout.',
@@ -491,7 +518,7 @@ export const features: Feature[] = [
   },
   {
     id: 'stash-rescue',
-    icon: '🚑',
+    icon: faTruckMedical,
     title: 'Stash-Conflict Rescue',
     description:
       'When restoring a stash conflicts, get guided rescue actions instead of a cryptic Git error.',
@@ -510,7 +537,7 @@ export const features: Feature[] = [
   },
   {
     id: 'auto-stash-manager',
-    icon: '📋',
+    icon: faBoxArchive,
     title: 'Auto-Stash Manager',
     description:
       'Inspect, recover, or remove the stashes Git Smart Checkout creates — see branch, age, file count and a diff preview, then Apply, Pop, or Drop each one with a single click.',
@@ -531,7 +558,7 @@ export const features: Feature[] = [
   },
   {
     id: 'status-bar',
-    icon: '📊',
+    icon: faWindowMaximize,
     title: 'Status Bar Integration',
     description:
       "See your current stash mode at a glance, then click the status bar item for a quick-actions menu — checkout, pull/rebase, worktree commands, clone PR, and settings, each gated to your repo's state.",

--- a/website/src/components/PlannedFeatures/PlannedFeatures.tsx
+++ b/website/src/components/PlannedFeatures/PlannedFeatures.tsx
@@ -1,8 +1,15 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faGlobe,
+  faLayerGroup,
+  faTowerBroadcast,
+} from '@fortawesome/free-solid-svg-icons';
+
 import { FeatureCard } from '../FeatureCard/FeatureCard';
 import styles from './PlannedFeatures.module.css';
 
 interface PlannedFeature {
-  icon: string;
+  icon: IconDefinition;
   title: string;
   description: string;
   tier: 1 | 2;
@@ -10,21 +17,21 @@ interface PlannedFeature {
 
 const planned: PlannedFeature[] = [
   {
-    icon: '📡',
+    icon: faTowerBroadcast,
     tier: 1,
     title: 'Upstream Indicator',
     description:
       'See ⇡N ⇣M (ahead/behind) counts in the status bar for the current branch, with a click-to-fetch shortcut.',
   },
   {
-    icon: '🗂️',
+    icon: faLayerGroup,
     tier: 2,
     title: 'Multi-root Workspace',
     description:
       'Proper support for workspaces with multiple git repositories — pick the target repo when a command is ambiguous.',
   },
   {
-    icon: '🌐',
+    icon: faGlobe,
     tier: 2,
     title: 'GitLab & Bitbucket',
     description:

--- a/website/src/components/StashModes/StashModes.module.css
+++ b/website/src/components/StashModes/StashModes.module.css
@@ -59,7 +59,9 @@
 }
 
 .icon {
-  font-size: 26px;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--accent);
 }
 
 .badge {
@@ -103,7 +105,9 @@
 }
 
 .tipIcon {
-  font-size: 20px;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--orange);
   flex-shrink: 0;
   margin-top: 1px;
 }

--- a/website/src/components/StashModes/StashModes.tsx
+++ b/website/src/components/StashModes/StashModes.tsx
@@ -1,10 +1,9 @@
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faArrowUpFromBracket,
-  faCopy,
+  faCodeBranch,
   faGear,
   faLightbulb,
-  faThumbtack,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -27,7 +26,7 @@ const modes: Mode[] = [
     useCase: 'Best when: you want full control over every checkout decision.',
   },
   {
-    icon: faThumbtack,
+    icon: faCodeBranch,
     name: 'Auto stash in current branch',
     badge: 'Recommended',
     description:
@@ -43,7 +42,7 @@ const modes: Mode[] = [
     useCase: 'Best when: you started work on the wrong branch and need to move it.',
   },
   {
-    icon: faCopy,
+    icon: faArrowUpFromBracket,
     name: 'Auto stash and apply',
     badge: 'Non-destructive',
     description:

--- a/website/src/components/StashModes/StashModes.tsx
+++ b/website/src/components/StashModes/StashModes.tsx
@@ -1,7 +1,17 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faArrowUpFromBracket,
+  faCopy,
+  faGear,
+  faLightbulb,
+  faThumbtack,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import styles from './StashModes.module.css';
 
 interface Mode {
-  icon: string;
+  icon: IconDefinition;
   name: string;
   badge: string;
   description: string;
@@ -10,14 +20,14 @@ interface Mode {
 
 const modes: Mode[] = [
   {
-    icon: '⚙️',
+    icon: faGear,
     name: 'Manual',
     badge: 'Default',
     description: 'You choose the stash strategy each time you run a checkout command.',
     useCase: 'Best when: you want full control over every checkout decision.',
   },
   {
-    icon: '📌',
+    icon: faThumbtack,
     name: 'Auto stash in current branch',
     badge: 'Recommended',
     description:
@@ -25,7 +35,7 @@ const modes: Mode[] = [
     useCase: 'Best when: you frequently context-switch between long-running branches.',
   },
   {
-    icon: '📤',
+    icon: faArrowUpFromBracket,
     name: 'Auto stash and pop',
     badge: 'Transfer',
     description:
@@ -33,7 +43,7 @@ const modes: Mode[] = [
     useCase: 'Best when: you started work on the wrong branch and need to move it.',
   },
   {
-    icon: '📋',
+    icon: faCopy,
     name: 'Auto stash and apply',
     badge: 'Non-destructive',
     description:
@@ -59,7 +69,9 @@ export function StashModes() {
           {modes.map((mode) => (
             <article key={mode.name} className={styles.card}>
               <div className={styles.cardTop}>
-                <span className={styles.icon}>{mode.icon}</span>
+                <span className={styles.icon} aria-hidden="true">
+                  <FontAwesomeIcon icon={mode.icon} />
+                </span>
                 <span className={styles.badge}>{mode.badge}</span>
               </div>
               <h3 className={styles.modeName}>{mode.name}</h3>
@@ -70,7 +82,9 @@ export function StashModes() {
         </div>
 
         <div className={styles.tip}>
-          <span className={styles.tipIcon}>💡</span>
+          <span className={styles.tipIcon} aria-hidden="true">
+            <FontAwesomeIcon icon={faLightbulb} />
+          </span>
           <p>
             Set your default mode once in the status bar — the extension remembers it per workspace.
             Override it any time with a single click.

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,9 +1,16 @@
+import { config } from '@fortawesome/fontawesome-svg-core';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
 
+import '@fortawesome/fontawesome-svg-core/styles.css';
 import './index.css';
+
+// Ship Font Awesome's CSS in the stylesheet bundle (imported above) instead of
+// letting the core inject it at runtime — avoids icons flashing at full size
+// before first paint.
+config.autoAddCss = false;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -207,6 +207,30 @@
   dependencies:
     tslib "^2.4.0"
 
+"@fortawesome/fontawesome-common-types@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz#913fe0c0aed1184390efeec2546d78f9c4c8dc4a"
+  integrity sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==
+
+"@fortawesome/fontawesome-svg-core@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.1.tgz#eca344c1c8094598240c44d28e97ad53eb0c4537"
+  integrity sha512-BoxVN3PKnMbgStHhjoaky/oWdxHomDqmBVA24IA3KEmssFGeI7u9YT/BJceOjIum/t6TpPa/vcMKaVYQeIQ/3Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.3.1"
+
+"@fortawesome/free-solid-svg-icons@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.1.tgz#07d38cd0cffd759ae64c78e40a9a928ecf0cb19a"
+  integrity sha512-v0BLa0eqg7ubvVWeNSHVBs8fWH/GJicERZoJaxJ3FE/lj67VSqzoMg9pzfZVOfLMX10y0pGwQAuxoRVVH2patg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.3.1"
+
+"@fortawesome/react-fontawesome@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-3.5.0.tgz#ce8152e556809326e1253682088bfdd116a453bd"
+  integrity sha512-63mlRr6fiBbJ0wjr1Cf6dsDGtP2lNvk9lnatKgxs/fIkhslsZT291hIUzJkuUkI9yr69ZvWnWfgb2qXm4QyVaA==
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"


### PR DESCRIPTION
## Summary
- Replaces the emoji glyphs used as icons on the website with Font Awesome **free (solid)** SVG icons, so icons render identically on every OS instead of depending on the local emoji font.
- Covers all three icon-bearing card sets: the Features grid + feature modal (`featuresData.tsx`), the Roadmap cards (`PlannedFeatures.tsx`), and the stash-mode cards + tip callout (`StashModes.tsx`).
- `icon` fields are now typed `IconDefinition` rather than `string`, so a bad icon is a type error instead of a broken glyph.
- Adds `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`, `@fortawesome/react-fontawesome` (free set only — no Pro packages, no registry token needed).
- `config.autoAddCss = false` + an explicit `styles.css` import in `main.tsx` moves Font Awesome's CSS into the stylesheet bundle instead of runtime injection, avoiding a flash of full-size icons before first paint.
- Icon CSS updated for SVGs: fixed 1.25em icon column so card titles align, sizes tuned down slightly (SVGs read larger than emoji), and icons take `var(--accent)` (the tip lightbulb takes `var(--orange)`) since SVGs are monochrome `currentColor`.

### Manual verification
1. `cd website && yarn install`
2. `yarn dev`, open the local URL.
3. Features section: every card shows a monochrome accent-blue icon (e.g. code-branch for Smart Branch Checkout, star for Preferred Branches, broom for Delete Merged Branches); titles line up in a straight column.
4. Click any feature card — the modal header shows the same icon.
5. Scroll to **Stash Modes**: gear / thumbtack / arrow-up-from-bracket / copy icons, plus an orange lightbulb on the tip callout.
6. Scroll to **Roadmap**: tower-broadcast, layer-group, and globe icons on the Tier 1/2 cards.
7. Confirm no icon flashes oversized on hard reload (Cmd+Shift+R).

## Test plan
- [x] Website type check + production build passes (`cd website && yarn build` — runs `tsc -b && vite build`)
- [x] Font Awesome CSS lands in the emitted stylesheet, not injected at runtime
- [ ] Manual smoke test of the rendered site

Note: no extension source is touched — this PR is website-only, so the extension unit/e2e suites are unaffected.