### PR TITLE
fix: use real cherry-pick conflict state instead of workdir-dirtiness heuristic

### DIFF
--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -142,23 +142,35 @@ export function parseStashNameStatusOutput(
 }
 
 /**
- * Parses `git status --porcelain` (v1) output into the changed/untracked paths it reports.
- * Each line is `XY <path>`; rename and copy entries are `XY <old> -> <new>`, and we report the
- * destination. Paths containing special characters arrive C-quoted (`"src/\303\251.ts"`) — the
- * surrounding quotes and the escapes git adds for `"` and `\` are undone so the path reads
- * naturally in UI.
+ * Parses `git status --porcelain` (v1) output into `{ status, path }` entries. Each line is
+ * `XY <path>`; rename and copy entries are `XY <old> -> <new>`, and we report the destination.
+ * Paths containing special characters arrive C-quoted (`"src/\303\251.ts"`) — the surrounding
+ * quotes and the escapes git adds for `"` and `\` are undone so the path reads naturally in UI.
  */
-export function parseStatusPorcelainPaths(output: string): string[] {
+export function parseStatusPorcelainEntries(output: string): Array<{ status: string; path: string }> {
   return output
     .split('\n')
     .filter((line) => line.trim().length > 0)
     .map((line) => {
+      const status = line.slice(0, 2);
       const pathPart = line.slice(3).trimEnd();
       const arrowIndex = pathPart.lastIndexOf(' -> ');
-      return unquoteStatusPath(arrowIndex === -1 ? pathPart : pathPart.slice(arrowIndex + 4));
+      const path = unquoteStatusPath(arrowIndex === -1 ? pathPart : pathPart.slice(arrowIndex + 4));
+      return { status, path };
     })
-    .filter((path) => path.length > 0);
+    .filter((entry) => entry.path.length > 0);
 }
+
+/** Paths of the changed/untracked files reported by `git status --porcelain`. */
+export function parseStatusPorcelainPaths(output: string): string[] {
+  return parseStatusPorcelainEntries(output).map((entry) => entry.path);
+}
+
+/**
+ * `git status --porcelain` XY status codes that indicate an unmerged/conflicted path: either
+ * side is `U`, or both sides agree on an add/add or delete/delete conflict.
+ */
+const UNMERGED_STATUS_CODES = new Set(['UU', 'AA', 'DD', 'AU', 'UA', 'UD', 'DU']);
 
 function unquoteStatusPath(path: string): string {
   if (!path.startsWith('"') || !path.endsWith('"') || path.length < 2) {
@@ -974,6 +986,29 @@ export class GitExecutor {
   async hasConflicts(): Promise<boolean> {
     const conflictedFiles = await this.getConflictedFiles();
     return conflictedFiles.length > 0;
+  }
+
+  /**
+   * Paths of files still unmerged per `git status --porcelain`'s XY status code (`UU`, `AA`,
+   * `DD`, `AU`, `UA`, `UD`, `DU` — either side `U`, or both `A`/both `D`). Used to distinguish a
+   * real unresolved conflict from a conflict the user resolved down to an empty diff, which
+   * `isWorkdirHasChanges()` alone cannot tell apart (see issue #207).
+   */
+  async getUnresolvedConflicts(): Promise<string[]> {
+    const { stdout } = await this.#execGitCommand(['status', '--porcelain']);
+    return parseStatusPorcelainEntries(stdout)
+      .filter(({ status }) => UNMERGED_STATUS_CODES.has(status))
+      .map(({ path }) => path);
+  }
+
+  /**
+   * Finishes an in-progress cherry-pick (`CHERRY_PICK_HEAD` set) whose conflict resolution
+   * collapsed to no diff against HEAD, by committing an intentionally empty commit with the
+   * original commit message. Equivalent to `cherry-pick --continue` for that case, which would
+   * otherwise fail with "previous cherry-pick is now empty".
+   */
+  async commitAllowEmpty(): Promise<void> {
+    await this.#execGitCommand(['commit', '--allow-empty', '--no-edit']);
   }
 
   async cherryPick(

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -82,10 +82,38 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
     }
 
     if (isContinue) {
+      const unresolvedConflicts = await this.git.getUnresolvedConflicts();
+      if (unresolvedConflicts.length > 0) {
+        await window.showWarningMessage(
+          `Cannot continue: the following files still have unresolved conflicts:\n${unresolvedConflicts.join('\n')}`,
+          { modal: true }
+        );
+        return;
+      }
+
       if (await this.git.isWorkdirHasChanges()) {
         await this.git.cherryPickContinue();
       } else {
-        await this.git.cherryPickSkip();
+        // The conflict resolution collapsed to no diff against HEAD — cherry-pick --continue
+        // would fail ("previous cherry-pick is now empty"). Never decide silently: ask the user.
+        const skipOption = 'Skip this commit';
+        const emptyOption = 'Keep as empty commit';
+        const abortOption = 'Abort clone';
+        const choice = await window.showQuickPick([skipOption, emptyOption, abortOption], {
+          placeHolder:
+            'Resolving the conflict produced no changes. What should happen to this commit?',
+          ignoreFocusOut: true,
+        });
+
+        if (choice === emptyOption) {
+          await this.git.commitAllowEmpty();
+        } else if (choice === skipOption) {
+          await this.git.cherryPickSkip();
+        } else {
+          // 'Abort clone' or dismissed (Escape) — never silently skip or continue.
+          await this.abortClonePR();
+          return;
+        }
       }
     }
 

--- a/src/test/unit/prCloneCherryPickContinueState.test.ts
+++ b/src/test/unit/prCloneCherryPickContinueState.test.ts
@@ -1,0 +1,212 @@
+import * as assert from 'assert';
+import { window as vscodeWindow } from 'vscode';
+
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { PrCloneInPlaceService } from '../../services/prCloneInPlaceService';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+/**
+ * Regression tests for issue #207: "Cherry-pick continue-vs-skip decided by workdir
+ * dirtiness — silently drops commits". `cherryPickNext(true)` must decide continue vs.
+ * skip vs. prompt from real cherry-pick state (`getUnresolvedConflicts()` +
+ * `isWorkdirHasChanges()`), never silently skip a legitimately-empty resolution.
+ */
+describe('PrCloneInPlaceService.cherryPickNext(true) conflict-state decision', () => {
+  interface GitCalls {
+    getUnresolvedConflicts: number;
+    isWorkdirHasChanges: number;
+    cherryPickContinue: number;
+    cherryPickSkip: number;
+    commitAllowEmpty: number;
+  }
+
+  const createGitStub = (opts: { unresolvedConflicts?: string[]; workdirHasChanges?: boolean }) => {
+    const calls: GitCalls = {
+      getUnresolvedConflicts: 0,
+      isWorkdirHasChanges: 0,
+      cherryPickContinue: 0,
+      cherryPickSkip: 0,
+      commitAllowEmpty: 0,
+    };
+
+    const gitStub = {
+      hasConflicts: async () => false,
+      getUnresolvedConflicts: async () => {
+        calls.getUnresolvedConflicts += 1;
+        return opts.unresolvedConflicts ?? [];
+      },
+      isWorkdirHasChanges: async () => {
+        calls.isWorkdirHasChanges += 1;
+        return opts.workdirHasChanges ?? false;
+      },
+      cherryPickContinue: async () => {
+        calls.cherryPickContinue += 1;
+      },
+      cherryPickSkip: async () => {
+        calls.cherryPickSkip += 1;
+      },
+      commitAllowEmpty: async () => {
+        calls.commitAllowEmpty += 1;
+      },
+      // Reached only after the decision under test; make it fail predictably so the
+      // remainder of cherryPickNext's "commit landed" flow short-circuits via the
+      // existing try/catch, without needing to mock the full push/PR-creation chain.
+      pushBranchToGitHub: async () => {
+        throw new Error('stop-after-decision (expected in this test)');
+      },
+    } as unknown as GitExecutor;
+
+    return { gitStub, calls };
+  };
+
+  // A fake commit generator that is immediately "done" — cherryPickNext's post-decision
+  // code path (push/PR creation) is not what these tests exercise; see pushBranchToGitHub
+  // stub above for how that path is short-circuited.
+  const fakeDoneGenerator = () =>
+    (async function* () {
+      // no commits to yield
+    })();
+
+  const createService = (gitStub: GitExecutor) => {
+    const service = new PrCloneInPlaceService(gitStub, {} as any, mockLogService);
+    (service as any).commitGenerator = fakeDoneGenerator();
+    return service;
+  };
+
+  let originalShowWarningMessage: typeof vscodeWindow.showWarningMessage;
+  let originalShowQuickPick: typeof vscodeWindow.showQuickPick;
+  let originalShowErrorMessage: typeof vscodeWindow.showErrorMessage;
+
+  const stubWindow = () => {
+    const warnings: string[] = [];
+    let quickPickResponse: string | undefined;
+
+    originalShowWarningMessage = vscodeWindow.showWarningMessage;
+    originalShowQuickPick = vscodeWindow.showQuickPick;
+    originalShowErrorMessage = vscodeWindow.showErrorMessage;
+
+    (vscodeWindow as any).showWarningMessage = async (message: string) => {
+      warnings.push(message);
+      return undefined;
+    };
+    let quickPickCallCount = 0;
+    (vscodeWindow as any).showQuickPick = async () => {
+      quickPickCallCount += 1;
+      return quickPickResponse;
+    };
+    (vscodeWindow as any).showErrorMessage = async () => undefined;
+
+    return {
+      warnings,
+      setQuickPickResponse: (value: string | undefined) => {
+        quickPickResponse = value;
+      },
+      getQuickPickCallCount: () => quickPickCallCount,
+    };
+  };
+
+  const restoreWindow = () => {
+    (vscodeWindow as any).showWarningMessage = originalShowWarningMessage;
+    (vscodeWindow as any).showQuickPick = originalShowQuickPick;
+    (vscodeWindow as any).showErrorMessage = originalShowErrorMessage;
+  };
+
+  it('unresolved conflicts remain: warns with the file list, never continues or skips', async () => {
+    const { gitStub, calls } = createGitStub({ unresolvedConflicts: ['src/foo.ts', 'src/bar.ts'] });
+    const service = createService(gitStub);
+    const { warnings } = stubWindow();
+
+    try {
+      await service.cherryPickNext(true);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.strictEqual(calls.getUnresolvedConflicts, 1);
+    assert.strictEqual(calls.cherryPickContinue, 0, 'must not continue with unresolved conflicts');
+    assert.strictEqual(calls.cherryPickSkip, 0, 'must not skip with unresolved conflicts');
+    assert.strictEqual(calls.commitAllowEmpty, 0);
+    assert.strictEqual(calls.isWorkdirHasChanges, 0, 'must not even consult workdir dirtiness');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /src\/foo\.ts/);
+    assert.match(warnings[0], /src\/bar\.ts/);
+  });
+
+  it('resolved, non-empty result: continues the cherry-pick, no prompt shown', async () => {
+    const { gitStub, calls } = createGitStub({ unresolvedConflicts: [], workdirHasChanges: true });
+    const service = createService(gitStub);
+    const { getQuickPickCallCount } = stubWindow();
+
+    try {
+      await service.cherryPickNext(true);
+    } catch {
+      // expected: the post-decision push/PR flow short-circuits via the stubbed
+      // pushBranchToGitHub rejection — irrelevant to this test.
+    } finally {
+      restoreWindow();
+    }
+
+    assert.strictEqual(calls.cherryPickContinue, 1, 'must continue when the result is non-empty');
+    assert.strictEqual(calls.cherryPickSkip, 0);
+    assert.strictEqual(calls.commitAllowEmpty, 0);
+    assert.strictEqual(getQuickPickCallCount(), 0, 'must not prompt when the result is non-empty');
+  });
+
+  describe('resolved, empty result (the issue #207 failure scenario)', () => {
+    it('never silently skips — prompts, and "Keep as empty commit" commits an empty commit', async () => {
+      const { gitStub, calls } = createGitStub({ unresolvedConflicts: [], workdirHasChanges: false });
+      const service = createService(gitStub);
+      const { setQuickPickResponse, getQuickPickCallCount } = stubWindow();
+      setQuickPickResponse('Keep as empty commit');
+
+      try {
+        await service.cherryPickNext(true);
+      } catch {
+        // expected short-circuit past the decision under test; see stub comment above.
+      } finally {
+        restoreWindow();
+      }
+
+      assert.strictEqual(getQuickPickCallCount(), 1, 'must prompt instead of silently skipping');
+      assert.strictEqual(calls.commitAllowEmpty, 1);
+      assert.strictEqual(calls.cherryPickSkip, 0);
+      assert.strictEqual(calls.cherryPickContinue, 0);
+    });
+
+    it('"Skip this commit" explicitly chosen skips the commit', async () => {
+      const { gitStub, calls } = createGitStub({ unresolvedConflicts: [], workdirHasChanges: false });
+      const service = createService(gitStub);
+      const { setQuickPickResponse } = stubWindow();
+      setQuickPickResponse('Skip this commit');
+
+      try {
+        await service.cherryPickNext(true);
+      } catch {
+        // expected short-circuit past the decision under test; see stub comment above.
+      } finally {
+        restoreWindow();
+      }
+
+      assert.strictEqual(calls.cherryPickSkip, 1);
+      assert.strictEqual(calls.commitAllowEmpty, 0);
+      assert.strictEqual(calls.cherryPickContinue, 0);
+    });
+
+    it('dismissing the prompt (Escape) aborts the clone rather than skipping or continuing', async () => {
+      const { gitStub, calls } = createGitStub({ unresolvedConflicts: [], workdirHasChanges: false });
+      const service = createService(gitStub);
+      const { setQuickPickResponse } = stubWindow();
+      setQuickPickResponse(undefined);
+
+      try {
+        await service.cherryPickNext(true);
+      } finally {
+        restoreWindow();
+      }
+
+      assert.strictEqual(calls.cherryPickSkip, 0);
+      assert.strictEqual(calls.commitAllowEmpty, 0);
+      assert.strictEqual(calls.cherryPickContinue, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces `prCloneInPlaceService.cherryPickNext`'s `isWorkdirHasChanges()` continue-vs-skip heuristic with real cherry-pick state: `GitExecutor.getUnresolvedConflicts()` (git status --porcelain, filtered to unmerged `UU`/`AA`/`DD`/etc status codes) reports still-conflicted files by name and blocks proceeding; a genuinely empty resolution now prompts (Skip this commit / Keep as empty commit / Abort clone) instead of being silently skipped and dropped from the cloned PR.
- Adds `GitExecutor.commitAllowEmpty()` (`git commit --allow-empty --no-edit`) to finish an in-progress cherry-pick as an intentional empty commit when the user chooses "Keep as empty commit".
- To verify manually: create a PR whose commit conflicts with the target branch, resolve the conflict so the result is identical to the base (an empty diff), stage it, and click "Conflicts resolved" — a QuickPick should appear instead of the commit silently disappearing from the cloned branch.

Closes #207

## Test plan
- [x] `yarn compile` (type check + lint) passes
- [x] `yarn test:unit` passes (873 passing), including new `src/test/unit/prCloneCherryPickContinueState.test.ts` covering all three states: unresolved conflicts, resolved non-empty, resolved empty (Skip / Keep as empty / Abort / dismiss)
- [ ] Manual smoke test in VS Code extension host (create a PR clone with a conflicting commit resolved to an empty diff)