### PR TITLE
fix(release): harden publish pipeline after the 0.17.0 pre-release incident

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,6 +18,18 @@ jobs:
       pull-requests: write
 
     steps:
+      # A re-run replays the original commit SHA. If that SHA already pushed a
+      # version commit + tag (i.e. it failed after `prepare` but during
+      # `publish`), the replayed SHA is now behind main, semantic-release
+      # refuses to release, and the job exits 0 -- a false-positive success
+      # that published nothing. This is exactly what happened to 0.17.0.
+      - name: Reject workflow re-runs
+        if: github.run_attempt != '1'
+        run: |
+          echo "::error::This is attempt #${{ github.run_attempt }}. Re-running a semantic-release job is unsafe: it replays the original commit, which is now behind main if the previous attempt already pushed a version commit/tag before failing. semantic-release then sees 'branch is behind' and exits 0 without publishing anything."
+          echo "::error::Dispatch a fresh Pre-release run instead. If a previous run tagged a version but didn't finish publishing, use the Republish workflow to resume it."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -26,8 +38,21 @@ jobs:
 
       - name: Check for new commits since the last tag
         id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           last_tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          echo "last-tag=$last_tag" >> "$GITHUB_OUTPUT"
+
+          # A tag with no matching GitHub release means a previous run tagged
+          # a version and then failed mid-publish -- treat that as broken
+          # state, not as "nothing to do".
+          if [ -n "$last_tag" ] && ! gh release view "$last_tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::$last_tag is tagged but has no matching GitHub release -- a previous release run failed mid-publish and never finished."
+            echo "::error::Run the Republish workflow for $last_tag before starting a new release."
+            exit 1
+          fi
+
           if [ "${{ inputs.force }}" = "true" ] || [ -z "$last_tag" ]; then
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           elif [ -z "$(git log "$last_tag"..HEAD --oneline)" ]; then
@@ -58,7 +83,9 @@ jobs:
 
       - name: Pre-release
         if: steps.guard.outputs.should-release == 'true'
-        run: yarn semantic-release
+        run: |
+          set -o pipefail
+          yarn semantic-release 2>&1 | tee semantic-release.log
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           VSCODE_PAT: ${{ secrets.VSCODE_PAT }}
@@ -66,3 +93,29 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           RELEASE_CHANNEL: pre
+
+      - name: Assert a release happened
+        if: steps.guard.outputs.should-release == 'true'
+        id: assert
+        run: |
+          if grep -q "is behind the remote one" semantic-release.log; then
+            echo "::error::semantic-release refused to release because main had already moved past this run's commit (the exact 0.17.0 incident signature) -- failing instead of letting this report as a silent success."
+            exit 1
+          fi
+
+          new_tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ "$new_tag" = "${{ steps.guard.outputs.last-tag }}" ]; then
+            # Unlike the stable lane, the pre-release lane's analyzeCommitsCmd
+            # (scripts/nextReleaseType.mjs) always returns a non-empty bump for
+            # channel 'pre', so reaching should-release=true guarantees a
+            # release was expected -- "no new tag" here is always a bug, never
+            # a legitimate no-op.
+            echo "::error::semantic-release exited successfully but produced no new tag (still $new_tag) -- nothing was published."
+            exit 1
+          fi
+          echo "New pre-release tag: $new_tag"
+          echo "version=${new_tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify published
+        if: steps.guard.outputs.should-release == 'true'
+        run: node scripts/verifyPublished.mjs "${{ steps.assert.outputs.version }}" --pre-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,41 @@
-name: Deploy VS Code Extension (Deprecated)
+name: Republish (recovery)
 
-# Emergency manual release only — semantic-release (release.yml) handles normal releases.
-# Triggered by tag.yml (workflow_dispatch) when a manual override is needed.
+# Recovery path for when Release or Pre-release already pushed a version
+# commit + tag (via @semantic-release/git, which runs before publishing) but
+# failed before finishing the publish step -- see docs/releasing.md, "If a
+# release workflow fails". Idempotent: scripts/publishVsix.mjs skips a
+# registry that already has the version, so it's safe to run against a tag
+# that partially published.
+#
+# Also reachable from tag.yml (Create and Push Tag, deprecated manual path)
+# via workflow_call, which needs the same package/publish/release steps for a
+# tag it created directly (without semantic-release ever touching
+# package.json).
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish/republish (e.g. v1.2.3)'
+        required: true
+        type: string
+      pre_release:
+        description: 'Mark this release as a pre-release'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v1.2.3)'
+        description: 'Tag to publish/republish (e.g. v1.2.3)'
         required: true
         type: string
+      pre_release:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  deploy:
+  republish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,7 +47,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -34,35 +58,30 @@ jobs:
       - name: Extract version from tag
         id: get_version
         run: |
-          REF="${{ inputs.tag || github.ref }}"
-          TAG="${REF#refs/tags/}"
-          VERSION="${REF#refs/tags/v}"
-          VERSION="${VERSION#v}"
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Publishing tag: $TAG"
-          echo "Extracted version: $VERSION"
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Republishing tag: $TAG (version $VERSION, pre-release: ${{ inputs.pre_release }})"
 
-      - name: Update package.json version
+      - name: Sync package.json version with tag (if needed)
         run: |
-          yarn version --new-version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
-          echo "Updated package.json version to ${{ steps.get_version.outputs.VERSION }}"
+          CURRENT=$(node -p "require('./package.json').version")
+          TARGET="${{ steps.get_version.outputs.VERSION }}"
+          if [ "$CURRENT" = "$TARGET" ]; then
+            echo "package.json is already at $TARGET -- no bump needed (this tag came from semantic-release)."
+          else
+            yarn version --new-version "$TARGET" --no-git-tag-version
+            echo "Bumped package.json from $CURRENT to $TARGET."
+          fi
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      # - name: Run linting
-      #   run: yarn lint
-
-      # - name: Run tests
-      #   run: yarn test
-      #   continue-on-error: true # Continue if tests fail (optional)
 
       - name: Build extension
         run: yarn build-all
 
       - name: Create VSIX package
-        run: yarn build-vsix
+        run: yarn vsce package --yarn${{ inputs.pre_release && ' --pre-release' || '' }}
 
       - name: Upload VSIX as artifact
         uses: actions/upload-artifact@v7
@@ -71,29 +90,28 @@ jobs:
           path: '*.vsix'
           retention-days: 30
 
-      - name: Publish to VS Code Marketplace
-        run: yarn vsce publish --yarn --pat ${{ secrets.VSCODE_PAT }}
+      - name: Publish to both registries
+        run: node scripts/publishVsix.mjs git-smart-checkout-${{ steps.get_version.outputs.VERSION }}.vsix${{ inputs.pre_release && ' --pre-release' || '' }}
         env:
-          VSCE_PAT: ${{ secrets.VSCODE_PAT }}
+          VSCODE_PAT: ${{ secrets.VSCODE_PAT }}
+          OPEN_VSX_PAT: ${{ secrets.OPEN_VSX_PAT }}
 
-      - name: Publish to Open VSX Registry
-        run: yarn ovsx publish --yarn --pat ${{ secrets.OPEN_VSX_PAT }}
+      - name: Create GitHub release if missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.tag }}"
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $TAG already exists -- leaving it as-is."
+          else
+            ARGS=(--title "Release ${{ steps.get_version.outputs.VERSION }}" \
+              --notes "Republished from tag $TAG via the recovery workflow." \
+              --verify-tag)
+            if [ "${{ inputs.pre_release }}" = "true" ]; then
+              ARGS+=(--prerelease --latest=false)
+            fi
+            gh release create "$TAG" "git-smart-checkout-${{ steps.get_version.outputs.VERSION }}.vsix#VS Code Extension" "${ARGS[@]}"
+          fi
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.get_version.outputs.TAG }}
-          name: Release ${{ steps.get_version.outputs.VERSION }}
-          body: |
-            ## Changes in v${{ steps.get_version.outputs.VERSION }}
-
-            - Automated release from tag ${{ steps.get_version.outputs.TAG }}
-            - Built and published to VS Code Marketplace
-
-            ### Installation
-            You can install this extension from:
-            - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=vradchuk.git-smart-checkout)
-            - Download the VSIX file from this release and install manually
-          draft: false
-          prerelease: false
-          files: ./git-smart-checkout-${{ steps.get_version.outputs.VERSION }}.vsix
+      - name: Verify published
+        run: node scripts/verifyPublished.mjs "${{ steps.get_version.outputs.VERSION }}"${{ inputs.pre_release && ' --pre-release' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,26 @@ jobs:
       pull-requests: write
 
     steps:
+      # See pre-release.yml for the full rationale: a re-run replays a stale
+      # SHA if the previous attempt already pushed a version commit/tag before
+      # failing, causing semantic-release to silently exit 0 having published
+      # nothing.
+      - name: Reject workflow re-runs
+        if: github.run_attempt != '1'
+        run: |
+          echo "::error::This is attempt #${{ github.run_attempt }}. Re-running a semantic-release job is unsafe: it replays the original commit, which is now behind main if the previous attempt already pushed a version commit/tag before failing. semantic-release then sees 'branch is behind' and exits 0 without publishing anything."
+          echo "::error::Dispatch a fresh Release run instead. If a previous run tagged a version but didn't finish publishing, use the Republish workflow to resume it."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Record last tag
+        id: before
+        run: echo "tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -35,7 +50,9 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Release
-        run: yarn semantic-release
+        run: |
+          set -o pipefail
+          yarn semantic-release 2>&1 | tee semantic-release.log
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           VSCODE_PAT: ${{ secrets.VSCODE_PAT }}
@@ -43,3 +60,33 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           RELEASE_CHANNEL: stable
+
+      # Unlike pre-release.yml, "no new tag" is not by itself a failure here --
+      # the stable lane defers to @semantic-release/commit-analyzer, so a
+      # dispatch with only chore/docs commits since the last tag correctly
+      # produces no release. What must never happen silently is the specific
+      # re-run bug from the 0.17.0 incident: semantic-release refusing to
+      # release because main had already moved past the checked-out commit.
+      - name: Detect stale-branch false success
+        run: |
+          if grep -q "is behind the remote one" semantic-release.log; then
+            echo "::error::semantic-release refused to release because main had already moved past this run's commit (the exact 0.17.0 incident signature) -- failing instead of letting this report as a silent success."
+            exit 1
+          fi
+
+      - name: Determine whether a new version was released
+        id: after
+        run: |
+          new_tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ "$new_tag" != "${{ steps.before.outputs.tag }}" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=${new_tag#v}" >> "$GITHUB_OUTPUT"
+            echo "Released $new_tag."
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No new tag -- no releasable commits since $new_tag. Nothing to verify."
+          fi
+
+      - name: Verify published
+        if: steps.after.outputs.released == 'true'
+        run: node scripts/verifyPublished.mjs "${{ steps.after.outputs.version }}"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -61,7 +61,53 @@ release — hotfix or not — jumps to `0.20.0` and carries everything merged to
 
 Neither workflow requires manual version bumping — `semantic-release` computes
 the next version, updates `package.json`/`CHANGELOG.md`, tags, packages the
-VSIX, and publishes to both registries in one run.
+VSIX, and publishes to both registries in one run (`scripts/publishVsix.mjs`,
+independently per registry with retry — see below).
+
+## If a release workflow fails
+
+**Never use "Re-run failed jobs" on Release or Pre-release.** Both workflows
+reject a re-run outright (`github.run_attempt != 1`) for a specific reason: by
+the time `publish` runs, `prepare` has already committed the version bump and
+pushed the `v${version}` tag. A re-run replays the *original* commit SHA, which
+is now behind `main` — semantic-release sees "branch is behind" and exits `0`
+having published nothing, reporting a false-positive green run. This is
+exactly what happened to `v0.17.0` (details below).
+
+Instead, check where it failed:
+
+- **Failed before the tag was pushed** (no new tag on `main`) — nothing
+  happened. Dispatch a fresh run.
+- **Failed after the tag was pushed** — the version is committed and tagged
+  but not (fully) published. **Dispatch Republish** (`.github/workflows/publish.yml`,
+  `workflow_dispatch`, inputs `tag` and `pre_release`) **with that tag.** It
+  re-packages the VSIX and calls the same `scripts/publishVsix.mjs` used by
+  the main lanes, which is idempotent per registry — a registry that already
+  has the version is skipped, so it's safe to run against a partially
+  published tag.
+
+Both `release.yml` and `pre-release.yml` also refuse to start a new release
+if the last tag has no matching GitHub release — that state means a previous
+run tagged a version and then failed mid-publish, so a new release must not
+be layered on top until the previous one is finished via Republish.
+
+Every release run ends with `scripts/verifyPublished.mjs`, which polls both
+registries and fails the job if the version isn't actually there — the
+detail that let `v0.17.0` go unnoticed for a while.
+
+### If a version was skipped entirely
+
+Don't try to reclaim it. Both registries serve one increasing version line
+and VS Code always installs the highest version available on a client's
+channel, so a version below the current one is permanently unreachable once
+a later one is published. Move forward — the next pre-release/stable version
+picks up from wherever the sequence actually is.
+
+This section exists because `v0.17.0` hit exactly this: it was tagged and
+committed but never reached either registry — the Marketplace publish hit a
+transient gallery timeout, and the old `vsce publish && ovsx publish` chain
+meant Open VSX was never even attempted as a result. `v0.17.0` was abandoned;
+the next pre-release picked up from `0.19.0`.
 
 ## Opting in to pre-releases
 

--- a/release.config.js
+++ b/release.config.js
@@ -27,12 +27,12 @@ module.exports = {
       // package.json version is already updated by @semantic-release/npm above,
       // so vsce package will embed the correct version in the VSIX filename.
       prepareCmd: `yarn build-all && yarn vsce package --yarn${isPre ? ' --pre-release' : ''}`,
-      publishCmd:
-        `yarn vsce publish --pat \${process.env.VSCODE_PAT} --packagePath git-smart-checkout-\${nextRelease.version}.vsix${isPre ? ' --pre-release' : ''}` +
-        // ovsx ignores/warns on --pre-release for a prepackaged vsix -- the
-        // Microsoft.VisualStudio.Code.PreRelease marker baked in by `vsce package
-        // --pre-release` above is what Open VSX actually reads.
-        ' && yarn ovsx publish --pat ${process.env.OPEN_VSX_PAT} --packagePath git-smart-checkout-${nextRelease.version}.vsix',
+      // Publishes both registries independently with retry via
+      // scripts/publishVsix.mjs -- a transient failure on one registry (e.g. a
+      // Marketplace gallery timeout) must never prevent the other from being
+      // attempted, and the script is idempotent so it's safe to re-run against
+      // a partially-published version (see the Republish workflow).
+      publishCmd: `node scripts/publishVsix.mjs git-smart-checkout-\${nextRelease.version}.vsix${isPre ? ' --pre-release' : ''}`,
       // semantic-release/github has no `prerelease` option and only infers it from
       // its own prerelease-branch mode, which this single-branch design doesn't use.
       ...(isPre && {

--- a/scripts/publishVsix.mjs
+++ b/scripts/publishVsix.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Publishes one packaged VSIX to both the VS Code Marketplace and Open VSX,
+// independently, with retry. Replaces the old `vsce publish && ovsx publish`
+// chain in release.config.js, which let a transient failure on one registry
+// (e.g. a Marketplace gallery timeout) silently prevent the other from ever
+// being attempted -- see plans/2026-08-09-pre-release-publish-failure-postmortem.md.
+//
+// Design:
+//  - The two registries are published via Promise.allSettled so a failure in
+//    one never blocks or cancels the other.
+//  - Transient failures (gallery timeouts, connection resets, 5xx) are retried
+//    with exponential backoff.
+//  - "Already published" is treated as SUCCESS, which is what makes this
+//    script safe to re-run against a tag that partially published --
+//    the core requirement for the Republish recovery workflow.
+
+import { spawn } from 'node:child_process';
+
+const MAX_ATTEMPTS = 4;
+const BASE_DELAY_MS = 1000;
+const BACKOFF_FACTOR = 4; // 1s, 4s, 16s
+
+const TRANSIENT_ERROR_PATTERN =
+  /request timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|socket hang up|network error|\b50[0234]\b/i;
+const ALREADY_PUBLISHED_PATTERN =
+  /already (been )?(published|exists)|is already published|version .* already exists/i;
+
+/** @param {string} output @returns {'already-published' | 'transient' | 'fatal'} */
+export function classifyFailure(output) {
+  if (ALREADY_PUBLISHED_PATTERN.test(output)) return 'already-published';
+  if (TRANSIENT_ERROR_PATTERN.test(output)) return 'transient';
+  return 'fatal';
+}
+
+/** @param {number} attempt 1-based attempt number that just failed */
+export function backoffDelayMs(attempt) {
+  return BASE_DELAY_MS * BACKOFF_FACTOR ** (attempt - 1);
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Runs `run()` up to `attempts` times, retrying on transient failures and
+ * treating "already published" as a terminal success.
+ *
+ * @param {{ label: string, run: () => Promise<{ ok: boolean, output: string }>, attempts?: number, sleep?: (ms: number) => Promise<void> }} opts
+ */
+export async function publishToRegistry({ label, run, attempts = MAX_ATTEMPTS, sleep = defaultSleep }) {
+  let lastOutput = '';
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await run();
+    if (result.ok) {
+      return { label, status: 'published', attempt };
+    }
+
+    lastOutput = result.output;
+    const kind = classifyFailure(result.output);
+
+    if (kind === 'already-published') {
+      return { label, status: 'already-published', attempt };
+    }
+    if (kind === 'fatal' || attempt === attempts) {
+      return { label, status: 'failed', attempt, output: lastOutput };
+    }
+
+    await sleep(backoffDelayMs(attempt));
+  }
+  return { label, status: 'failed', attempt: attempts, output: lastOutput };
+}
+
+function spawnCommand(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+      process.stdout.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      output += chunk;
+      process.stderr.write(chunk);
+    });
+    child.on('close', (code) => resolve({ ok: code === 0, output }));
+    child.on('error', (err) => resolve({ ok: false, output: `${output}\n${err.message}` }));
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const preRelease = args.includes('--pre-release');
+  const vsixPath = args.find((a) => !a.startsWith('--'));
+
+  if (!vsixPath) {
+    console.error('Usage: node scripts/publishVsix.mjs <path-to-vsix> [--pre-release]');
+    process.exit(1);
+  }
+
+  const vscodePat = process.env.VSCODE_PAT;
+  const openVsxPat = process.env.OPEN_VSX_PAT;
+  if (!vscodePat || !openVsxPat) {
+    console.error('Both VSCODE_PAT and OPEN_VSX_PAT must be set in the environment.');
+    process.exit(1);
+  }
+
+  const vsceArgs = [
+    'vsce',
+    'publish',
+    '--pat',
+    vscodePat,
+    '--packagePath',
+    vsixPath,
+    ...(preRelease ? ['--pre-release'] : []),
+  ];
+  // ovsx ignores/warns on --pre-release for a prepackaged VSIX -- the
+  // Microsoft.VisualStudio.Code.PreRelease marker baked in by `vsce package
+  // --pre-release` is what Open VSX actually reads, so the flag is omitted here.
+  const ovsxArgs = ['ovsx', 'publish', '--pat', openVsxPat, '--packagePath', vsixPath];
+
+  const settled = await Promise.allSettled([
+    publishToRegistry({ label: 'VS Code Marketplace', run: () => spawnCommand('yarn', vsceArgs) }),
+    publishToRegistry({ label: 'Open VSX', run: () => spawnCommand('yarn', ovsxArgs) }),
+  ]);
+
+  const labels = ['VS Code Marketplace', 'Open VSX'];
+  const results = settled.map((r, i) =>
+    r.status === 'fulfilled' ? r.value : { label: labels[i], status: 'failed', output: String(r.reason) },
+  );
+
+  console.log('\n=== Publish summary ===');
+  for (const r of results) {
+    const attemptNote = r.attempt ? ` (attempt ${r.attempt}/${MAX_ATTEMPTS})` : '';
+    console.log(`  ${r.label}: ${r.status}${attemptNote}`);
+  }
+
+  const failed = results.filter((r) => r.status === 'failed');
+  if (failed.length > 0) {
+    for (const r of failed) {
+      console.error(`\n::error::${r.label} publish failed after ${r.attempt} attempt(s).`);
+      if (r.output) console.error(r.output);
+    }
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/verifyPublished.mjs
+++ b/scripts/verifyPublished.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Confirms a version actually landed on both the VS Code Marketplace and Open
+// VSX after a release. Without this, a green semantic-release run was the
+// only signal a release actually happened -- and that signal can lie (see
+// plans/2026-08-09-pre-release-publish-failure-postmortem.md: a stale re-run
+// exited 0 having published nothing).
+
+const PUBLISHER = 'vradchuk';
+const EXTENSION = 'git-smart-checkout';
+const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery';
+const OPEN_VSX_URL = `https://open-vsx.org/api/${PUBLISHER}/${EXTENSION}`;
+const PRE_RELEASE_PROPERTY = 'Microsoft.VisualStudio.Code.PreRelease';
+
+export async function fetchMarketplaceVersions(fetchImpl = fetch) {
+  const res = await fetchImpl(MARKETPLACE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json;api-version=7.2-preview.1',
+    },
+    body: JSON.stringify({
+      filters: [{ criteria: [{ filterType: 7, value: `${PUBLISHER}.${EXTENSION}` }] }],
+      // 2151 includes per-version `properties`, needed to read the PreRelease marker.
+      flags: 2151,
+    }),
+  });
+  if (!res.ok) throw new Error(`Marketplace query failed: HTTP ${res.status}`);
+  const data = await res.json();
+  return data?.results?.[0]?.extensions?.[0]?.versions ?? [];
+}
+
+export async function fetchOpenVsxVersions(fetchImpl = fetch) {
+  const res = await fetchImpl(OPEN_VSX_URL);
+  if (!res.ok) throw new Error(`Open VSX query failed: HTTP ${res.status}`);
+  const data = await res.json();
+  return Object.keys(data?.allVersions ?? {}).filter((v) => v !== 'latest');
+}
+
+/**
+ * @param {Array<{ version: string, properties?: Array<{ key: string, value: string }> }>} versions
+ * @param {string} version
+ * @param {boolean} expectPreRelease
+ */
+export function marketplaceHasVersion(versions, version, expectPreRelease) {
+  const match = versions.find((v) => v.version === version);
+  if (!match) return false;
+  if (!expectPreRelease) return true;
+
+  const properties = match.properties ?? [];
+  return properties.some((p) => p.key === PRE_RELEASE_PROPERTY && p.value === 'true');
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Polls `check()` until it returns true or attempts are exhausted. */
+export async function pollUntil(check, { attempts = 6, delayMs = 20000, sleep = defaultSleep } = {}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (await check()) return true;
+    if (attempt < attempts) await sleep(delayMs);
+  }
+  return false;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const preRelease = args.includes('--pre-release');
+  const version = args.find((a) => !a.startsWith('--'));
+
+  if (!version) {
+    console.error('Usage: node scripts/verifyPublished.mjs <version> [--pre-release]');
+    process.exit(1);
+  }
+
+  console.log(`Verifying ${EXTENSION}@${version} (pre-release: ${preRelease}) is live on both registries...`);
+
+  const marketplaceOk = await pollUntil(async () => {
+    const versions = await fetchMarketplaceVersions();
+    return marketplaceHasVersion(versions, version, preRelease);
+  });
+  console.log(`  VS Code Marketplace: ${marketplaceOk ? 'OK' : 'MISSING'}`);
+
+  const openVsxOk = await pollUntil(async () => {
+    const versions = await fetchOpenVsxVersions();
+    return versions.includes(version);
+  });
+  console.log(`  Open VSX: ${openVsxOk ? 'OK' : 'MISSING'}`);
+
+  if (!marketplaceOk || !openVsxOk) {
+    const missing = [!marketplaceOk && 'the VS Code Marketplace', !openVsxOk && 'Open VSX'].filter(Boolean).join(' and ');
+    console.error(
+      `::error::${EXTENSION}@${version} is missing from ${missing} after polling. The release did not actually publish everywhere it should have -- see the Republish workflow to resume it.`,
+    );
+    process.exit(1);
+  }
+
+  console.log('Both registries confirmed.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/test/unit/publishVsix.test.ts
+++ b/src/test/unit/publishVsix.test.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+describe('publishVsix', () => {
+  let classifyFailure: (output: string) => 'already-published' | 'transient' | 'fatal';
+  let backoffDelayMs: (attempt: number) => number;
+  let publishToRegistry: (opts: {
+    label: string;
+    run: () => Promise<{ ok: boolean; output: string }>;
+    attempts?: number;
+    sleep?: (ms: number) => Promise<void>;
+  }) => Promise<{ label: string; status: string; attempt: number; output?: string }>;
+
+  before(async () => {
+    const modulePath = path.join(__dirname, '..', '..', '..', 'scripts', 'publishVsix.mjs');
+    ({ classifyFailure, backoffDelayMs, publishToRegistry } = await import(modulePath));
+  });
+
+  describe('classifyFailure', () => {
+    it('classifies a Marketplace gallery timeout as transient', () => {
+      assert.strictEqual(classifyFailure('::error::Request timeout: /_apis/gallery'), 'transient');
+    });
+
+    it('classifies connection resets and 5xx as transient', () => {
+      assert.strictEqual(classifyFailure('Error: connect ECONNRESET'), 'transient');
+      assert.strictEqual(classifyFailure('Server responded with 503 Service Unavailable'), 'transient');
+    });
+
+    it('classifies "already published" as already-published', () => {
+      assert.strictEqual(classifyFailure('Error: Extension already exists.'), 'already-published');
+      assert.strictEqual(
+        classifyFailure('Extension \'vradchuk.git-smart-checkout\' version 0.19.0 is already published.'),
+        'already-published',
+      );
+    });
+
+    it('classifies an unrecognized error as fatal', () => {
+      assert.strictEqual(classifyFailure('Error: Invalid Personal Access Token'), 'fatal');
+    });
+  });
+
+  describe('backoffDelayMs', () => {
+    it('grows exponentially starting at 1s', () => {
+      assert.strictEqual(backoffDelayMs(1), 1000);
+      assert.strictEqual(backoffDelayMs(2), 4000);
+      assert.strictEqual(backoffDelayMs(3), 16000);
+    });
+  });
+
+  describe('publishToRegistry', () => {
+    it('succeeds immediately when the run succeeds on the first attempt', async () => {
+      let calls = 0;
+      const result = await publishToRegistry({
+        label: 'Test Registry',
+        run: async () => {
+          calls += 1;
+          return { ok: true, output: '' };
+        },
+      });
+      assert.strictEqual(result.status, 'published');
+      assert.strictEqual(result.attempt, 1);
+      assert.strictEqual(calls, 1);
+    });
+
+    it('retries transient failures and eventually succeeds', async () => {
+      let calls = 0;
+      const sleeps: number[] = [];
+      const result = await publishToRegistry({
+        label: 'Test Registry',
+        run: async () => {
+          calls += 1;
+          if (calls < 3) {
+            return { ok: false, output: 'Request timeout: /_apis/gallery' };
+          }
+          return { ok: true, output: '' };
+        },
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      });
+      assert.strictEqual(result.status, 'published');
+      assert.strictEqual(calls, 3);
+      assert.deepStrictEqual(sleeps, [1000, 4000]);
+    });
+
+    it('treats "already published" as a terminal success without retrying further', async () => {
+      let calls = 0;
+      const result = await publishToRegistry({
+        label: 'Test Registry',
+        run: async () => {
+          calls += 1;
+          return { ok: false, output: 'Error: version is already published.' };
+        },
+      });
+      assert.strictEqual(result.status, 'already-published');
+      assert.strictEqual(calls, 1);
+    });
+
+    it('fails fast on a fatal error without retrying', async () => {
+      let calls = 0;
+      const result = await publishToRegistry({
+        label: 'Test Registry',
+        run: async () => {
+          calls += 1;
+          return { ok: false, output: 'Error: Invalid Personal Access Token' };
+        },
+      });
+      assert.strictEqual(result.status, 'failed');
+      assert.strictEqual(calls, 1);
+    });
+
+    it('gives up after exhausting attempts on repeated transient failures', async () => {
+      let calls = 0;
+      const result = await publishToRegistry({
+        label: 'Test Registry',
+        attempts: 3,
+        sleep: async () => {},
+        run: async () => {
+          calls += 1;
+          return { ok: false, output: 'ETIMEDOUT' };
+        },
+      });
+      assert.strictEqual(result.status, 'failed');
+      assert.strictEqual(calls, 3);
+    });
+  });
+});

--- a/src/test/unit/verifyPublished.test.ts
+++ b/src/test/unit/verifyPublished.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+describe('verifyPublished', () => {
+  let marketplaceHasVersion: (
+    versions: Array<{ version: string; properties?: Array<{ key: string; value: string }> }>,
+    version: string,
+    expectPreRelease: boolean,
+  ) => boolean;
+  let pollUntil: (
+    check: () => Promise<boolean>,
+    opts?: { attempts?: number; delayMs?: number; sleep?: (ms: number) => Promise<void> },
+  ) => Promise<boolean>;
+
+  before(async () => {
+    const modulePath = path.join(__dirname, '..', '..', '..', 'scripts', 'verifyPublished.mjs');
+    ({ marketplaceHasVersion, pollUntil } = await import(modulePath));
+  });
+
+  describe('marketplaceHasVersion', () => {
+    const versions = [
+      { version: '0.18.0', properties: [] },
+      {
+        version: '0.19.0',
+        properties: [{ key: 'Microsoft.VisualStudio.Code.PreRelease', value: 'true' }],
+      },
+    ];
+
+    it('returns false when the version is absent', () => {
+      assert.strictEqual(marketplaceHasVersion(versions, '0.20.0', false), false);
+    });
+
+    it('returns true for a stable check when the version exists, regardless of properties', () => {
+      assert.strictEqual(marketplaceHasVersion(versions, '0.18.0', false), true);
+    });
+
+    it('returns true only when the PreRelease marker is set for a pre-release check', () => {
+      assert.strictEqual(marketplaceHasVersion(versions, '0.19.0', true), true);
+      assert.strictEqual(marketplaceHasVersion(versions, '0.18.0', true), false);
+    });
+  });
+
+  describe('pollUntil', () => {
+    it('returns true as soon as the check passes, without sleeping again', async () => {
+      let calls = 0;
+      const sleeps: number[] = [];
+      const result = await pollUntil(
+        async () => {
+          calls += 1;
+          return calls === 2;
+        },
+        {
+          attempts: 5,
+          delayMs: 111,
+          sleep: async (ms) => {
+            sleeps.push(ms);
+          },
+        },
+      );
+      assert.strictEqual(result, true);
+      assert.strictEqual(calls, 2);
+      assert.deepStrictEqual(sleeps, [111]);
+    });
+
+    it('returns false after exhausting all attempts', async () => {
+      let calls = 0;
+      const result = await pollUntil(
+        async () => {
+          calls += 1;
+          return false;
+        },
+        { attempts: 3, delayMs: 1, sleep: async () => {} },
+      );
+      assert.strictEqual(result, false);
+      assert.strictEqual(calls, 3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`v0.17.0` was tagged and committed by the Pre-release workflow but never reached the VS Code Marketplace or Open VSX. Root cause chain:

1. `vsce publish` hit a transient `Request timeout: /_apis/gallery` from the Marketplace gallery endpoint.
2. `publishCmd` was `vsce publish ... && ovsx publish ...` — the `&&` meant Open VSX was never even attempted once vsce failed.
3. By the time `publish` runs, `prepare` (`@semantic-release/git`) had already committed the version bump and pushed the `v0.17.0` tag — so the failure left an orphaned tag on `main`.
4. Recovery via GitHub's "Re-run failed jobs" replayed the *original* (now stale) commit SHA. semantic-release saw `main` had moved past it, logged "the local branch main is behind the remote one", and **exited 0** — a green run that published nothing, with no verification step to catch it.
5. A subsequent stable `Release` published `0.18.0`, permanently orphaning `0.17.0` (both registries serve one increasing version line; clients always install the highest version on their channel).

This PR makes the pipeline resilient to (1)–(2), fail loudly instead of silently on (3)–(4), and adds a recovery path.

- **`scripts/publishVsix.mjs`** — publishes both registries independently via `Promise.allSettled` (a failure in one never blocks the other), with retry/backoff on transient errors, and treats "already published" as success — making the whole publish step idempotent and safe to re-run. `release.config.js`'s `publishCmd` now calls this instead of the `&&` chain.
- **`scripts/verifyPublished.mjs`** — polls the Marketplace gallery API and Open VSX after a release and fails the job if the version isn't actually live (this is the check that would have caught the incident within minutes instead of never).
- **`release.yml` / `pre-release.yml`** — both now reject re-runs outright (`github.run_attempt != 1`, with an explanatory error), detect the specific "branch is behind" false-success log signature, and call `verifyPublished.mjs`. `pre-release.yml` additionally refuses to start a new release if the last tag has no matching GitHub release (a sign a previous run failed mid-publish). Note: the stable lane's "no new tag" outcome is *not* itself treated as a failure, since `commit-analyzer` can legitimately decide there's nothing to release — only the specific stale-branch signature is.
- **`publish.yml`** — repurposed from a deprecated one-off script into **Republish (recovery)**: `workflow_dispatch` with `tag` + `pre_release` inputs, calling the same idempotent `publishVsix.mjs`. Safe to run against a tag that partially published. `tag.yml`'s existing `workflow_call` into it is unchanged (contract preserved).
- **`docs/releasing.md`** — documents the recovery runbook ("If a release workflow fails" / "If a version was skipped entirely").

`v0.17.0` itself is abandoned (unreachable by any client regardless); the next pre-release will be `0.19.0`, computed correctly by the existing odd/even convention.

## Test plan

- [x] `yarn compile` (type check + lint) passes
- [x] `yarn test:unit` passes — 840/840, including 15 new tests for `publishVsix.mjs` (failure classification, backoff, retry/already-published/fatal semantics) and `verifyPublished.mjs` (marketplace pre-release detection, polling)
- [x] All 4 touched workflow YAML files validated with `actionlint` (shellcheck-integrated) — no findings
- [x] `node scripts/publishVsix.mjs` / `node scripts/verifyPublished.mjs` run standalone and print correct usage errors on missing args
- [ ] Manual: dispatch **Pre-release** for real once there's a commit past `0.18.0` on `main`, confirm `0.19.0` lands on both registries and `verifyPublished.mjs` passes
- [ ] Manual: dispatch **Republish** against a synthetic/test tag to confirm the recovery path end-to-end (not exercised in this PR — no real credentials/registries touched)