### PR TITLE
fix(stash): stop wiping tracked changes before popping post-pull/rebase stash

### DIFF
--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -155,12 +155,21 @@ export class AutoStashService {
     }
 
     if (isWorkdirHasChangesBeforeStash) {
-      const isWorkdirHasChanges = await git.isWorkdirHasChanges();
-      if (isWorkdirHasChanges) {
-        await git.resetLocalChanges();
+      try {
+        await git.popStash(stashMessage);
+      } catch (e) {
+        const conflicts = await git.getConflictedFiles();
+        if (conflicts.length > 0) {
+          // The pull/rebase left tracked changes in the tree that overlap the stash. Git's
+          // `stash pop` already leaves the stash intact when the pop itself conflicts, so
+          // route to the same rescue flow used elsewhere instead of wiping the tree.
+          await offerConflictRescue(git, conflicts, 'pop');
+          capture(event, { had_changes: isWorkdirHasChangesBeforeStash, stashConflict: true });
+          this.onStashesChanged?.();
+          return;
+        }
+        throw e;
       }
-
-      await git.popStash(stashMessage);
     }
 
     capture(event, { had_changes: isWorkdirHasChangesBeforeStash });
@@ -200,11 +209,21 @@ export class AutoStashService {
     }
 
     if (isWorkdirHasChanges) {
-      const hasChangesAfterRebase = await git.isWorkdirHasChanges();
-      if (hasChangesAfterRebase) {
-        await git.resetLocalChanges();
+      try {
+        await git.popStash(stashMessage);
+      } catch (e) {
+        const conflicts = await git.getConflictedFiles();
+        if (conflicts.length > 0) {
+          // The rebase left tracked changes in the tree that overlap the stash. Git's
+          // `stash pop` already leaves the stash intact when the pop itself conflicts, so
+          // route to the same rescue flow used elsewhere instead of wiping the tree.
+          await offerConflictRescue(git, conflicts, 'pop');
+          capture(AnalyticsEvent.RebaseWithStash, { stash_mode: mode, had_changes: isWorkdirHasChanges, stashConflict: true });
+          this.onStashesChanged?.();
+          return;
+        }
+        throw e;
       }
-      await git.popStash(stashMessage);
     }
 
     capture(AnalyticsEvent.RebaseWithStash, { stash_mode: mode, had_changes: isWorkdirHasChanges });

--- a/src/test/e2e/rebaseWithStash.test.ts
+++ b/src/test/e2e/rebaseWithStash.test.ts
@@ -157,7 +157,7 @@ describe('AutoStashService - rebaseAndStashChanges', () => {
     before(() => { repo = createRebaseTestRepo(); });
     after(() => { repo.cleanup(); });
 
-    it('resets tracked changes created by a successful rebase before popping the stash', async () => {
+    it('preserves tracked changes created by a successful rebase when popping the stash', async () => {
       repo.makeChange('file1.txt', 'tracked work in progress\n');
 
       const hookPath = path.join(repo.repoPath, '.git', 'hooks', 'post-rewrite');
@@ -167,7 +167,7 @@ describe('AutoStashService - rebaseAndStashChanges', () => {
       await sut.rebaseAndStashChanges(repo.git, repo.featureBranch, repo.mainBranch, AUTO_STASH_CURRENT_BRANCH);
 
       assertHeadContains(repo, repo.mainBranch);
-      assert.strictEqual(repo.readFile('main.txt'), 'main content\n', 'hook change should be discarded');
+      assert.strictEqual(repo.readFile('main.txt'), 'hook dirtied main\n', 'hook change must not be discarded');
       assert.strictEqual(repo.readFile('file1.txt'), 'tracked work in progress\n', 'original stash should be restored');
       assert.strictEqual(repo.stashCount(), 0);
     });

--- a/src/test/unit/pullAndStashChanges.test.ts
+++ b/src/test/unit/pullAndStashChanges.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 
 import { ConfigurationManager } from '../../configuration/configurationManager';
 import { GitExecutor } from '../../common/git/gitExecutor';
@@ -7,12 +8,16 @@ import { mockLogService } from '../e2e/helpers/mockLogService';
 
 function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
   return {
+    repositoryPath: '/repo',
     isWorkdirHasChanges: async () => true,
     createStash: async () => {},
     hasUpstreamBranch: async () => true,
     pullFromRemoteBranch: async () => {},
     popStash: async () => {},
     resetLocalChanges: async () => {},
+    getConflictedFiles: async () => [],
+    isMergeInProgress: async () => false,
+    isCherryPickInProgress: async () => false,
     ...overrides,
   } as unknown as GitExecutor;
 }
@@ -101,5 +106,50 @@ describe('AutoStashService.pullAndStashChanges', () => {
     );
 
     assert.deepStrictEqual(popCalls, []);
+  });
+
+  it('does not discard post-pull tracked changes: pops the stash directly without resetting the working tree', async () => {
+    const resetCalls: number[] = [];
+    const popCalls: string[] = [];
+    const git = makeGitStub({
+      // Dirty both before the stash and after a successful pull (e.g. renormalization,
+      // merge side effects) — this must NOT be wiped via `git restore .` before popping.
+      isWorkdirHasChanges: async () => true,
+      resetLocalChanges: (async () => {
+        resetCalls.push(1);
+      }) as unknown as GitExecutor['resetLocalChanges'],
+      popStash: (async (msg: string) => {
+        popCalls.push(msg);
+      }) as unknown as GitExecutor['popStash'],
+    });
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await service.pullAndStashChanges(git, 'feature-x', 'merge');
+
+    assert.deepStrictEqual(resetCalls, []);
+    assert.strictEqual(popCalls.length, 1);
+  });
+
+  it('routes a conflicted post-pull stash pop to the rescue flow instead of failing silently', async () => {
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async () => undefined;
+    try {
+      const git = makeGitStub({
+        isWorkdirHasChanges: async () => true,
+        popStash: async () => {
+          throw new Error('CONFLICT (content): Merge conflict in file.ts');
+        },
+        getConflictedFiles: async () => ['file.ts'],
+      });
+
+      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+      // Must resolve (not throw) — the pull already succeeded, only the pop conflicted,
+      // and git leaves the stash intact on a conflicted `stash pop`.
+      await service.pullAndStashChanges(git, 'feature-x', 'merge');
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
   });
 });

--- a/src/test/unit/rebaseAndStashChanges.test.ts
+++ b/src/test/unit/rebaseAndStashChanges.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { AUTO_STASH_CURRENT_BRANCH } from '../../commands/checkoutToCommand/constants';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { AutoStashService } from '../../services/autoStashService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function makeGitStub(overrides: Partial<GitExecutor> = {}): GitExecutor {
+  return {
+    repositoryPath: '/repo',
+    isWorkdirHasChanges: async () => true,
+    createStash: async () => {},
+    rebase: async () => {},
+    popStash: async () => {},
+    resetLocalChanges: async () => {},
+    getConflictedFiles: async () => [],
+    isMergeInProgress: async () => false,
+    isCherryPickInProgress: async () => false,
+    ...overrides,
+  } as unknown as GitExecutor;
+}
+
+describe('AutoStashService.rebaseAndStashChanges', () => {
+  it('does not discard post-rebase tracked changes: pops the stash directly without resetting the working tree', async () => {
+    const resetCalls: number[] = [];
+    const popCalls: string[] = [];
+    const git = makeGitStub({
+      // Dirty both before the stash and after a successful rebase — this must NOT be
+      // wiped via `git restore .` before popping.
+      isWorkdirHasChanges: async () => true,
+      resetLocalChanges: (async () => {
+        resetCalls.push(1);
+      }) as unknown as GitExecutor['resetLocalChanges'],
+      popStash: (async (msg: string) => {
+        popCalls.push(msg);
+      }) as unknown as GitExecutor['popStash'],
+    });
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await service.rebaseAndStashChanges(git, 'feature-x', 'main', AUTO_STASH_CURRENT_BRANCH);
+
+    assert.deepStrictEqual(resetCalls, []);
+    assert.strictEqual(popCalls.length, 1);
+  });
+
+  it('routes a conflicted post-rebase stash pop to the rescue flow instead of failing silently', async () => {
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async () => undefined;
+    try {
+      const git = makeGitStub({
+        isWorkdirHasChanges: async () => true,
+        popStash: async () => {
+          throw new Error('CONFLICT (content): Merge conflict in file.ts');
+        },
+        getConflictedFiles: async () => ['file.ts'],
+      });
+
+      const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+      // Must resolve (not throw) — the rebase already succeeded, only the pop conflicted,
+      // and git leaves the stash intact on a conflicted `stash pop`.
+      await service.rebaseAndStashChanges(git, 'feature-x', 'main', AUTO_STASH_CURRENT_BRANCH);
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
+  it('rethrows non-conflict pop errors', async () => {
+    const git = makeGitStub({
+      isWorkdirHasChanges: async () => true,
+      popStash: async () => {
+        throw new Error('No stash found');
+      },
+      getConflictedFiles: async () => [],
+    });
+
+    const service = new AutoStashService({} as ConfigurationManager, mockLogService);
+
+    await assert.rejects(
+      () => service.rebaseAndStashChanges(git, 'feature-x', 'main', AUTO_STASH_CURRENT_BRANCH),
+      /No stash found/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `AutoStashService.pullAndStashChanges` / `rebaseAndStashChanges` used to call `git.resetLocalChanges()` (`git restore .`) whenever the working tree was dirty after a successful pull/rebase, right before popping the auto-stash. `git restore .` unconditionally discards **all** unstaged tracked modifications, so any legitimate post-pull/rebase change (merge side effects, line-ending renormalization, hooks touching files) was silently destroyed before the stash was restored.
- Removed that reset and pop the stash directly. If the pop itself conflicts, route to the existing `offerConflictRescue` flow (same mechanism already used elsewhere in this service) instead of pre-wiping the tree — git's own `stash pop` already leaves the stash intact when the pop conflicts, so no data is lost either way.
- Addresses item 4 in `TO_IMPLEMENT.md`.

## Test plan
- [x] `yarn compile`
- [x] `yarn test:unit` (873 passing, including 5 new tests covering: no-reset-before-pop for both pull and rebase, and conflicted-pop rescue routing for both)
- [ ] Manual smoke test: pull a branch where the pull leaves tracked changes in the tree, confirm those changes survive after the stash pops