### PR TITLE
fix: force LC_ALL=C for git subprocesses

### DIFF
--- a/src/test/unit/execCommand.test.ts
+++ b/src/test/unit/execCommand.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+
+import { execCommand } from '../../utils/execCommand';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+describe('execCommand', () => {
+  it('pins LC_ALL and LANG to C so git output cannot be localized', async () => {
+    const { stdout } = await execCommand(
+      process.execPath,
+      ['-e', 'process.stdout.write(`${process.env.LC_ALL}|${process.env.LANG}`)'],
+      mockLogService,
+      { env: { ...process.env, LC_ALL: 'de_DE.UTF-8', LANG: 'de_DE.UTF-8' } }
+    );
+
+    assert.strictEqual(stdout, 'C|C');
+  });
+
+  it('preserves other options such as cwd while pinning the locale', async () => {
+    const { stdout } = await execCommand(
+      process.execPath,
+      ['-e', 'process.stdout.write(process.cwd())'],
+      mockLogService,
+      { cwd: __dirname }
+    );
+
+    assert.strictEqual(stdout, __dirname);
+  });
+});

--- a/src/utils/execCommand.ts
+++ b/src/utils/execCommand.ts
@@ -11,7 +11,11 @@ export async function execCommand(
   options?: ExecFileOptions
 ): Promise<TPromiseResponse> {
   const commandStr = [file, ...args].join(' ');
-  const combinedOptions = { encoding: 'utf-8' as const, ...options };
+  const combinedOptions = {
+    encoding: 'utf-8' as const,
+    ...options,
+    env: { ...process.env, ...options?.env, LC_ALL: 'C', LANG: 'C' },
+  };
 
   return new Promise((resolve, reject) => {
     execFile(file, args, combinedOptions, (err, stdout, stderr) => {


### PR DESCRIPTION
## Summary
- Pins `LC_ALL=C` and `LANG=C` in `execCommand`'s `execFile` options (merged with any caller-supplied options, preserving `cwd` and other fields), so every git subprocess this extension spawns always emits English output.
- Several call sites string-match English git output for control flow: `gitExecutor.ts` `createStash` (checks stdout for `'No local changes to save'`), `cherryPick` (checks stderr for `'previous cherry-pick is now empty'`), and `handleErrorMessage.ts` (`error.message === 'No local changes to save'`). On a machine with a localized git (e.g. German/Japanese), those matches silently fail to catch, causing phantom-stash behavior and misclassified empty cherry-picks.
- Checked `src/services/worktreeSetupService.ts`: its git calls (`ls-files --others -z`) only parse a NUL-delimited filename list, not locale-sensitive prose, so no change was needed there. Its user-configured setup command runs via `spawn` with the user's own environment, left untouched intentionally.
- To verify manually: `LANG=de_DE.UTF-8 code .`, then run "GSC: Checkout to…" with a clean working tree — no phantom-stash behavior should occur.

Closes #203

## Test plan
- [x] Unit tests pass (`yarn test:unit`) — added `src/test/unit/execCommand.test.ts` asserting `execCommand` pins `LC_ALL=C`/`LANG=C` even when overridden, and preserves other options like `cwd`.
- [x] Type check + lint pass (`yarn compile`)
- [ ] Manual smoke test in VS Code extension host