### PR TITLE
fix: preserve detached HEAD state for PR-clone rollback

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -617,6 +617,11 @@ export class GitExecutor {
     return stdout.trim();
   }
 
+  async getHeadCommit() {
+    const { stdout } = await this.#execGitCommand(['rev-parse', 'HEAD']);
+    return stdout.trim();
+  }
+
   async listRemotes(): Promise<Array<{ name: string; fetchUrl: string; pushUrl: string }>> {
     const { stdout } = await this.#execGitCommand(['remote', '-v']);
     const remotes = new Map<string, { name: string; fetchUrl: string; pushUrl: string }>();

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -21,6 +21,10 @@ import { PrCloneReportedError } from './prCloneError';
 
 interface IServiceStore {
   originalBranch?: string;
+  /** Ref to restore on cleanup: the original branch name, or the original commit SHA when HEAD was detached. */
+  originalRef?: string;
+  /** True when the clone was started from a detached HEAD (so `originalRef` is a SHA, not a branch). */
+  isDetached?: boolean;
   createdBranchName?: string;
   stashMessage?: string;
   originalPrData?: PrCloneData;
@@ -37,6 +41,10 @@ export const PR_CLONE_IN_PLACE_STATE_KEY = 'gitSmartCheckout.prCloneInPlaceOpera
 export interface IPersistedCloneOperation {
   repoPath: string;
   originalBranch: string;
+  /** Ref to restore on cleanup: the original branch name, or the original commit SHA when HEAD was detached. */
+  originalRef: string;
+  /** True when the clone was started from a detached HEAD (so `originalRef` is a SHA, not a branch). */
+  isDetached: boolean;
   createdBranchName: string;
   stashMessage?: string;
   /** Shas that still need to land, including the one that may currently be mid-conflict. */
@@ -192,7 +200,8 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
       // A service for an inactive clone mode can be disposed without ever
       // touching the repository. Do not reset that repository during cleanup.
-      if (!this.serviceStore.originalBranch) {
+      const restoreRef = this.serviceStore.originalBranch || this.serviceStore.originalRef;
+      if (!restoreRef) {
         return;
       }
 
@@ -224,12 +233,15 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       let restoredOriginalBranch = false;
       if (!stayOnClonedBranch) {
         try {
-          await this.git.checkout(this.serviceStore.originalBranch);
+          if (this.serviceStore.isDetached) {
+            // Detached HEAD has no branch to restore — check out the captured SHA directly.
+            await this.git.checkout(restoreRef);
+          } else {
+            await this.git.checkout(this.serviceStore.originalBranch || restoreRef);
+          }
           restoredOriginalBranch = true;
         } catch (error) {
-          this.loggingService.warn(
-            `Failed to restore original branch '${this.serviceStore.originalBranch}': ${error}`
-          );
+          this.loggingService.warn(`Failed to restore original ref '${restoreRef}': ${error}`);
         }
 
         if (restoredOriginalBranch && this.serviceStore.stashMessage) {
@@ -299,6 +311,15 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
       // Step 1: Store original branch and stash changes if needed
       this.serviceStore.originalBranch = await this.git.getCurrentBranch();
+      if (!this.serviceStore.originalBranch) {
+        // Detached HEAD: capture the commit SHA so cleanup can still restore the original
+        // state instead of silently leaving the clone's branch/stash/commits behind.
+        this.serviceStore.originalRef = await this.git.getHeadCommit();
+        this.serviceStore.isDetached = true;
+      } else {
+        this.serviceStore.originalRef = this.serviceStore.originalBranch;
+        this.serviceStore.isDetached = false;
+      }
       updateProgress.report({ message: 'Checking for uncommitted changes...' });
 
       const hasUncommittedChanges = await this.git.isWorkdirHasChanges();
@@ -455,14 +476,17 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       return;
     }
 
-    const { originalBranch, createdBranchName, stashMessage, originalPrData } = this.serviceStore;
-    if (!originalBranch || !createdBranchName || !originalPrData) {
+    const { originalBranch, originalRef, isDetached, createdBranchName, stashMessage, originalPrData } =
+      this.serviceStore;
+    if ((!originalBranch && !originalRef) || !createdBranchName || !originalPrData) {
       return;
     }
 
     const record: IPersistedCloneOperation = {
       repoPath: this.git.repositoryPath,
-      originalBranch,
+      originalBranch: originalBranch ?? '',
+      originalRef: originalRef ?? originalBranch ?? '',
+      isDetached: isDetached ?? false,
       createdBranchName,
       stashMessage,
       remainingShas: [...this.remainingShas],
@@ -488,6 +512,8 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
   private restoreServiceStoreFromRecord(record: IPersistedCloneOperation): void {
     this.serviceStore = {
       originalBranch: record.originalBranch,
+      originalRef: record.originalRef,
+      isDetached: record.isDetached,
       createdBranchName: record.createdBranchName,
       stashMessage: record.stashMessage,
       originalPrData: {

--- a/src/test/unit/prCloneDetachedHead.test.ts
+++ b/src/test/unit/prCloneDetachedHead.test.ts
@@ -1,0 +1,173 @@
+import * as assert from 'assert';
+import { Memento } from 'vscode';
+
+import { GitHubClient } from '../../common/api/ghClient';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import {
+  IPersistedCloneOperation,
+  PR_CLONE_IN_PLACE_STATE_KEY,
+  PrCloneInPlaceService,
+} from '../../services/prCloneInPlaceService';
+import { PrCloneData } from '../../services/prCloneService';
+import { GitHubPR } from '../../types/dataTypes';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Regression tests for issue 204: "Detached HEAD silently disables PR-clone rollback".
+ *
+ * When a PR clone is started from a detached HEAD, `getCurrentBranch()` returns `''`, which
+ * used to make cleanUp() short-circuit (nothing restored, created branch/stash left behind)
+ * and persistState() refuse to write a crash-recovery record. The fix captures the detached
+ * commit SHA via `getHeadCommit()` and restores/persists against that instead.
+ */
+
+function createFakeMemento(): Memento {
+  const store = new Map<string, unknown>();
+
+  return {
+    get: ((key: string, defaultValue?: unknown) =>
+      store.has(key) ? store.get(key) : defaultValue) as Memento['get'],
+    update: async (key: string, value: unknown) => {
+      if (value === undefined) {
+        store.delete(key);
+      } else {
+        store.set(key, value);
+      }
+    },
+    keys: () => [...store.keys()],
+  };
+}
+
+const prData = {
+  number: 204,
+  title: 'Detached HEAD PR',
+  body: 'desc',
+  head: { ref: 'feature/source' },
+  base: { ref: 'main' },
+  labels: [],
+  assignees: [],
+} as unknown as GitHubPR;
+
+const cloneData: PrCloneData = {
+  prData,
+  targetBranch: 'main',
+  featureBranch: 'feature/clone',
+  description: 'desc',
+  selectedCommits: ['c1'],
+  isDraft: false,
+};
+
+const DETACHED_SHA = 'abc1234deadbeefabc1234deadbeefabc1234de';
+
+function createDetachedGitStub(repositoryPath = '/repo') {
+  const calls = {
+    reset: 0,
+    checkout: [] as string[],
+    popStash: [] as string[],
+    deleteLocalBranch: [] as string[],
+    cherryPickAbort: 0,
+    isCherryPickInProgress: 0,
+  };
+
+  const git = {
+    repositoryPath,
+    getCurrentBranch: async () => '',
+    getHeadCommit: async () => DETACHED_SHA,
+    isWorkdirHasChanges: async () => false,
+    fetchPullRequestHead: async () => {},
+    checkout: async (branch: string) => {
+      calls.checkout.push(branch);
+    },
+    pullCurrentBranch: async () => {},
+    createUniqueFeatureBranch: async () => 'feature/clone',
+    commitExists: async () => true,
+    hasConflicts: async () => false,
+    cherryPick: async () => ({ conflicts: false }),
+    isCherryPickInProgress: async () => {
+      calls.isCherryPickInProgress += 1;
+      return false;
+    },
+    reset: async () => {
+      calls.reset += 1;
+    },
+    popStash: async (message: string) => {
+      calls.popStash.push(message);
+    },
+    deleteLocalBranch: async (branch: string) => {
+      calls.deleteLocalBranch.push(branch);
+    },
+    cherryPickAbort: async () => {
+      calls.cherryPickAbort += 1;
+    },
+    pushBranchToGitHub: async () => {},
+  } as unknown as GitExecutor;
+
+  return { git, calls };
+}
+
+describe('PrCloneInPlaceService detached-HEAD rollback (issue 204)', () => {
+  it('captures the HEAD SHA and persists state when started from detached HEAD', async () => {
+    const memento = createFakeMemento();
+    const { git } = createDetachedGitStub();
+    // Stall on a conflict so we can inspect the persisted record before cleanup runs.
+    (git as any).cherryPick = async () => ({ conflicts: true });
+    const service = new PrCloneInPlaceService(git, {} as GitHubClient, mockLogService, memento);
+
+    await service.clonePR(cloneData);
+
+    const persisted = memento.get<IPersistedCloneOperation>(PR_CLONE_IN_PLACE_STATE_KEY);
+    assert.ok(persisted, 'a record should be persisted even though originalBranch is empty');
+    assert.strictEqual(persisted!.originalBranch, '', 'originalBranch stays empty for compatibility');
+    assert.strictEqual(persisted!.originalRef, DETACHED_SHA, 'originalRef must capture the detached SHA');
+    assert.strictEqual(persisted!.isDetached, true);
+  });
+
+  it('cleanUp checks out the captured SHA (not a branch name) instead of silently returning', async () => {
+    const memento = createFakeMemento();
+    const { git, calls } = createDetachedGitStub();
+    (git as any).cherryPick = async () => ({ conflicts: true });
+    const service = new PrCloneInPlaceService(git, {} as GitHubClient, mockLogService, memento);
+
+    await service.clonePR(cloneData);
+    // clonePR itself checks out the target branch and the new feature branch; only the
+    // checkout(s) issued by cleanUp (below) are relevant to this assertion.
+    calls.checkout.length = 0;
+
+    await service.abortClonePR();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(calls.reset, 1, 'a started clone must still hard-reset on abort');
+    assert.deepStrictEqual(
+      calls.checkout,
+      [DETACHED_SHA],
+      'cleanup must restore by checking out the captured SHA, not a (nonexistent) branch name'
+    );
+    assert.deepStrictEqual(
+      calls.deleteLocalBranch,
+      ['feature/clone'],
+      'the created feature branch must still be deleted on abort'
+    );
+    assert.strictEqual(
+      memento.get(PR_CLONE_IN_PLACE_STATE_KEY),
+      undefined,
+      'the persisted record must be cleared after abort'
+    );
+  });
+
+  it('cleanUp no longer short-circuits when originalBranch is empty but originalRef is set', async () => {
+    const { git, calls } = createDetachedGitStub();
+    const service = new PrCloneInPlaceService(git, {} as GitHubClient, mockLogService);
+
+    (service as any).serviceStore = {
+      originalBranch: '',
+      originalRef: DETACHED_SHA,
+      isDetached: true,
+      createdBranchName: 'feature/clone',
+    };
+
+    await (service as any).cleanUp(true);
+
+    assert.deepStrictEqual(calls.checkout, [DETACHED_SHA]);
+    assert.deepStrictEqual(calls.deleteLocalBranch, ['feature/clone']);
+  });
+});

--- a/src/test/unit/prCloneInterruptedRecovery.test.ts
+++ b/src/test/unit/prCloneInterruptedRecovery.test.ts
@@ -159,6 +159,8 @@ describe('checkForInterruptedPrClone activation flow', () => {
     return {
       repoPath: '/repo',
       originalBranch: 'original',
+      originalRef: 'original',
+      isDetached: false,
       createdBranchName: 'feature/clone',
       stashMessage: undefined,
       remainingShas: ['c2'],


### PR DESCRIPTION
## Summary
- `PrCloneInPlaceService.clonePR` used to store only `getCurrentBranch()`, which returns `''` when HEAD is detached (e.g. reviewing a tag/commit). `cleanUp()` then short-circuited on the empty branch, leaving the created feature branch, cherry-picked commits, and auto-stash behind on failure/abort, and `persistState()` refused to write a crash-recovery record.
- Added `GitExecutor.getHeadCommit()` (`git rev-parse HEAD`). `clonePR` now also captures the detached commit SHA into a new `originalRef`/`isDetached` pair on the service store and in `IPersistedCloneOperation`, alongside the existing `originalBranch` (kept for compatibility).
- `cleanUp()` now restores against `originalBranch || originalRef`, checking out the SHA directly when `isDetached` is true, instead of returning early.
- `persistState()` now persists whenever either `originalBranch` or `originalRef` is set.

## Test plan
- [x] Unit tests pass (`yarn test:unit`, 871 passing) — added `src/test/unit/prCloneDetachedHead.test.ts` covering: persisting `originalRef`/`isDetached` from a mocked `getCurrentBranch() → ''`, cleanup checking out the captured SHA on abort, and the `originalBranch` short-circuit no longer firing when only `originalRef` is set.
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test: `git checkout <some-tag>`, run PR clone, cancel mid-way, confirm HEAD is back on the original commit and the temp branch is deleted.

Closes #204