### PR TITLE
refactor: reduce duplication and fix cancel handling in stash commands

### DIFF
--- a/src/commands/manageAutoStashesCommand/index.ts
+++ b/src/commands/manageAutoStashesCommand/index.ts
@@ -166,53 +166,61 @@ export class ManageAutoStashesCommand extends BaseCommand {
     action: StashAction
   ): Promise<boolean> {
     switch (action) {
-      case 'apply': {
-        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-        try {
-          await git.applyStash(selector);
-        } catch (error) {
-          const conflicts = await git.getConflictedFiles();
-          if (conflicts.length === 0) throw error;
-          await offerConflictRescue(git, conflicts, 'apply');
-          return true;
-        }
-        await vscode.window.showInformationMessage('Auto-stash applied.', 'OK');
-        return false;
-      }
-      case 'pop': {
-        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-        try {
-          await git.popStashBySelector(selector);
-        } catch (error) {
-          const conflicts = await git.getConflictedFiles();
-          if (conflicts.length === 0) throw error;
-          await offerConflictRescue(git, conflicts, 'pop');
-          return true;
-        }
-        await vscode.window.showInformationMessage('Auto-stash popped.', 'OK');
-        return false;
-      }
-      case 'drop': {
-        const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-        await git.dropStash(selector);
-        await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
-        return false;
-      }
-      case 'diff': {
-        const patch = await git.getStashPatch(stash.selector);
-        if (!patch) {
-          await vscode.window.showInformationMessage('This auto-stash has no diff to display.', 'OK');
-          return false;
-        }
-
-        const document = await vscode.workspace.openTextDocument({
-          content: patch,
-          language: 'diff',
-        });
-        await vscode.window.showTextDocument(document, { preview: true });
-        return false;
-      }
+      case 'apply':
+        return this.applyOrPopStash(git, stash, 'apply');
+      case 'pop':
+        return this.applyOrPopStash(git, stash, 'pop');
+      case 'drop':
+        return this.dropStash(git, stash);
+      case 'diff':
+        return this.showStashDiff(git, stash);
     }
+  }
+
+  private async applyOrPopStash(
+    git: GitExecutor,
+    stash: IGitStash,
+    action: 'apply' | 'pop'
+  ): Promise<boolean> {
+    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+    try {
+      if (action === 'apply') {
+        await git.applyStash(selector);
+      } else {
+        await git.popStashBySelector(selector);
+      }
+    } catch (error) {
+      const conflicts = await git.getConflictedFiles();
+      if (conflicts.length === 0) throw error;
+      await offerConflictRescue(git, conflicts, action);
+      return true;
+    }
+
+    const message = action === 'apply' ? 'Auto-stash applied.' : 'Auto-stash popped.';
+    await vscode.window.showInformationMessage(message, 'OK');
+    return false;
+  }
+
+  private async dropStash(git: GitExecutor, stash: IGitStash): Promise<boolean> {
+    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+    await git.dropStash(selector);
+    await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
+    return false;
+  }
+
+  private async showStashDiff(git: GitExecutor, stash: IGitStash): Promise<boolean> {
+    const patch = await git.getStashPatch(stash.selector);
+    if (!patch) {
+      await vscode.window.showInformationMessage('This auto-stash has no diff to display.', 'OK');
+      return false;
+    }
+
+    const document = await vscode.workspace.openTextDocument({
+      content: patch,
+      language: 'diff',
+    });
+    await vscode.window.showTextDocument(document, { preview: true });
+    return false;
   }
 
   private formatFileCount(count: number): string {

--- a/src/commands/pullWithStashCommand/index.ts
+++ b/src/commands/pullWithStashCommand/index.ts
@@ -1,8 +1,10 @@
 import { LoggingService } from '../../logging/loggingService';
-import { AutoStashService } from '../../services/autoStashService';
+import { AutoStashService, TPullWithStashStrategy } from '../../services/autoStashService';
 import { BaseCommand } from '../command';
 
-export class PullWithStashCommand extends BaseCommand {
+abstract class BasePullWithStashCommand extends BaseCommand {
+  protected abstract readonly pullMode: TPullWithStashStrategy;
+
   constructor(logService: LoggingService, private autoStashService: AutoStashService) {
     super(logService);
   }
@@ -11,19 +13,14 @@ export class PullWithStashCommand extends BaseCommand {
     const git = await this.getGitExecutor();
     const currentBranch = await git.getCurrentBranch();
 
-    await this.autoStashService.pullAndStashChanges(git, currentBranch, 'merge');
+    await this.autoStashService.pullAndStashChanges(git, currentBranch, this.pullMode);
   }
 }
 
-export class PullRebaseWithStashCommand extends BaseCommand {
-  constructor(logService: LoggingService, private autoStashService: AutoStashService) {
-    super(logService);
-  }
+export class PullWithStashCommand extends BasePullWithStashCommand {
+  protected readonly pullMode: TPullWithStashStrategy = 'merge';
+}
 
-  async execute(): Promise<void> {
-    const git = await this.getGitExecutor();
-    const currentBranch = await git.getCurrentBranch();
-
-    await this.autoStashService.pullAndStashChanges(git, currentBranch, 'rebase');
-  }
+export class PullRebaseWithStashCommand extends BasePullWithStashCommand {
+  protected readonly pullMode: TPullWithStashStrategy = 'rebase';
 }

--- a/src/commands/rebaseWithStashCommand/index.ts
+++ b/src/commands/rebaseWithStashCommand/index.ts
@@ -12,6 +12,7 @@ import { prepareInitialRefDetails, refreshRemainingRefDetails } from '../utils/r
 import { getMergedBranchLists } from '../utils/getMergedBranchLists';
 import { getRefDescription, getRefLabel } from '../utils/refFormatting';
 import { GitExecutor } from '../../common/git/gitExecutor';
+import { UserCancelledError } from '../../utils/userCancelledError';
 
 export class RebaseWithStashCommand extends BaseCommand {
   constructor(
@@ -53,6 +54,10 @@ export class RebaseWithStashCommand extends BaseCommand {
         this.vscodeGitProvider
       );
     } catch (error) {
+      if (error instanceof UserCancelledError) {
+        // User dismissed a picker (e.g. the multi-root repository picker) — not an error.
+        return;
+      }
       if (error instanceof Error) {
         const message = error.message;
         message && (await vscode.window.showErrorMessage(message, 'OK'));


### PR DESCRIPTION
## Summary
- `pullWithStashCommand`: `PullWithStashCommand` and `PullRebaseWithStashCommand` had nearly identical bodies differing only in the pull strategy literal. Extracted a shared `BasePullWithStashCommand` so the logic lives in one place.
- `manageAutoStashesCommand`: the `apply` and `pop` switch cases duplicated selector resolution, try/catch, and conflict-rescue handling almost verbatim. Extracted into a shared `applyOrPopStash` helper (plus small `dropStash`/`showStashDiff` helpers for symmetry).
- `rebaseWithStashCommand`: the top-level catch block didn't special-case `UserCancelledError` the way other commands (e.g. `checkoutToCommand`) do, so dismissing the multi-root repository picker (thrown by `getGitExecutor`) surfaced a spurious "Operation cancelled by the user" error dialog instead of silently returning.

No command IDs, public constructors, or registered behavior changed — this is an internal cleanup only.

## Test plan
- [x] `yarn check-types` passes
- [x] `yarn lint` passes (0 errors; same pre-existing warning count as main)
- [x] `yarn test:unit` passes (685 passing)
- [ ] Manual smoke test: run "Pull (stash)", "Pull --rebase (stash)", "Rebase with stash", and "Manage auto-stashes" commands in the Extension Development Host