### PR TITLE
fix: prevent hard reset from destroying unstashed work in PR clone

### DIFF
--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -24,6 +24,8 @@ interface IServiceStore {
   createdBranchName?: string;
   stashMessage?: string;
   originalPrData?: PrCloneData;
+  /** Whether the working tree had uncommitted changes at the start of the clone. */
+  hadUncommittedChanges?: boolean;
 }
 
 /** Key used to persist an in-progress in-place clone operation so it can survive a window reload/crash. */
@@ -206,10 +208,27 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       }
 
       if (this.serviceStore.createdBranchName) {
-        try {
-          await this.git.reset(true);
-        } catch (error) {
-          this.loggingService.warn(`Failed to reset working directory: ${error}`);
+        // A hard reset is only safe when there's nothing uncommitted to lose: either the
+        // uncommitted changes were actually stashed, or the tree was already clean at the
+        // start of the clone. If uncommitted changes exist that were never safely stashed
+        // (e.g. `createStash` itself failed), skip the destructive reset so we don't wipe
+        // the user's work — the checkout/branch-delete cleanup below still runs.
+        const safeToHardReset =
+          Boolean(this.serviceStore.stashMessage) || !this.serviceStore.hadUncommittedChanges;
+
+        if (safeToHardReset) {
+          try {
+            await this.git.reset(true);
+          } catch (error) {
+            this.loggingService.warn(`Failed to reset working directory: ${error}`);
+          }
+        } else {
+          this.loggingService.warn(
+            'Skipping hard reset during clone cleanup: uncommitted changes exist that were never stashed. Your working tree changes are preserved.'
+          );
+          await window.showWarningMessage(
+            'PR clone cleanup: your uncommitted changes could not be safely stashed, so they were left in your working tree instead of being discarded.'
+          );
         }
       }
 
@@ -302,6 +321,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       updateProgress.report({ message: 'Checking for uncommitted changes...' });
 
       const hasUncommittedChanges = await this.git.isWorkdirHasChanges();
+      this.serviceStore.hadUncommittedChanges = hasUncommittedChanges;
       if (hasUncommittedChanges) {
         this.serviceStore.stashMessage = getStashMessage(this.serviceStore.originalBranch, true);
         this.loggingService.info(`Stashing uncommitted changes: ${this.serviceStore.stashMessage}`);
@@ -310,8 +330,13 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
           await this.git.createStash(this.serviceStore.stashMessage);
           this.loggingService.info('Changes stashed successfully');
         } catch (error) {
-          this.loggingService.warn(`Failed to stash changes: ${error}`);
           this.serviceStore.stashMessage = undefined;
+          // Continuing here would leave the tree dirty with no safety net: a later failure
+          // routes to cleanup, which could otherwise hard-reset and destroy this work. Abort
+          // the clone immediately instead, before anything else (fetch, branch creation) happens.
+          throw new Error(
+            `Failed to stash your uncommitted changes (${error}). The PR clone was aborted to protect your working tree. Commit or stash manually and retry.`
+          );
         }
       }
 

--- a/src/test/unit/prCloneErrorRecovery.test.ts
+++ b/src/test/unit/prCloneErrorRecovery.test.ts
@@ -166,6 +166,61 @@ describe('PrCloneInPlaceService error recovery', () => {
     );
     assert.strictEqual(service.reportedErrors.length, 2);
   });
+
+  it('aborts before fetching and never hard-resets when stash creation fails on a dirty tree', async () => {
+    const events: string[] = [];
+    const stashError = new Error('index locked');
+
+    const git = {
+      getCurrentBranch: async () => {
+        events.push('get-current-branch');
+        return 'original';
+      },
+      isWorkdirHasChanges: async () => true,
+      createStash: async (message: string) => {
+        events.push(`stash-attempt:${message}`);
+        throw stashError;
+      },
+      fetchPullRequestHead: async () => {
+        events.push('fetch');
+      },
+      checkout: async (branch: string) => {
+        events.push(`checkout:${branch}`);
+      },
+      isCherryPickInProgress: async () => false,
+      reset: async () => {
+        events.push('reset');
+      },
+      deleteLocalBranch: async (branch: string) => {
+        events.push(`delete:${branch}`);
+      },
+    } as unknown as GitExecutor;
+
+    const service = new TestPrCloneInPlaceService(git, {} as GitHubClient, mockLogService);
+
+    await assert.rejects(service.clonePR(cloneData), (error: unknown) => {
+      assert.ok(error instanceof PrCloneReportedError);
+      assert.ok(
+        error.originalError instanceof Error &&
+          error.originalError.message.includes('Failed to stash your uncommitted changes')
+      );
+      return true;
+    });
+
+    // The clone must abort right after the failed stash attempt, before ever fetching the
+    // PR's commits, and cleanup must never hard-reset since no stash was actually created.
+    assert.ok(
+      events.some((event) => event.startsWith('stash-attempt:')),
+      'a stash attempt must have been made'
+    );
+    assert.ok(!events.includes('fetch'), 'fetch must never run after a failed stash');
+    assert.ok(!events.includes('reset'), 'hard reset must never run when changes were never stashed');
+    assert.strictEqual(service.reportedErrors.length, 1);
+    assert.ok(
+      String(service.reportedErrors[0]).includes('Failed to stash your uncommitted changes'),
+      'the reported error should explain the abort'
+    );
+  });
 });
 
 describe('PrCloneWebViewProvider clone state recovery', () => {


### PR DESCRIPTION
## Summary
- If `createStash` fails while the working tree is dirty during an in-place PR clone, the clone previously logged a warning and continued. A later failure (e.g. cherry-pick conflict) then routed to `cleanUp(true)`, which ran `git reset --hard` and permanently destroyed the user's uncommitted changes.
- The stash-creation catch block now aborts the clone immediately with a clear error message ("Failed to stash your uncommitted changes ... The PR clone was aborted to protect your working tree. Commit or stash manually and retry."), before any fetch or branch creation happens.
- `cleanUp()` now only runs `git reset --hard` when it's actually safe: a stash was created, or the tree was already clean at clone start (tracked via a new `hadUncommittedChanges` flag on the service store). Otherwise it skips the reset, still checks out the original branch / deletes the temp branch, and warns the user their changes were left in the working tree instead of being discarded.
- To test manually: start a PR clone with uncommitted changes present, make `git stash` fail (e.g. a locked index), and confirm the clone aborts with the new message and the working tree changes are still there.

## Test plan
- [x] Unit/integration tests pass (`yarn test:unit`, 869 passing)
- [x] Type check + lint pass (`yarn compile`)
- [x] New unit test: mocks `createStash` to throw with a dirty workdir, asserts `fetchPullRequestHead` is never called and `reset(true)` is never called during cleanup

Closes #205