### PR TITLE
feat(stashes): add persistent Stashes tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ All commands are grouped under the `GSC:` prefix in the Command Palette.
 | Pull the current branch while preserving local changes | `GSC: Pull (With Stash)` | [Pull with stash](docs/pull-with-stash.md) |
 | Pull with rebase while preserving local changes | `GSC: Pull (Rebase With Stash)` | [Pull rebase with stash](docs/pull-rebase-with-stash.md) |
 | Rebase the current branch onto another ref while preserving local changes | `GSC: Rebase (With Stash)` | [Rebase with stash](docs/rebase-with-stash.md) |
-| Inspect, recover, or remove stashes created by Git Smart Checkout | `GSC: Manage Auto-Stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
+| Browse every stash (not just auto-stashes) for the open repositories in a dedicated "Stashes" view (activity bar), grouped into "Auto-stashes" and "Other stashes" with age, file count, and a stale marker (configurable threshold); expand a stash to see its changed files and click one for a side-by-side diff (including untracked files, via a synthetic `gsc-stash:` diff source); inline Apply/Pop/Drop, multi-select Drop with one confirmation, and a context menu for the full patch, creating a branch from the stash, and copying its message. The view's badge shows the auto-stash count and refreshes live on any stash mutation, from this view or elsewhere | `GSC: Refresh Stashes` | — |
+| Inspect, recover, or remove auto-stashes created by Git Smart Checkout from the command palette (superseded for day-to-day use by the "Stashes" view above, which manages all stashes; kept for palette-only workflows) | `GSC: Manage Auto-Stashes...` | [Manage auto-stashes](docs/manage-auto-stashes.md) |
 | Copy staged or WIP changes between existing worktrees | `GSC: Copy Staged Changes to Worktree...`, `GSC: Copy WIP Changes to Worktree...`, `GSC: Copy WIP from Worktree...`, `GSC: Move WIP from Worktree...` | [Copy changes to worktree](docs/copy-changes-to-worktree.md) |
 | Open a terminal in a selected worktree's directory | `GSC: Open Worktree Dev Terminal...` | [Open worktree dev terminal](docs/open-worktree-dev-terminal.md) |
 | Remove several Git worktrees at once with a single confirmation | `GSC: Remove Multiple Worktrees...` | [Remove multiple worktrees](docs/remove-multiple-worktrees.md) |
@@ -84,6 +85,7 @@ Click a setting ID to open that setting in VS Code.
 | ⚙️ [`git-smart-checkout.tagRemote`](vscode://settings/git-smart-checkout.tagRemote) (Tag remote) | `string` | Git remote used when pushing created tags. |
 | ⚙️ [`git-smart-checkout.telemetry.enabled`](vscode://settings/git-smart-checkout.telemetry.enabled) (Telemetry enabled) | `boolean` | Enables anonymous Git Smart Checkout analytics while respecting VS Code's global telemetry settings. |
 | ⚙️ [`git-smart-checkout.stacks.enabled`](vscode://settings/git-smart-checkout.stacks.enabled) (Stacks enabled) | `boolean` | Detects and visualizes the current branch's GitHub-native PR stack (Stacks view and status bar indicator). Default `true`. |
+| ⚙️ [`git-smart-checkout.stashes.staleAfterDays`](vscode://settings/git-smart-checkout.stashes.staleAfterDays) (Stashes stale after days) | `number` | Flags a stash as stale (⚠) in the Stashes view once it is older than this many days. Set to `0` to disable staleness. Default `7`. |
 
 ## Telemetry
 

--- a/docs/manage-auto-stashes.md
+++ b/docs/manage-auto-stashes.md
@@ -4,6 +4,9 @@ Command: `Git Smart Checkout: Manage auto-stashes...`
 
 Use this command to inspect and recover stashes created by Git Smart Checkout. The manager only lists stash messages beginning with `auto-stash-`; ordinary Git stashes are left out of the picker.
 
+> [!TIP]
+> The activity bar's "Stashes" view covers the same actions (plus per-file diffs, "Create Branch from Stash", and multi-select drop) for *every* stash, not just auto-stashes, and stays open instead of a one-shot picker. This command remains for palette-only workflows.
+
 ## What It Shows
 
 Each auto-stash entry includes:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
           "when": "git-smart-checkout.hasRepository"
         },
         {
+          "id": "git-smart-checkout.stashes",
+          "name": "Stashes",
+          "type": "tree",
+          "icon": "$(archive)",
+          "when": "git-smart-checkout.hasRepository"
+        },
+        {
           "id": "git-smart-checkout.prClone",
           "name": "PR Clone",
           "type": "webview",
@@ -302,6 +309,45 @@
         "category": "GSC"
       },
       {
+        "command": "git-smart-checkout.stash.apply",
+        "title": "Apply",
+        "icon": "$(files)",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stash.pop",
+        "title": "Pop",
+        "icon": "$(move)",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stash.drop",
+        "title": "Drop",
+        "icon": "$(trash)",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stash.viewPatch",
+        "title": "View Full Patch",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stash.createBranch",
+        "title": "Create Branch from Stash...",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stash.copyMessage",
+        "title": "Copy Message",
+        "category": "GSC"
+      },
+      {
+        "command": "git-smart-checkout.stashes.refresh",
+        "title": "Refresh Stashes",
+        "icon": "$(refresh)",
+        "category": "GSC"
+      },
+      {
         "command": "git-smart-checkout.cleanupBranches",
         "title": "Delete Merged Branches...",
         "category": "GSC"
@@ -348,6 +394,36 @@
           "command": "git-smart-checkout.worktree.reveal",
           "when": "view == git-smart-checkout.worktrees && viewItem =~ /\\bworktree\\b/",
           "group": "7_modification@3"
+        },
+        {
+          "command": "git-smart-checkout.stash.apply",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "inline@1"
+        },
+        {
+          "command": "git-smart-checkout.stash.pop",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "inline@2"
+        },
+        {
+          "command": "git-smart-checkout.stash.drop",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "inline@3"
+        },
+        {
+          "command": "git-smart-checkout.stash.viewPatch",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "7_modification@1"
+        },
+        {
+          "command": "git-smart-checkout.stash.createBranch",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "7_modification@2"
+        },
+        {
+          "command": "git-smart-checkout.stash.copyMessage",
+          "when": "view == git-smart-checkout.stashes && viewItem == stash",
+          "group": "7_modification@3"
         }
       ],
       "view/title": [
@@ -369,6 +445,11 @@
         {
           "command": "git-smart-checkout.stacks.refresh",
           "when": "view == git-smart-checkout.stacks",
+          "group": "navigation@1"
+        },
+        {
+          "command": "git-smart-checkout.stashes.refresh",
+          "when": "view == git-smart-checkout.stashes",
           "group": "navigation@1"
         },
         {
@@ -713,6 +794,12 @@
           "type": "boolean",
           "default": true,
           "description": "Detect and visualize the current branch's GitHub-native PR stack (Stacks view and status bar indicator)."
+        },
+        "git-smart-checkout.stashes.staleAfterDays": {
+          "type": "number",
+          "default": 7,
+          "minimum": 0,
+          "description": "Flag a stash as stale in the Stashes view once it's older than this many days. Set to 0 to disable staleness."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -311,13 +311,13 @@
       {
         "command": "git-smart-checkout.stash.apply",
         "title": "Apply",
-        "icon": "$(files)",
+        "icon": "$(git-stash-apply)",
         "category": "GSC"
       },
       {
         "command": "git-smart-checkout.stash.pop",
         "title": "Pop",
-        "icon": "$(move)",
+        "icon": "$(git-stash-pop)",
         "category": "GSC"
       },
       {

--- a/src/commands/manageAutoStashesCommand/index.ts
+++ b/src/commands/manageAutoStashesCommand/index.ts
@@ -8,22 +8,28 @@ import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
 import { LoggingService } from '../../logging/loggingService';
 import { BaseCommand } from '../command';
 import { AUTO_STASH_PREFIX } from '../checkoutToCommand/constants';
-import { offerConflictRescue } from '../../services/stashConflictRescue';
+import { confirmDirtyWorktree, confirmDropStashes, StashService } from '../../services/stashService';
 
 const ACTION_APPLY = 'Apply';
 const ACTION_POP = 'Pop';
 const ACTION_DIFF = 'View Diff';
 const ACTION_DROP = 'Drop';
-const ACTION_CONTINUE = 'Continue';
-const ACTION_CANCEL = 'Cancel';
 
 type StashAction = 'apply' | 'pop' | 'diff' | 'drop';
 type StashQuickPickItem = vscode.QuickPickItem & { stash: IGitStash };
 type ActionQuickPickItem = vscode.QuickPickItem & { action: StashAction };
 
+/**
+ * Palette entry point for stash management (`GSC: Manage Auto-Stashes...`), kept as a modal
+ * QuickPick loop for users who prefer the command palette over the Stashes tree view. Superseded
+ * in day-to-day use by the tree view, but shares the exact same business logic — `StashService` —
+ * so both surfaces stay in lockstep on safety semantics (hash-verified selectors, dirty-worktree
+ * confirmation, conflict rescue, drop confirmation).
+ */
 export class ManageAutoStashesCommand extends BaseCommand {
   constructor(
     logService: LoggingService,
+    private readonly stashService: StashService,
     private vscodeGitProvider?: VscodeGitProvider
   ) {
     super(logService);
@@ -57,12 +63,12 @@ export class ManageAutoStashesCommand extends BaseCommand {
         if (
           (action === 'apply' || action === 'pop') &&
           hadChanges &&
-          !(await this.confirmDirtyWorktree(action))
+          !(await confirmDirtyWorktree(action))
         ) {
           continue;
         }
 
-        if (action === 'drop' && !(await this.confirmDrop(stash))) {
+        if (action === 'drop' && !(await confirmDropStashes([stash]))) {
           continue;
         }
 
@@ -133,28 +139,6 @@ export class ManageAutoStashesCommand extends BaseCommand {
     return picked?.action;
   }
 
-  private async confirmDirtyWorktree(action: 'apply' | 'pop'): Promise<boolean> {
-    const choice = await vscode.window.showWarningMessage(
-      `The current worktree has uncommitted changes. ${action === 'apply' ? ACTION_APPLY : ACTION_POP} this auto-stash anyway?`,
-      { modal: true },
-      ACTION_CONTINUE,
-      ACTION_CANCEL
-    );
-
-    return choice === ACTION_CONTINUE;
-  }
-
-  private async confirmDrop(stash: IGitStash): Promise<boolean> {
-    const choice = await vscode.window.showWarningMessage(
-      `Permanently drop the auto-stash for "${stash.sourceBranch ?? 'unknown branch'}"?`,
-      { modal: true },
-      ACTION_DROP,
-      ACTION_CANCEL
-    );
-
-    return choice === ACTION_DROP;
-  }
-
   /**
    * Runs the selected stash action. Returns true when the action ended in a
    * conflict-rescue path (so the caller can tag analytics instead of reporting
@@ -166,50 +150,31 @@ export class ManageAutoStashesCommand extends BaseCommand {
     action: StashAction
   ): Promise<boolean> {
     switch (action) {
-      case 'apply':
-        return this.applyOrPopStash(git, stash, 'apply');
-      case 'pop':
-        return this.applyOrPopStash(git, stash, 'pop');
+      case 'apply': {
+        const rescued = (await this.stashService.applyStash(git, stash)) === 'rescued';
+        if (!rescued) {
+          await vscode.window.showInformationMessage('Auto-stash applied.', 'OK');
+        }
+        return rescued;
+      }
+      case 'pop': {
+        const rescued = (await this.stashService.popStash(git, stash)) === 'rescued';
+        if (!rescued) {
+          await vscode.window.showInformationMessage('Auto-stash popped.', 'OK');
+        }
+        return rescued;
+      }
       case 'drop':
-        return this.dropStash(git, stash);
+        await this.stashService.dropStash(git, stash);
+        await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
+        return false;
       case 'diff':
         return this.showStashDiff(git, stash);
     }
   }
 
-  private async applyOrPopStash(
-    git: GitExecutor,
-    stash: IGitStash,
-    action: 'apply' | 'pop'
-  ): Promise<boolean> {
-    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-    try {
-      if (action === 'apply') {
-        await git.applyStash(selector);
-      } else {
-        await git.popStashBySelector(selector);
-      }
-    } catch (error) {
-      const conflicts = await git.getConflictedFiles();
-      if (conflicts.length === 0) throw error;
-      await offerConflictRescue(git, conflicts, action);
-      return true;
-    }
-
-    const message = action === 'apply' ? 'Auto-stash applied.' : 'Auto-stash popped.';
-    await vscode.window.showInformationMessage(message, 'OK');
-    return false;
-  }
-
-  private async dropStash(git: GitExecutor, stash: IGitStash): Promise<boolean> {
-    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
-    await git.dropStash(selector);
-    await vscode.window.showInformationMessage('Auto-stash dropped.', 'OK');
-    return false;
-  }
-
   private async showStashDiff(git: GitExecutor, stash: IGitStash): Promise<boolean> {
-    const patch = await git.getStashPatch(stash.selector);
+    const patch = await this.stashService.getStashPatch(git, stash);
     if (!patch) {
       await vscode.window.showInformationMessage('This auto-stash has no diff to display.', 'OK');
       return false;

--- a/src/commands/stashTreeActionCommand.ts
+++ b/src/commands/stashTreeActionCommand.ts
@@ -1,0 +1,157 @@
+import * as vscode from 'vscode';
+
+import { AnalyticsEvent, capture, captureException } from '../analytics/analytics';
+import { GitExecutor } from '../common/git/gitExecutor';
+import { IGitStash } from '../common/git/types';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { LoggingService } from '../logging/loggingService';
+import { confirmDirtyWorktree, confirmDropStashes, StashService } from '../services/stashService';
+import { BaseCommand } from './command';
+import { resolveStashArg } from './utils/resolveStashArg';
+
+export type StashTreeAction = 'apply' | 'pop' | 'drop' | 'viewPatch' | 'createBranch' | 'copyMessage';
+
+/**
+ * Handles inline/context-menu actions triggered from the Stashes tree view. Business logic
+ * (hash-verified selectors, conflict rescue, the shared `onDidChangeStashes` notification) lives
+ * in `StashService`, shared with `ManageAutoStashesCommand`; this class only resolves the tree
+ * selection into `IGitStash[]` + a repository, and owns the confirmation/notification UI.
+ */
+export class StashTreeActionCommand extends BaseCommand {
+  constructor(
+    private readonly action: StashTreeAction,
+    logService: LoggingService,
+    private readonly stashService: StashService,
+    private readonly vscodeGitProvider?: VscodeGitProvider
+  ) {
+    super(logService);
+  }
+
+  async execute(item?: unknown, items?: unknown): Promise<void> {
+    const resolved = resolveStashArg(item, items);
+    if (!resolved) {
+      return;
+    }
+    const { stashes, repositoryPath } = resolved;
+    const git = new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider);
+
+    switch (this.action) {
+      case 'apply':
+        await this.applyOrPop(git, stashes[0], 'apply');
+        return;
+      case 'pop':
+        await this.applyOrPop(git, stashes[0], 'pop');
+        return;
+      case 'drop':
+        await this.drop(git, stashes);
+        return;
+      case 'viewPatch':
+        await this.viewPatch(git, stashes[0]);
+        return;
+      case 'createBranch':
+        await this.createBranch(git, stashes[0]);
+        return;
+      case 'copyMessage':
+        await vscode.env.clipboard.writeText(stashes[0].message);
+        return;
+    }
+  }
+
+  private async applyOrPop(git: GitExecutor, stash: IGitStash, action: 'apply' | 'pop'): Promise<void> {
+    try {
+      const hadChanges = await git.isWorkdirHasChanges();
+      if (hadChanges && !(await confirmDirtyWorktree(action))) {
+        return;
+      }
+
+      const result =
+        action === 'apply'
+          ? await this.stashService.applyStash(git, stash)
+          : await this.stashService.popStash(git, stash);
+
+      capture(AnalyticsEvent.AutoStashManaged, {
+        action,
+        file_count: stash.files.length,
+        had_changes: hadChanges,
+        ...(result === 'rescued' ? { stashConflict: true } : {}),
+      });
+
+      if (result !== 'rescued') {
+        await vscode.window.showInformationMessage(
+          action === 'apply' ? 'Stash applied.' : 'Stash popped.',
+          'OK'
+        );
+      }
+    } catch (error) {
+      captureException(error);
+      const message = error instanceof Error ? error.message : String(error);
+      message && (await this.showErrorMessage(`Failed to ${action} the stash: ${message}`, 'OK'));
+    }
+  }
+
+  private async drop(git: GitExecutor, stashes: IGitStash[]): Promise<void> {
+    try {
+      // Multi-select Drop shows one confirmation modal for the whole batch, not one per stash.
+      if (!(await confirmDropStashes(stashes))) {
+        return;
+      }
+
+      await this.stashService.dropStashes(git, stashes);
+
+      capture(AnalyticsEvent.AutoStashManaged, {
+        action: 'drop',
+        file_count: stashes.reduce((sum, stash) => sum + stash.files.length, 0),
+        had_changes: false,
+        count: stashes.length,
+      });
+
+      await vscode.window.showInformationMessage(
+        stashes.length === 1 ? 'Stash dropped.' : `${stashes.length} stashes dropped.`,
+        'OK'
+      );
+    } catch (error) {
+      captureException(error);
+      const message = error instanceof Error ? error.message : String(error);
+      message && (await this.showErrorMessage(`Failed to drop the stash(es): ${message}`, 'OK'));
+    }
+  }
+
+  private async viewPatch(git: GitExecutor, stash: IGitStash): Promise<void> {
+    try {
+      const patch = await this.stashService.getStashPatch(git, stash);
+      if (!patch) {
+        await vscode.window.showInformationMessage('This stash has no diff to display.', 'OK');
+        return;
+      }
+
+      const document = await vscode.workspace.openTextDocument({ content: patch, language: 'diff' });
+      await vscode.window.showTextDocument(document, { preview: true });
+    } catch (error) {
+      captureException(error);
+      const message = error instanceof Error ? error.message : String(error);
+      message && (await this.showErrorMessage(`Failed to load the stash patch: ${message}`, 'OK'));
+    }
+  }
+
+  private async createBranch(git: GitExecutor, stash: IGitStash): Promise<void> {
+    const branchName = await vscode.window.showInputBox({
+      title: 'Create Branch from Stash',
+      prompt: 'Name of the new branch',
+      value: stash.sourceBranch ?? '',
+      validateInput: (value) => (value.trim() ? undefined : 'Branch name is required.'),
+    });
+    if (!branchName) {
+      return;
+    }
+
+    try {
+      const trimmed = branchName.trim();
+      await this.stashService.createBranchFromStash(git, stash, trimmed);
+      await vscode.window.showInformationMessage(`Created branch "${trimmed}" from the stash.`, 'OK');
+    } catch (error) {
+      captureException(error);
+      const message = error instanceof Error ? error.message : String(error);
+      message && (await this.showErrorMessage(`Failed to create a branch from the stash: ${message}`, 'OK'));
+    }
+  }
+}

--- a/src/commands/utils/resolveStashArg.ts
+++ b/src/commands/utils/resolveStashArg.ts
@@ -1,0 +1,27 @@
+import { IGitStash } from '../../common/git/types';
+import { StashTreeItem } from '../../view/StashTreeDataProvider';
+
+export interface ResolvedStashArg {
+  stashes: IGitStash[];
+  repositoryPath: string;
+}
+
+/**
+ * `view/item/context` commands are invoked by VS Code with the clicked tree element as the
+ * first argument and — when `canSelectMany` is on and multiple rows are selected — the full
+ * selection as the second argument. Normalizes both shapes into the underlying stashes plus
+ * the repository they belong to (all selected rows come from the same repository's tree).
+ */
+export function resolveStashArg(item: unknown, items?: unknown): ResolvedStashArg | undefined {
+  const candidates = Array.isArray(items) && items.length > 0 ? items : [item];
+  const stashItems = candidates.filter((candidate): candidate is StashTreeItem => candidate instanceof StashTreeItem);
+
+  if (stashItems.length === 0) {
+    return undefined;
+  }
+
+  return {
+    stashes: stashItems.map((stashItem) => stashItem.stash),
+    repositoryPath: stashItems[0].repositoryPath,
+  };
+}

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -115,6 +115,32 @@ export function parseStashFilesOutput(output: string): string[] {
   return output.split('\0').filter((file) => file.length > 0);
 }
 
+/**
+ * Parses `--name-status -z` output. Under `-z` git separates the status from the path with a NUL
+ * (not a tab), so the stream is a flat run of alternating fields: `M\0a.txt\0D\0b.txt\0`. Rename
+ * and copy statuses (`R100`, `C75`) carry *two* paths — source then destination — and we report the
+ * destination, which is the path that exists once the stash is applied.
+ */
+export function parseStashNameStatusOutput(
+  output: string
+): Array<{ status: string; path: string }> {
+  const fields = output.split('\0').filter((field) => field.length > 0);
+  const entries: Array<{ status: string; path: string }> = [];
+
+  for (let i = 0; i < fields.length; ) {
+    const status = fields[i++];
+    const takesTwoPaths = status.startsWith('R') || status.startsWith('C');
+    const path = takesTwoPaths ? fields[i + 1] : fields[i];
+    i += takesTwoPaths ? 2 : 1;
+
+    if (path) {
+      entries.push({ status, path });
+    }
+  }
+
+  return entries;
+}
+
 export function parseWorktreeListPorcelain(output: string): IGitWorktree[] {
   const worktrees: IGitWorktree[] = [];
   let current: IGitWorktree | undefined;
@@ -676,14 +702,7 @@ export class GitExecutor {
       selector,
     ]);
 
-    return stdout
-      .split('\0')
-      .filter((entry) => entry.trim() !== '')
-      .map((entry) => {
-        const [status, ...pathParts] = entry.split('\t');
-        return { status: status.trim(), path: pathParts.join('\t') };
-      })
-      .filter((entry) => entry.path !== '');
+    return parseStashNameStatusOutput(stdout);
   }
 
   /**

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -664,6 +664,47 @@ export class GitExecutor {
     await this.#execGitCommand(['stash', 'drop', selector]);
   }
 
+  /** Name + status (`A`/`M`/`D`/…) for each file touched by a stash, including untracked files. */
+  async getStashFilesWithStatus(selector: string): Promise<Array<{ status: string; path: string }>> {
+    const { stdout } = await this.#execGitCommand([
+      'stash',
+      'show',
+      '--name-status',
+      '-z',
+      '--include-untracked',
+      '--format=',
+      selector,
+    ]);
+
+    return stdout
+      .split('\0')
+      .filter((entry) => entry.trim() !== '')
+      .map((entry) => {
+        const [status, ...pathParts] = entry.split('\t');
+        return { status: status.trim(), path: pathParts.join('\t') };
+      })
+      .filter((entry) => entry.path !== '');
+  }
+
+  /**
+   * `git show <rev>:<path>` — the content of `path` at `rev`. Returns
+   * `undefined` (rather than throwing) when the file doesn't exist at that
+   * revision, so callers can render the missing side of a diff as empty.
+   */
+  async getFileAtRev(rev: string, filePath: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await this.#execGitCommand(['show', `${rev}:${filePath}`]);
+      return stdout;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** `git stash branch <branchName> <selector>` — creates and checks out a new branch from a stash. */
+  async createBranchFromStash(branchName: string, selector: string): Promise<void> {
+    await this.#execGitCommand(['stash', 'branch', branchName, selector]);
+  }
+
   async getStashPatch(selector: string): Promise<string> {
     const includeUntrackedSupported = await this.#supportsStashShowIncludeUntracked();
 

--- a/src/configuration/configurationManager.ts
+++ b/src/configuration/configurationManager.ts
@@ -128,6 +128,9 @@ export class ConfigurationManager {
       stacks: {
         enabled: vscodeConfig.get('stacks.enabled', true),
       },
+      stashes: {
+        staleAfterDays: vscodeConfig.get('stashes.staleAfterDays', 7),
+      },
     };
   }
 

--- a/src/configuration/extensionConfig.ts
+++ b/src/configuration/extensionConfig.ts
@@ -48,6 +48,11 @@ export interface StacksConfig {
   enabled: boolean;
 }
 
+export interface StashesConfig {
+  /** Days after which a stash is flagged "stale" in the Stashes tree. 0 disables staleness. */
+  staleAfterDays: number;
+}
+
 export interface ExtensionConfig {
   mode: TAutoStashModeConfig;
   useFastBranchList: boolean;
@@ -82,6 +87,7 @@ export interface ExtensionConfig {
   branchTemplates: NamedTemplate[];
   jira: JiraConfig;
   stacks: StacksConfig;
+  stashes: StashesConfig;
 }
 
 export interface IAutoStashMode {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,6 +81,10 @@ import { indicatorBranchesOf, stackInfoMapOf } from './services/stackModel';
 import { StackWebViewProvider } from './view/StackWebViewProvider';
 import { CheckoutBranchCommand } from './commands/checkoutBranchCommand';
 import { FetchBranchCommand } from './commands/fetchBranchCommand';
+import { StashService } from './services/stashService';
+import { StashTreeDataProvider } from './view/StashTreeDataProvider';
+import { StashContentProvider, STASH_URI_SCHEME } from './view/stashContentProvider';
+import { StashTreeActionCommand } from './commands/stashTreeActionCommand';
 
 export function activate(context: vscode.ExtensionContext) {
   const anonymousId = context.globalState.get<string>('analytics.anonymousId') ?? (() => {
@@ -196,10 +200,52 @@ export function activate(context: vscode.ExtensionContext) {
     logService,
     prCloneService
   );
-  const autoStashService = new AutoStashService(configManager, logService, () =>
-    updateNotificationService.recordStashCarryingCheckoutSuccess(context)
+  const stashService = new StashService();
+  const autoStashService = new AutoStashService(
+    configManager,
+    logService,
+    () => updateNotificationService.recordStashCarryingCheckoutSuccess(context),
+    () => stashService.notifyChanged()
   );
   const refDetailsCache = new RefDetailsCache(context.globalState, logService);
+
+  let stashTreeView: vscode.TreeView<unknown> | undefined;
+  const stashTreeDataProvider = new StashTreeDataProvider(
+    logService,
+    () => configManager.get().stashes.staleAfterDays,
+    vscodeGitProvider,
+    (autoStashCount) => {
+      if (stashTreeView) {
+        stashTreeView.badge =
+          autoStashCount > 0 ? { value: autoStashCount, tooltip: 'auto-stashes' } : undefined;
+      }
+    }
+  );
+  // A stash mutation from anywhere — the tree view's own actions, the palette's "Manage
+  // Auto-Stashes..." command, or an auto-stash created/popped during checkout/pull/rebase —
+  // notifies through this one shared event, so the tree stays live without polling.
+  const stashChangeListener = stashService.onDidChangeStashes(() => stashTreeDataProvider.refreshDebounced());
+
+  const stashApplyCommand = new StashTreeActionCommand('apply', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.apply`, stashApplyCommand);
+  const stashPopCommand = new StashTreeActionCommand('pop', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.pop`, stashPopCommand);
+  const stashDropCommand = new StashTreeActionCommand('drop', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.drop`, stashDropCommand);
+  const stashViewPatchCommand = new StashTreeActionCommand('viewPatch', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.viewPatch`, stashViewPatchCommand);
+  const stashCreateBranchCommand = new StashTreeActionCommand('createBranch', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.createBranch`, stashCreateBranchCommand);
+  const stashCopyMessageCommand = new StashTreeActionCommand('copyMessage', logService, stashService, vscodeGitProvider);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stash.copyMessage`, stashCopyMessageCommand);
+  commandManager.registerCommand(`${EXTENSION_NAME}.stashes.refresh`, {
+    execute: async () => stashTreeDataProvider.refresh(),
+  });
+
+  const stashContentProviderRegistration = vscode.workspace.registerTextDocumentContentProvider(
+    STASH_URI_SCHEME,
+    new StashContentProvider(logService, vscodeGitProvider)
+  );
 
   /**
    * Refreshes the current branch's PR stack (GitHub PR chains, authoritative;
@@ -409,7 +455,7 @@ export function activate(context: vscode.ExtensionContext) {
   const openWorktreeDevTerminalCommand = new OpenWorktreeDevTerminalCommand(logService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.openWorktreeDevTerminal`, openWorktreeDevTerminalCommand);
 
-  const manageAutoStashesCommand = new ManageAutoStashesCommand(logService, vscodeGitProvider);
+  const manageAutoStashesCommand = new ManageAutoStashesCommand(logService, stashService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.manageAutoStashes`, manageAutoStashesCommand);
   commandManager.registerCommand(`${EXTENSION_NAME}.cleanupBranches`, new CleanupBranchesCommand(logService, vscodeGitProvider));
 
@@ -556,12 +602,14 @@ export function activate(context: vscode.ExtensionContext) {
       // Debounced: rapid focus toggling (e.g. alt-tabbing) collapses into a
       // single reload rather than one per focus event.
       worktreeTreeDataProvider.refreshDebounced();
+      stashTreeDataProvider.refreshDebounced();
     }
   });
   const workspaceFoldersListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
     void refreshRemoveMultipleWorktreesVisibility(logService, vscodeGitProvider);
     void refreshRepositoryContext(logService);
     worktreeTreeDataProvider.refresh();
+    stashTreeDataProvider.refresh();
   });
   // Keep the tree in sync with checkouts/commits/stash operations performed
   // outside this extension (VS Code's built-in Source Control view, terminal
@@ -580,6 +628,7 @@ export function activate(context: vscode.ExtensionContext) {
   };
   const gitStateListener = vscodeGitProvider?.onDidChangeAnyRepositoryState(() => {
     worktreeTreeDataProvider.refreshDebounced();
+    stashTreeDataProvider.refreshDebounced();
     refreshStacksDebounced();
   });
 
@@ -598,6 +647,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   worktreeTreeView = vscode.window.createTreeView(`${EXTENSION_NAME}.worktrees`, {
     treeDataProvider: worktreeTreeDataProvider,
+  });
+
+  stashTreeView = vscode.window.createTreeView(`${EXTENSION_NAME}.stashes`, {
+    treeDataProvider: stashTreeDataProvider,
+    // Enables selecting several stashes at once so "Drop" can act on the whole selection
+    // behind a single confirmation modal instead of one row at a time.
+    canSelectMany: true,
   });
 
   // Add to context subscriptions
@@ -625,7 +681,12 @@ export function activate(context: vscode.ExtensionContext) {
     worktreeTreeView,
     worktreeTreeDataProvider,
     stackWebViewProvider,
-    vscode.window.registerWebviewViewProvider(`${EXTENSION_NAME}.stacks`, stackWebViewProvider)
+    vscode.window.registerWebviewViewProvider(`${EXTENSION_NAME}.stacks`, stackWebViewProvider),
+    stashTreeView,
+    stashTreeDataProvider,
+    stashService,
+    stashChangeListener,
+    stashContentProviderRegistration
   );
 
   // Show status bar

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -22,7 +22,13 @@ export class AutoStashService {
   constructor(
     private configManager: ConfigurationManager,
     private logService: LoggingService,
-    private onStashCarryingCheckoutSuccess?: () => void | Promise<void>
+    private onStashCarryingCheckoutSuccess?: () => void | Promise<void>,
+    /**
+     * Notified after every checkout/pull/rebase path that may have created, popped, or otherwise
+     * mutated a stash — shared with `StashService.onDidChangeStashes` so the Stashes tree view
+     * (and the auto-stash badge) refresh without polling for stashes created outside it.
+     */
+    private onStashesChanged?: () => void
   ) { }
 
   async getAutoStashMode(): Promise<TAutoStashMode | undefined> {
@@ -158,6 +164,7 @@ export class AutoStashService {
     }
 
     capture(event, { had_changes: isWorkdirHasChangesBeforeStash });
+    this.onStashesChanged?.();
   }
 
   async rebaseAndStashChanges(
@@ -172,6 +179,7 @@ export class AutoStashService {
     if (mode === AUTO_STASH_IGNORE) {
       await this.#doRebase(git, targetRef, vscodeGitProvider);
       capture(AnalyticsEvent.RebaseWithStash, { stash_mode: mode, had_changes: isWorkdirHasChanges });
+      this.onStashesChanged?.();
       return;
     }
 
@@ -200,6 +208,7 @@ export class AutoStashService {
     }
 
     capture(AnalyticsEvent.RebaseWithStash, { stash_mode: mode, had_changes: isWorkdirHasChanges });
+    this.onStashesChanged?.();
   }
 
   /**
@@ -332,6 +341,10 @@ export class AutoStashService {
       // Checkout happened, but the stash pop/apply conflicted and a rescue notification
       // was already shown in place of a generic error — tag instead of double-reporting success.
       capture(AnalyticsEvent.CheckoutToBranch, { stash_mode: autoStashMode, had_changes: isWorkdirHasChanges, stashConflict: true });
+    }
+
+    if (autoStashMode !== AUTO_STASH_IGNORE) {
+      this.onStashesChanged?.();
     }
 
     return outcome;

--- a/src/services/stashService.ts
+++ b/src/services/stashService.ts
@@ -1,0 +1,189 @@
+import * as vscode from 'vscode';
+
+import { GitExecutor } from '../common/git/gitExecutor';
+import { IGitStash } from '../common/git/types';
+import { AUTO_STASH_PREFIX } from '../commands/checkoutToCommand/constants';
+import { offerConflictRescue, StashOperation } from './stashConflictRescue';
+
+export interface GroupedStashes {
+  autoStashes: IGitStash[];
+  otherStashes: IGitStash[];
+}
+
+/** True when `stash` was created by `AutoStashService` (message starts with `auto-stash-`). */
+export function isAutoStash(stash: IGitStash): boolean {
+  return stash.message.startsWith(`${AUTO_STASH_PREFIX}-`);
+}
+
+/**
+ * Splits every stash (not just auto-stashes) into the "Auto-stashes" and
+ * "Other stashes" groups the Stashes tree renders as top-level nodes.
+ */
+export function groupStashes(stashes: IGitStash[]): GroupedStashes {
+  const autoStashes: IGitStash[] = [];
+  const otherStashes: IGitStash[] = [];
+  for (const stash of stashes) {
+    (isAutoStash(stash) ? autoStashes : otherStashes).push(stash);
+  }
+  return { autoStashes, otherStashes };
+}
+
+/**
+ * True when `stash` is older than `staleAfterDays`. A `staleAfterDays` of 0
+ * (or below) disables staleness entirely (`git-smart-checkout.stashes.staleAfterDays`).
+ */
+export function isStashStale(stash: IGitStash, staleAfterDays: number, now: number = Date.now()): boolean {
+  if (!staleAfterDays || staleAfterDays <= 0) {
+    return false;
+  }
+  const ageMs = now - stash.timestamp * 1000;
+  return ageMs > staleAfterDays * 24 * 60 * 60 * 1000;
+}
+
+/** Confirmation copy for dropping one or more stashes in a single modal. */
+export function formatDropConfirmation(stashes: IGitStash[]): string {
+  if (stashes.length === 1) {
+    const stash = stashes[0];
+    return `Permanently drop the stash for "${stash.sourceBranch ?? stash.message}"?`;
+  }
+  const branches = stashes.map((stash) => stash.sourceBranch ?? stash.message).join(', ');
+  return `Permanently drop ${stashes.length} stashes (${branches})?`;
+}
+
+export type StashDiffSide = 'before' | 'after';
+
+/**
+ * Resolves file content for one side of a per-file stash diff.
+ * - 'before': the pre-stash state, `<hash>^:<path>`. Missing at that revision means the file
+ *   didn't exist before the stash (added by it) — rendered as an empty side.
+ * - 'after': the stashed state. Tracked changes live in the stash commit itself, `<hash>:<path>`.
+ *   Untracked files captured by the stash live only in its third parent (the "untracked files"
+ *   commit `git stash` creates), `<hash>^3:<path>` — tried as a fallback when the primary lookup
+ *   doesn't find the file.
+ */
+export async function getStashFileContent(
+  git: Pick<GitExecutor, 'getFileAtRev'>,
+  hash: string,
+  filePath: string,
+  side: StashDiffSide
+): Promise<string> {
+  if (side === 'before') {
+    return (await git.getFileAtRev(`${hash}^`, filePath)) ?? '';
+  }
+
+  const tracked = await git.getFileAtRev(hash, filePath);
+  if (tracked !== undefined) {
+    return tracked;
+  }
+
+  const untracked = await git.getFileAtRev(`${hash}^3`, filePath);
+  return untracked ?? '';
+}
+
+/** Warns about uncommitted changes before an apply/pop that could conflict with them. */
+export async function confirmDirtyWorktree(action: 'apply' | 'pop'): Promise<boolean> {
+  const choice = await vscode.window.showWarningMessage(
+    `The current worktree has uncommitted changes. ${action === 'apply' ? 'Apply' : 'Pop'} this stash anyway?`,
+    { modal: true },
+    'Continue',
+    'Cancel'
+  );
+  return choice === 'Continue';
+}
+
+/** Single modal confirming drop of one or more stashes (never one dialog per stash). */
+export async function confirmDropStashes(stashes: IGitStash[]): Promise<boolean> {
+  const choice = await vscode.window.showWarningMessage(
+    formatDropConfirmation(stashes),
+    { modal: true },
+    'Drop',
+    'Cancel'
+  );
+  return choice === 'Drop';
+}
+
+/**
+ * Business logic shared by the Stashes tree view and `ManageAutoStashesCommand`: hash-verified
+ * selectors (via `GitExecutor.resolveStashSelector`, so a stale positional `stash@{N}` never acts
+ * on the wrong entry), conflict-rescue on apply/pop, and a single `onDidChangeStashes` event fired
+ * after every mutation — shared with `AutoStashService`, whose checkout-time stash creates/pops
+ * also notify through it — so the Stashes tree (and the auto-stash badge) refresh without polling.
+ */
+export class StashService {
+  private readonly changeEmitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeStashes = this.changeEmitter.event;
+
+  /** Notifies listeners that stash state changed. Called by this service and by `AutoStashService`. */
+  notifyChanged(): void {
+    this.changeEmitter.fire();
+  }
+
+  dispose(): void {
+    this.changeEmitter.dispose();
+  }
+
+  async listStashes(git: GitExecutor): Promise<IGitStash[]> {
+    return git.listStashes();
+  }
+
+  async applyStash(git: GitExecutor, stash: IGitStash): Promise<'applied' | 'rescued'> {
+    return (await this.applyOrPop(git, stash, 'apply')) as 'applied' | 'rescued';
+  }
+
+  async popStash(git: GitExecutor, stash: IGitStash): Promise<'popped' | 'rescued'> {
+    return (await this.applyOrPop(git, stash, 'pop')) as 'popped' | 'rescued';
+  }
+
+  private async applyOrPop(
+    git: GitExecutor,
+    stash: IGitStash,
+    operation: StashOperation
+  ): Promise<'applied' | 'popped' | 'rescued'> {
+    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+    try {
+      if (operation === 'apply') {
+        await git.applyStash(selector);
+      } else {
+        await git.popStashBySelector(selector);
+      }
+    } catch (error) {
+      const conflicts = await git.getConflictedFiles();
+      if (conflicts.length === 0) {
+        throw error;
+      }
+      await offerConflictRescue(git, conflicts, operation);
+      this.notifyChanged();
+      return 'rescued';
+    }
+    this.notifyChanged();
+    return operation === 'apply' ? 'applied' : 'popped';
+  }
+
+  async dropStash(git: GitExecutor, stash: IGitStash): Promise<void> {
+    await this.dropStashes(git, [stash]);
+  }
+
+  /**
+   * Drops several stashes from one confirmation. Each selector is re-resolved by hash
+   * immediately before its own drop — `stash@{N}` indices shift after every removal, so reusing
+   * selectors captured before the loop started could drop the wrong entry.
+   */
+  async dropStashes(git: GitExecutor, stashes: IGitStash[]): Promise<void> {
+    for (const stash of stashes) {
+      const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+      await git.dropStash(selector);
+    }
+    this.notifyChanged();
+  }
+
+  async createBranchFromStash(git: GitExecutor, stash: IGitStash, branchName: string): Promise<void> {
+    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+    await git.createBranchFromStash(branchName, selector);
+    this.notifyChanged();
+  }
+
+  async getStashPatch(git: GitExecutor, stash: IGitStash): Promise<string> {
+    const selector = await git.resolveStashSelector(stash.selector, stash.hash);
+    return git.getStashPatch(selector);
+  }
+}

--- a/src/test/unit/branchTemplateAvailability.test.ts
+++ b/src/test/unit/branchTemplateAvailability.test.ts
@@ -39,6 +39,7 @@ function baseConfig(overrides: {
     branchTemplates: overrides.branchTemplates ?? [],
     jira: overrides.jira ?? { domain: '', username: '', token: '', projectKeys: [], customJql: '' },
     stacks: { enabled: true },
+    stashes: { staleAfterDays: 7 },
   };
 }
 

--- a/src/test/unit/resolveStashArg.test.ts
+++ b/src/test/unit/resolveStashArg.test.ts
@@ -1,0 +1,51 @@
+import * as assert from 'assert';
+
+import { resolveStashArg } from '../../commands/utils/resolveStashArg';
+import { StashTreeItem } from '../../view/StashTreeDataProvider';
+import { IGitStash } from '../../common/git/types';
+
+function makeStash(overrides: Partial<IGitStash> = {}): IGitStash {
+  return {
+    selector: 'stash@{0}',
+    hash: 'abc123',
+    message: 'auto-stash-feat/login',
+    sourceBranch: 'feat/login',
+    timestamp: Math.floor(Date.now() / 1000),
+    files: ['src/a.ts'],
+    ...overrides,
+  };
+}
+
+describe('resolveStashArg', () => {
+  it('returns undefined for an unrelated argument', () => {
+    assert.strictEqual(resolveStashArg({ notAStash: true }), undefined);
+  });
+
+  it('resolves a single clicked stash item', () => {
+    const item = new StashTreeItem(makeStash(), '/repo', 7);
+    const resolved = resolveStashArg(item);
+
+    assert.ok(resolved);
+    assert.strictEqual(resolved?.repositoryPath, '/repo');
+    assert.strictEqual(resolved?.stashes.length, 1);
+    assert.strictEqual(resolved?.stashes[0].hash, 'abc123');
+  });
+
+  it('resolves every selected item when a multi-select array is passed', () => {
+    const first = new StashTreeItem(makeStash({ hash: 'a1' }), '/repo', 7);
+    const second = new StashTreeItem(makeStash({ hash: 'a2' }), '/repo', 7);
+
+    const resolved = resolveStashArg(first, [first, second]);
+
+    assert.ok(resolved);
+    assert.deepStrictEqual(resolved?.stashes.map((stash) => stash.hash), ['a1', 'a2']);
+  });
+
+  it('falls back to the single clicked item when the selection array is empty', () => {
+    const item = new StashTreeItem(makeStash({ hash: 'solo' }), '/repo', 7);
+    const resolved = resolveStashArg(item, []);
+
+    assert.ok(resolved);
+    assert.deepStrictEqual(resolved?.stashes.map((stash) => stash.hash), ['solo']);
+  });
+});

--- a/src/test/unit/stashListParser.test.ts
+++ b/src/test/unit/stashListParser.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import {
   parseStashFilesOutput,
   parseStashListOutput,
+  parseStashNameStatusOutput,
 } from '../../common/git/gitExecutor';
 
 describe('stash list parsing', () => {
@@ -44,5 +45,38 @@ describe('stash list parsing', () => {
       parseStashFilesOutput('src/one.ts\0docs/file with spaces.md\0'),
       ['src/one.ts', 'docs/file with spaces.md']
     );
+  });
+});
+
+describe('stash name-status parsing', () => {
+  // Under `-z` the status and path are separated by NUL, not a tab.
+  it('pairs each status with its following path', () => {
+    assert.deepStrictEqual(
+      parseStashNameStatusOutput('D\0todelete.txt\0M\0tracked.txt\0A\0untracked.txt\0'),
+      [
+        { status: 'D', path: 'todelete.txt' },
+        { status: 'M', path: 'tracked.txt' },
+        { status: 'A', path: 'untracked.txt' },
+      ]
+    );
+  });
+
+  it('reports the destination path for renames and copies', () => {
+    assert.deepStrictEqual(
+      parseStashNameStatusOutput('R100\0old.txt\0new.txt\0C75\0src.txt\0copy.txt\0M\0after.txt\0'),
+      [
+        { status: 'R100', path: 'new.txt' },
+        { status: 'C75', path: 'copy.txt' },
+        { status: 'M', path: 'after.txt' },
+      ]
+    );
+  });
+
+  it('preserves spaces in paths and handles empty output', () => {
+    assert.deepStrictEqual(
+      parseStashNameStatusOutput('M\0docs/file with spaces.md\0'),
+      [{ status: 'M', path: 'docs/file with spaces.md' }]
+    );
+    assert.deepStrictEqual(parseStashNameStatusOutput(''), []);
   });
 });

--- a/src/test/unit/stashService.test.ts
+++ b/src/test/unit/stashService.test.ts
@@ -1,0 +1,183 @@
+import * as assert from 'assert';
+
+import { IGitStash } from '../../common/git/types';
+import {
+  formatDropConfirmation,
+  getStashFileContent,
+  groupStashes,
+  isAutoStash,
+  isStashStale,
+} from '../../services/stashService';
+
+function makeStash(overrides: Partial<IGitStash> = {}): IGitStash {
+  return {
+    selector: 'stash@{0}',
+    hash: 'abc123',
+    message: 'WIP on main: abc123 message',
+    sourceBranch: 'main',
+    timestamp: Math.floor(Date.now() / 1000),
+    files: ['src/a.ts'],
+    ...overrides,
+  };
+}
+
+describe('isAutoStash / groupStashes', () => {
+  it('classifies a stash created by AutoStashService as an auto-stash', () => {
+    const stash = makeStash({ message: 'auto-stash-feat/login' });
+    assert.strictEqual(isAutoStash(stash), true);
+  });
+
+  it('classifies a stash whose message merely contains "auto-stash" mid-string as not an auto-stash', () => {
+    // The prefix check is anchored ("auto-stash-" at the start), not a substring match.
+    const stash = makeStash({ message: 'WIP on main: not-an-auto-stash-really' });
+    assert.strictEqual(isAutoStash(stash), false);
+  });
+
+  it('splits a mixed list into auto-stashes and other stashes, preserving order within each group', () => {
+    const auto1 = makeStash({ hash: 'a1', message: 'auto-stash-feat/login' });
+    const other1 = makeStash({ hash: 'o1', message: 'WIP on main: manual work' });
+    const auto2 = makeStash({ hash: 'a2', message: 'auto-stash-feat/login-2' });
+
+    const { autoStashes, otherStashes } = groupStashes([auto1, other1, auto2]);
+
+    assert.deepStrictEqual(autoStashes.map((s) => s.hash), ['a1', 'a2']);
+    assert.deepStrictEqual(otherStashes.map((s) => s.hash), ['o1']);
+  });
+
+  it('returns empty groups for an empty stash list', () => {
+    const { autoStashes, otherStashes } = groupStashes([]);
+    assert.deepStrictEqual(autoStashes, []);
+    assert.deepStrictEqual(otherStashes, []);
+  });
+});
+
+describe('isStashStale', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it('is never stale when staleAfterDays is 0 (disabled)', () => {
+    const stash = makeStash({ timestamp: 0 }); // effectively ancient
+    assert.strictEqual(isStashStale(stash, 0), false);
+  });
+
+  it('is never stale when staleAfterDays is negative', () => {
+    const stash = makeStash({ timestamp: 0 });
+    assert.strictEqual(isStashStale(stash, -5), false);
+  });
+
+  it('is not stale when younger than the threshold', () => {
+    const now = Date.now();
+    const stash = makeStash({ timestamp: Math.floor((now - 2 * DAY_MS) / 1000) });
+    assert.strictEqual(isStashStale(stash, 7, now), false);
+  });
+
+  it('is stale once older than the threshold', () => {
+    const now = Date.now();
+    const stash = makeStash({ timestamp: Math.floor((now - 10 * DAY_MS) / 1000) });
+    assert.strictEqual(isStashStale(stash, 7, now), true);
+  });
+
+  it('is not stale exactly at the boundary (age must exceed, not just reach, the threshold)', () => {
+    // Both values are exact multiples of 1000ms so the stash-timestamp round-trip (seconds ->
+    // ms) doesn't introduce sub-second drift across the boundary.
+    const now = Math.floor(Date.now() / 1000) * 1000;
+    const stash = makeStash({ timestamp: now / 1000 - 7 * 24 * 60 * 60 });
+    assert.strictEqual(isStashStale(stash, 7, now), false);
+  });
+});
+
+describe('formatDropConfirmation', () => {
+  it('names the branch for a single-stash drop', () => {
+    const stash = makeStash({ sourceBranch: 'feat/login' });
+    assert.strictEqual(
+      formatDropConfirmation([stash]),
+      'Permanently drop the stash for "feat/login"?'
+    );
+  });
+
+  it('falls back to the stash message when sourceBranch is unknown', () => {
+    const stash = makeStash({ sourceBranch: undefined, message: 'WIP on main: abc123 fix' });
+    assert.strictEqual(
+      formatDropConfirmation([stash]),
+      'Permanently drop the stash for "WIP on main: abc123 fix"?'
+    );
+  });
+
+  it('states the count and lists every branch for a multi-select drop', () => {
+    const stashes = [
+      makeStash({ sourceBranch: 'feat/login' }),
+      makeStash({ sourceBranch: 'feat/signup' }),
+      makeStash({ sourceBranch: 'chore/deps' }),
+    ];
+
+    assert.strictEqual(
+      formatDropConfirmation(stashes),
+      'Permanently drop 3 stashes (feat/login, feat/signup, chore/deps)?'
+    );
+  });
+});
+
+describe('getStashFileContent', () => {
+  it('reads the pre-stash state from the first parent for the "before" side', async () => {
+    const calls: Array<[string, string]> = [];
+    const git = {
+      getFileAtRev: async (rev: string, path: string) => {
+        calls.push([rev, path]);
+        return 'original content';
+      },
+    };
+
+    const content = await getStashFileContent(git, 'abc123', 'src/a.ts', 'before');
+
+    assert.strictEqual(content, 'original content');
+    assert.deepStrictEqual(calls, [['abc123^', 'src/a.ts']]);
+  });
+
+  it('renders the "before" side as empty when the file did not exist before the stash', async () => {
+    const git = { getFileAtRev: async () => undefined };
+    const content = await getStashFileContent(git, 'abc123', 'src/new.ts', 'before');
+    assert.strictEqual(content, '');
+  });
+
+  it('reads a tracked change straight from the stash commit for the "after" side', async () => {
+    const calls: Array<[string, string]> = [];
+    const git = {
+      getFileAtRev: async (rev: string, path: string) => {
+        calls.push([rev, path]);
+        return rev === 'abc123' ? 'stashed content' : undefined;
+      },
+    };
+
+    const content = await getStashFileContent(git, 'abc123', 'src/a.ts', 'after');
+
+    assert.strictEqual(content, 'stashed content');
+    // Only the primary lookup is needed; the untracked-parent fallback isn't tried.
+    assert.deepStrictEqual(calls, [['abc123', 'src/a.ts']]);
+  });
+
+  it('falls back to the stash\'s third parent (^3) for an untracked file the stash commit itself lacks', async () => {
+    const calls: Array<[string, string]> = [];
+    const git = {
+      getFileAtRev: async (rev: string, path: string) => {
+        calls.push([rev, path]);
+        if (rev === 'abc123^3') {
+          return 'untracked file content';
+        }
+        return undefined;
+      },
+    };
+
+    const content = await getStashFileContent(git, 'abc123', 'src/token.ts', 'after');
+
+    assert.strictEqual(content, 'untracked file content');
+    assert.deepStrictEqual(calls, [
+      ['abc123', 'src/token.ts'],
+      ['abc123^3', 'src/token.ts'],
+    ]);
+  });
+
+  it('renders the "after" side as empty when the file is missing from both the stash commit and its third parent', async () => {
+    const git = { getFileAtRev: async () => undefined };
+    const content = await getStashFileContent(git, 'abc123', 'src/gone.ts', 'after');
+    assert.strictEqual(content, '');
+  });
+});

--- a/src/test/unit/stashTreeDataProvider.test.ts
+++ b/src/test/unit/stashTreeDataProvider.test.ts
@@ -1,0 +1,138 @@
+import * as assert from 'assert';
+
+import {
+  StashFileTreeItem,
+  StashGroupTreeItem,
+  StashTreeDataProvider,
+  StashTreeItem,
+} from '../../view/StashTreeDataProvider';
+import { IGitStash } from '../../common/git/types';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function makeStash(overrides: Partial<IGitStash> = {}): IGitStash {
+  return {
+    selector: 'stash@{0}',
+    hash: 'abc123',
+    message: 'auto-stash-feat/login',
+    sourceBranch: 'feat/login',
+    timestamp: Math.floor(Date.now() / 1000),
+    files: ['src/auth/login.ts', 'src/auth/token.ts'],
+    ...overrides,
+  };
+}
+
+describe('StashGroupTreeItem', () => {
+  it('labels the auto-stash group with a count', () => {
+    const item = new StashGroupTreeItem('auto', '/repo', [makeStash(), makeStash({ hash: 'def' })]);
+    assert.strictEqual(item.label, 'Auto-stashes (2)');
+    assert.strictEqual(item.contextValue, 'stashGroup autoStashes');
+  });
+
+  it('labels the other-stashes group with a count', () => {
+    const item = new StashGroupTreeItem('other', '/repo', [makeStash()]);
+    assert.strictEqual(item.label, 'Other stashes (1)');
+    assert.strictEqual(item.contextValue, 'stashGroup otherStashes');
+  });
+});
+
+describe('StashTreeItem', () => {
+  it('describes a fresh stash without a stale marker', () => {
+    const stash = makeStash({ timestamp: Math.floor(Date.now() / 1000) - 60 * 60 });
+    const item = new StashTreeItem(stash, '/repo', 7);
+
+    assert.strictEqual(item.label, 'feat/login');
+    assert.strictEqual(item.isStale, false);
+    assert.ok(!String(item.description).includes('stale'));
+    assert.strictEqual(item.contextValue, 'stash');
+  });
+
+  it('flags a stash older than the configured staleAfterDays threshold', () => {
+    const tenDaysAgo = Math.floor(Date.now() / 1000) - 10 * 24 * 60 * 60;
+    const stash = makeStash({ timestamp: tenDaysAgo });
+    const item = new StashTreeItem(stash, '/repo', 7);
+
+    assert.strictEqual(item.isStale, true);
+    assert.ok(String(item.description).includes('⚠ stale'));
+    assert.ok(String(item.tooltip).includes('staleness threshold'));
+  });
+
+  it('never flags a stash as stale when staleAfterDays is 0', () => {
+    const tenDaysAgo = Math.floor(Date.now() / 1000) - 10 * 24 * 60 * 60;
+    const stash = makeStash({ timestamp: tenDaysAgo });
+    const item = new StashTreeItem(stash, '/repo', 0);
+
+    assert.strictEqual(item.isStale, false);
+  });
+
+  it('falls back to the stash message when sourceBranch is unavailable', () => {
+    const stash = makeStash({ sourceBranch: undefined, message: 'WIP on develop: 9f3ab2 msg' });
+    const item = new StashTreeItem(stash, '/repo', 7);
+    assert.strictEqual(item.label, 'WIP on develop: 9f3ab2 msg');
+  });
+});
+
+describe('StashFileTreeItem', () => {
+  it('prefixes the label with the file status and wires a diff command', () => {
+    const stash = makeStash();
+    const item = new StashFileTreeItem(stash, '/repo', 'src/auth/login.ts', 'M');
+
+    assert.strictEqual(item.label, 'M src/auth/login.ts');
+    assert.strictEqual(item.command?.command, 'vscode.diff');
+    assert.strictEqual(item.command?.arguments?.length, 3);
+  });
+});
+
+describe('StashTreeDataProvider.getChildren', () => {
+  function makeProvider(onAutoStashCountChanged?: (count: number) => void) {
+    return new StashTreeDataProvider(mockLogService, () => 7, undefined, onAutoStashCountChanged);
+  }
+
+  it('returns no groups when there are no workspace folders', async () => {
+    const provider = makeProvider();
+    const children = await provider.getChildren();
+    assert.deepStrictEqual(children, []);
+  });
+
+  it('reports an auto-stash count of 0 when nothing loads', async () => {
+    let reportedCount: number | undefined;
+    const provider = makeProvider((count) => {
+      reportedCount = count;
+    });
+    await provider.getChildren();
+    assert.strictEqual(reportedCount, 0);
+  });
+});
+
+describe('StashTreeDataProvider.refreshDebounced', () => {
+  function makeProvider() {
+    return new StashTreeDataProvider(mockLogService, () => 7);
+  }
+
+  it('coalesces rapid refresh calls into a single reload', async () => {
+    const provider = makeProvider();
+    let fireCount = 0;
+    provider.onDidChangeTreeData(() => fireCount++);
+
+    for (let i = 0; i < 5; i++) {
+      provider.refreshDebounced(30);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    assert.strictEqual(fireCount, 1);
+    provider.dispose();
+  });
+
+  it('refresh() fires immediately and cancels a pending debounce', async () => {
+    const provider = makeProvider();
+    let fireCount = 0;
+    provider.onDidChangeTreeData(() => fireCount++);
+
+    provider.refreshDebounced(50);
+    provider.refresh();
+    assert.strictEqual(fireCount, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    assert.strictEqual(fireCount, 1);
+    provider.dispose();
+  });
+});

--- a/src/view/StashTreeDataProvider.ts
+++ b/src/view/StashTreeDataProvider.ts
@@ -1,0 +1,202 @@
+import { formatDistanceToNow } from 'date-fns';
+import * as vscode from 'vscode';
+import { GitExecutor } from '../common/git/gitExecutor';
+import { IGitStash } from '../common/git/types';
+import { LoggingService } from '../logging/loggingService';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { resolveGitRepositoryRoot } from '../utils/getGitExecutor';
+import { groupStashes, isStashStale } from '../services/stashService';
+import { stashFileUri } from './stashContentProvider';
+
+export type StashGroupKind = 'auto' | 'other';
+
+export class StashGroupTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly kind: StashGroupKind,
+    public readonly repositoryPath: string,
+    public readonly stashes: IGitStash[]
+  ) {
+    super(
+      kind === 'auto' ? `Auto-stashes (${stashes.length})` : `Other stashes (${stashes.length})`,
+      vscode.TreeItemCollapsibleState.Expanded
+    );
+    this.contextValue = kind === 'auto' ? 'stashGroup autoStashes' : 'stashGroup otherStashes';
+    this.iconPath = new vscode.ThemeIcon(kind === 'auto' ? 'archive' : 'inbox');
+  }
+}
+
+export class StashTreeItem extends vscode.TreeItem {
+  public readonly isStale: boolean;
+
+  constructor(
+    public readonly stash: IGitStash,
+    public readonly repositoryPath: string,
+    staleAfterDays: number
+  ) {
+    super(stash.sourceBranch ?? stash.message, vscode.TreeItemCollapsibleState.Collapsed);
+    this.isStale = isStashStale(stash, staleAfterDays);
+
+    const age = formatDistanceToNow(stash.timestamp * 1000, { addSuffix: true });
+    const fileCount = `${stash.files.length} ${stash.files.length === 1 ? 'file' : 'files'}`;
+    this.description = [age, '•', fileCount, this.isStale ? '⚠ stale' : ''].filter(Boolean).join(' ');
+
+    this.tooltip = [
+      stash.message,
+      `Branch: ${stash.sourceBranch ?? 'unknown'}`,
+      `Created: ${formatDistanceToNow(stash.timestamp * 1000, { addSuffix: true })}`,
+      `Files: ${stash.files.length > 0 ? stash.files.join(', ') : '(none)'}`,
+      this.isStale ? '⚠ Older than the configured staleness threshold.' : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    this.iconPath = new vscode.ThemeIcon('circle-filled');
+    this.contextValue = 'stash';
+  }
+}
+
+export class StashFileTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly stash: IGitStash,
+    public readonly repositoryPath: string,
+    public readonly filePath: string,
+    status: string
+  ) {
+    super(`${status} ${filePath}`, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = 'stashFile';
+    this.iconPath = vscode.ThemeIcon.File;
+    this.resourceUri = vscode.Uri.file(filePath);
+    this.command = {
+      command: 'vscode.diff',
+      title: 'Open Diff',
+      arguments: [
+        stashFileUri(repositoryPath, stash.hash, filePath, 'before'),
+        stashFileUri(repositoryPath, stash.hash, filePath, 'after'),
+        `${filePath} (stash @ ${stash.sourceBranch ?? stash.message})`,
+      ],
+    };
+  }
+}
+
+export type StashNode = StashGroupTreeItem | StashTreeItem | StashFileTreeItem;
+
+const DEFAULT_DEBOUNCE_MS = 2000;
+
+export class StashTreeDataProvider implements vscode.TreeDataProvider<StashNode> {
+  private readonly changeEmitter = new vscode.EventEmitter<StashNode | undefined>();
+  readonly onDidChangeTreeData = this.changeEmitter.event;
+  private groups: StashGroupTreeItem[] = [];
+  private loaded = false;
+  private debounceTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly logService: LoggingService,
+    /** Read lazily (rather than captured once) so a live config change takes effect on next reload. */
+    private readonly getStaleAfterDays: () => number,
+    private readonly vscodeGitProvider?: VscodeGitProvider,
+    private readonly onAutoStashCountChanged?: (autoStashCount: number) => void
+  ) {}
+
+  getTreeItem(item: StashNode): vscode.TreeItem {
+    return item;
+  }
+
+  async getChildren(element?: StashNode): Promise<StashNode[]> {
+    if (!this.loaded) {
+      await this.load();
+    }
+    if (!element) {
+      return this.groups;
+    }
+    if (element instanceof StashGroupTreeItem) {
+      return element.stashes.map(
+        (stash) => new StashTreeItem(stash, element.repositoryPath, this.getStaleAfterDays())
+      );
+    }
+    if (element instanceof StashTreeItem) {
+      return this.loadFiles(element);
+    }
+    return [];
+  }
+
+  /** Reloads immediately. Used for explicit user-triggered refreshes and after mutations. */
+  refresh(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+    this.loaded = false;
+    this.groups = [];
+    this.changeEmitter.fire(undefined);
+  }
+
+  /**
+   * Coalesces bursts of change notifications (several stash mutations run back to back, rapid
+   * window focus events) into a single reload after `delayMs` of quiet.
+   */
+  refreshDebounced(delayMs = DEFAULT_DEBOUNCE_MS): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.refresh();
+    }, delayMs);
+  }
+
+  dispose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.changeEmitter.dispose();
+  }
+
+  private async loadFiles(item: StashTreeItem): Promise<StashFileTreeItem[]> {
+    try {
+      const git = new GitExecutor(item.repositoryPath, this.logService, this.vscodeGitProvider);
+      const files = await git.getStashFilesWithStatus(item.stash.selector);
+      return files.map(
+        (file) => new StashFileTreeItem(item.stash, item.repositoryPath, file.path, file.status)
+      );
+    } catch (error) {
+      this.logService.warn(`Failed to load files for stash ${item.stash.selector}: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * Loads every workspace-folder repository's stashes and groups them into "Auto-stashes" /
+   * "Other stashes" (this view manages all stashes, not just auto-stashes). Single pass — unlike
+   * `WorktreeTreeDataProvider`, there's no separate enrichment phase, since `listStashes()` (used
+   * for both grouping and the per-stash summary) already returns everything the group/stash rows
+   * need; only the file-status breakdown is deferred, loaded lazily when a stash node expands.
+   */
+  private async load(): Promise<void> {
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    const groups: StashGroupTreeItem[] = [];
+    let autoStashCount = 0;
+
+    for (const folder of folders) {
+      try {
+        const repositoryPath = await resolveGitRepositoryRoot(folder.uri.fsPath, this.logService);
+        const git = new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider);
+        const stashes = await git.listStashes();
+        const { autoStashes, otherStashes } = groupStashes(stashes);
+
+        autoStashCount += autoStashes.length;
+        if (autoStashes.length > 0) {
+          groups.push(new StashGroupTreeItem('auto', repositoryPath, autoStashes));
+        }
+        if (otherStashes.length > 0) {
+          groups.push(new StashGroupTreeItem('other', repositoryPath, otherStashes));
+        }
+      } catch (error) {
+        this.logService.warn(`Failed to load stashes for ${folder.uri.fsPath}: ${error}`);
+      }
+    }
+
+    this.groups = groups;
+    this.loaded = true;
+    this.onAutoStashCountChanged?.(autoStashCount);
+  }
+}

--- a/src/view/stashContentProvider.ts
+++ b/src/view/stashContentProvider.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+
+import { GitExecutor } from '../common/git/gitExecutor';
+import { VscodeGitProvider } from '../common/git/vscodeGitProvider';
+import { LoggingService } from '../logging/loggingService';
+import { getStashFileContent, StashDiffSide } from '../services/stashService';
+
+/** Scheme backing the Stashes tree's per-file diff (`vscode.diff(gscStash:..., gscStash:..., ...)`). */
+export const STASH_URI_SCHEME = 'gsc-stash';
+
+interface StashUriQuery {
+  repositoryPath: string;
+  hash: string;
+  filePath: string;
+  side: StashDiffSide;
+}
+
+/**
+ * Builds a `gsc-stash:` URI identifying one side of a stashed file's diff. The path component is
+ * only for a readable tab/editor title; `StashContentProvider` reads everything it needs from the
+ * query, since a stash hash or repository path could itself contain characters that would be
+ * ambiguous to parse back out of a plain `hash^:path` string.
+ */
+export function stashFileUri(
+  repositoryPath: string,
+  hash: string,
+  filePath: string,
+  side: StashDiffSide
+): vscode.Uri {
+  const query: StashUriQuery = { repositoryPath, hash, filePath, side };
+  return vscode.Uri.from({
+    scheme: STASH_URI_SCHEME,
+    path: `/${filePath}`,
+    query: JSON.stringify(query),
+  });
+}
+
+/** Resolves `gsc-stash:` URIs (see `stashFileUri`) to file content via `GitExecutor.getFileAtRev`. */
+export class StashContentProvider implements vscode.TextDocumentContentProvider {
+  constructor(
+    private readonly logService: LoggingService,
+    private readonly vscodeGitProvider?: VscodeGitProvider
+  ) {}
+
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    try {
+      const { repositoryPath, hash, filePath, side } = JSON.parse(uri.query) as StashUriQuery;
+      const git = new GitExecutor(repositoryPath, this.logService, this.vscodeGitProvider);
+      return await getStashFileContent(git, hash, filePath, side);
+    } catch (error) {
+      this.logService.warn(`Failed to load stash file content for ${uri.toString()}: ${error}`);
+      return '';
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Upgrades stash management from a modal QuickPick loop (`GSC: Manage Auto-Stashes...`) to a persistent **Stashes** tree view in the activity bar, per issue #187.

- New `src/services/stashService.ts` centralizes stash business logic previously duplicated ad hoc: hash-verified selectors via `GitExecutor.resolveStashSelector`, `offerConflictRescue` on apply/pop conflicts, and a shared `onDidChangeStashes` event. `AutoStashService` fires the same event after checkout/pull/rebase stash mutations, so the tree (and the auto-stash badge) refresh live without polling.
- `src/view/StashTreeDataProvider.ts` — the view manages **every** stash (not just auto-stashes), grouped into "Auto-stashes (N)" and "Other stashes (N)" via `message.startsWith('auto-stash-')`. Each stash row shows source branch, relative age, file count, and a "⚠ stale" marker once older than `git-smart-checkout.stashes.staleAfterDays` (default `7`, `0` disables). Expanding a stash lazily lists its changed files with status letters (`git stash show --name-status`).
- Per-file diffs are the marquee upgrade: clicking a file opens a side-by-side diff backed by a new `gsc-stash:` `TextDocumentContentProvider` (`src/view/stashContentProvider.ts`) and `GitExecutor.getFileAtRev` (`git show <rev>:<path>`). Untracked files added by the stash live only in its third parent — `getStashFileContent` (in `stashService.ts`) automatically falls back to `<hash>^3:<path>` when `<hash>:<path>` doesn't have the file.
- Inline actions: Apply / Pop / Drop. Context menu: View Full Patch, Create Branch from Stash (new `GitExecutor.createBranchFromStash` → `git stash branch`), Copy Message. The tree view is `canSelectMany`, so Drop on a multi-selection shows **one** confirmation modal listing the count and branches, not one dialog per stash.
- `ManageAutoStashesCommand` (the palette entry point) is refactored onto `StashService` so its QuickPick flow keeps working with identical safety semantics (dirty-worktree confirmation, drop confirmation, conflict rescue) — it remains for palette-only workflows, superseded day-to-day by the tree view.
- New config: `git-smart-checkout.stashes.staleAfterDays` (package.json + `ExtensionConfig`).

### Deviations from spec

- The spec's conceptual `vscode.diff(gscStash:<hash>^:<path>, gscStash:<hash>:<path>, ...)` URI is implemented with the `gsc-stash` scheme but a structured JSON query (`{repositoryPath, hash, filePath, side}`) rather than a literal `hash^:path` string in the URI path — a stash hash or file path could contain characters ambiguous to parse back out of a colon-delimited string, and the query form is simpler to test in isolation (`getStashFileContent` is a pure, mockable function).
- `.claude/rules/architecture.md` (mentioned in the workflow as a doc to update) is gitignored and untracked in this repo (`git check-ignore` confirms it, `git ls-files` doesn't list it) — it isn't part of the actual git history, so there's nothing to update there. `README.md` and `docs/manage-auto-stashes.md` were updated instead.

## Test plan

- [x] `yarn compile` (check-types + lint + esbuild) passes
- [x] `yarn check-types-webview` passes (no webview code touched)
- [x] `yarn test` / `yarn test:unit` passes — 817 tests, including new coverage for:
  - `groupStashes` / `isAutoStash` grouping (mixed lists, empty lists)
  - `isStashStale` (disabled at 0, below/above/at the threshold)
  - `formatDropConfirmation` copy for single vs. multi-select drop
  - `getStashFileContent` untracked-parent `^3` resolution (before/after sides, tracked vs. untracked, both-missing)
  - `StashTreeItem`/`StashGroupTreeItem`/`StashFileTreeItem` rendering (stale marker, labels, diff command wiring)
  - `resolveStashArg` single-click vs. multi-select resolution
- [ ] Manual smoke test (not yet performed in this environment — no interactive VS Code host available here): open the Stashes view, create a few stashes (auto + manual), confirm grouping/badge/stale marker, click a file for a diff (including an untracked file), Apply/Pop/Drop (single and multi-select), Create Branch from Stash, and confirm `GSC: Manage Auto-Stashes...` still works from the palette.

Closes #187