### PR TITLE
fix: verify stash hash before popping to avoid popping the wrong stash

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -567,14 +567,15 @@ export class CheckoutToCommand extends BaseCommand {
     try {
       const dirty = await git.isWorkdirHasChanges();
       const stashName = `smart-checkout-new-branch-${Date.now()}`;
+      let stashHash: string | undefined;
       if (dirty) {
-        await git.createStash(stashName);
+        stashHash = await git.createStash(stashName);
       }
       const newBranch = await git.createBranch(newBranchName, baseRef.fullName);
       capture(AnalyticsEvent.BranchCreated);
       if (dirty) {
         try {
-          await git.popStash(stashName);
+          await git.popStash(stashName, false, stashHash);
         } catch {
           // conflicts are left for the user to resolve
         }

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -497,7 +497,8 @@ export class GitExecutor {
     };
   }
 
-  async createStash(stashName: string, include: 'all' | 'untracked' | 'none' = 'untracked') {
+  /** Creates a stash and returns its commit hash, so callers can later verify they pop the same stash (see `popStash`). */
+  async createStash(stashName: string, include: 'all' | 'untracked' | 'none' = 'untracked'): Promise<string> {
     const args = [
       'stash', 'push', '-m', stashName,
       ...(include === 'all' ? ['-a'] : []),
@@ -509,6 +510,9 @@ export class GitExecutor {
     if (stdout.includes('No local changes to save')) {
       throw new Error('No local changes to save');
     }
+
+    const { stdout: hashOut } = await this.#execGitCommand(['rev-parse', 'stash@{0}']);
+    return hashOut.trim();
   }
 
   async resetLocalChanges() {
@@ -662,7 +666,14 @@ export class GitExecutor {
     await this.#execGitCommand(['rebase', target]);
   }
 
-  async popStash(stashName: string, apply = false) {
+  /**
+   * Pops (or applies) the stash named `stashName`. A stash message alone is not a reliable
+   * selector — two auto-stashes can share a derived message, or a stash can be created/removed
+   * elsewhere between listing and acting — so when `expectedHash` is supplied, the resolved
+   * `stash@{N}` selector is re-verified against it via `resolveStashSelector` before acting.
+   * If the hash can't be matched to any stash, this throws instead of popping a guess.
+   */
+  async popStash(stashName: string, apply = false, expectedHash?: string) {
     // Get the list of stashes
     const { stdout: stdoutGitStashList } = await this.#execGitCommand(['--no-pager', 'stash', 'list', '--format=%gs']);
 
@@ -686,8 +697,20 @@ export class GitExecutor {
       throw new Error(`No stash found`);
     }
 
+    let selector = `stash@{${stashIndex}}`;
+
+    if (expectedHash) {
+      try {
+        selector = await this.resolveStashSelector(selector, expectedHash);
+      } catch {
+        throw new Error(
+          `Could not verify the stash "${stashName}" — its expected commit no longer matches any stash. Refusing to pop a different stash.`
+        );
+      }
+    }
+
     // Pop the stash
-    await this.#execGitCommand(['stash', apply ? 'apply' : 'pop', `stash@{${stashIndex}}`]);
+    await this.#execGitCommand(['stash', apply ? 'apply' : 'pop', selector]);
   }
 
   async listStashes(): Promise<IGitStash[]> {

--- a/src/services/autoStashService.ts
+++ b/src/services/autoStashService.ts
@@ -131,8 +131,9 @@ export class AutoStashService {
 
     const isWorkdirHasChangesBeforeStash = await git.isWorkdirHasChanges();
 
+    let stashHash: string | undefined;
     if (isWorkdirHasChangesBeforeStash) {
-      await git.createStash(stashMessage);
+      stashHash = await git.createStash(stashMessage);
     }
 
     try {
@@ -146,7 +147,7 @@ export class AutoStashService {
         const isWorkdirHasChangesAfterFailedPull = await git.isWorkdirHasChanges();
         if (!isWorkdirHasChangesAfterFailedPull) {
           // Nothing partially merged/rebased - safe to restore the user's changes.
-          await git.popStash(stashMessage);
+          await git.popStash(stashMessage, false, stashHash);
           throw new Error(`${operation} failed: ${msg}`);
         }
       }
@@ -160,7 +161,7 @@ export class AutoStashService {
         await git.resetLocalChanges();
       }
 
-      await git.popStash(stashMessage);
+      await git.popStash(stashMessage, false, stashHash);
     }
 
     capture(event, { had_changes: isWorkdirHasChangesBeforeStash });
@@ -186,8 +187,9 @@ export class AutoStashService {
     // AUTO_STASH_CURRENT_BRANCH (and any other mode treated as such)
     const stashMessage = getStashMessage(currentBranch, true);
 
+    let stashHash: string | undefined;
     if (isWorkdirHasChanges) {
-      await git.createStash(stashMessage);
+      stashHash = await git.createStash(stashMessage);
     }
 
     try {
@@ -204,7 +206,7 @@ export class AutoStashService {
       if (hasChangesAfterRebase) {
         await git.resetLocalChanges();
       }
-      await git.popStash(stashMessage);
+      await git.popStash(stashMessage, false, stashHash);
     }
 
     capture(AnalyticsEvent.RebaseWithStash, { stash_mode: mode, had_changes: isWorkdirHasChanges });
@@ -471,6 +473,7 @@ export class AutoStashService {
     const stashMessage = getStashMessage(currentBranch, true);
     const operation = apply ? 'apply' : 'pop';
 
+    let stashHash: string | undefined;
     try {
       if (isWorkdirHasChanges) {
         const conflicts = await git.getStashConflictPreview(previewRef);
@@ -481,7 +484,7 @@ export class AutoStashService {
             return 'cancelled';
           }
         }
-        await git.createStash(stashMessage);
+        stashHash = await git.createStash(stashMessage);
       }
     } catch (e) {
       handleErrorMessage(e, undefined, undefined, undefined, this.logService);
@@ -505,7 +508,7 @@ export class AutoStashService {
     try {
       const isStashWithMessageExists = await git.isStashWithMessageExists(stashMessage);
       if (isStashWithMessageExists) {
-        await git.popStash(stashMessage, apply);
+        await git.popStash(stashMessage, apply, stashHash);
       }
     } catch (e) {
       const conflicts = await git.getConflictedFiles();

--- a/src/services/prCloneInPlaceService.ts
+++ b/src/services/prCloneInPlaceService.ts
@@ -23,6 +23,7 @@ interface IServiceStore {
   originalBranch?: string;
   createdBranchName?: string;
   stashMessage?: string;
+  stashHash?: string;
   originalPrData?: PrCloneData;
 }
 
@@ -39,6 +40,12 @@ export interface IPersistedCloneOperation {
   originalBranch: string;
   createdBranchName: string;
   stashMessage?: string;
+  /**
+   * Commit hash of the stash created for `stashMessage`, used to verify the correct stash is
+   * popped on restore (see `GitExecutor.popStash`). Optional for backward compatibility with
+   * state persisted before this field existed.
+   */
+  stashHash?: string;
   /** Shas that still need to land, including the one that may currently be mid-conflict. */
   remainingShas: string[];
   prNumber: number;
@@ -234,7 +241,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
 
         if (restoredOriginalBranch && this.serviceStore.stashMessage) {
           try {
-            await this.git.popStash(this.serviceStore.stashMessage);
+            await this.git.popStash(this.serviceStore.stashMessage, false, this.serviceStore.stashHash);
           } catch (error) {
             this.loggingService.warn(
               `Failed to restore stashed changes '${this.serviceStore.stashMessage}': ${error}`
@@ -307,11 +314,12 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
         this.loggingService.info(`Stashing uncommitted changes: ${this.serviceStore.stashMessage}`);
 
         try {
-          await this.git.createStash(this.serviceStore.stashMessage);
+          this.serviceStore.stashHash = await this.git.createStash(this.serviceStore.stashMessage);
           this.loggingService.info('Changes stashed successfully');
         } catch (error) {
           this.loggingService.warn(`Failed to stash changes: ${error}`);
           this.serviceStore.stashMessage = undefined;
+          this.serviceStore.stashHash = undefined;
         }
       }
 
@@ -455,7 +463,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       return;
     }
 
-    const { originalBranch, createdBranchName, stashMessage, originalPrData } = this.serviceStore;
+    const { originalBranch, createdBranchName, stashMessage, stashHash, originalPrData } = this.serviceStore;
     if (!originalBranch || !createdBranchName || !originalPrData) {
       return;
     }
@@ -465,6 +473,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       originalBranch,
       createdBranchName,
       stashMessage,
+      stashHash,
       remainingShas: [...this.remainingShas],
       prNumber: originalPrData.prData.number,
       ts: Date.now(),
@@ -490,6 +499,7 @@ export class PrCloneInPlaceService extends PrCloneServiceBase {
       originalBranch: record.originalBranch,
       createdBranchName: record.createdBranchName,
       stashMessage: record.stashMessage,
+      stashHash: record.stashHash,
       originalPrData: {
         prData: record.prData,
         targetBranch: record.targetBranch,

--- a/src/test/unit/popStashHashVerification.test.ts
+++ b/src/test/unit/popStashHashVerification.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+
+import { createTestRepo, TestRepo } from '../e2e/helpers/gitTestRepo';
+
+describe('GitExecutor.popStash hash verification', () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('pops the stash matching the expected hash, not just the first message match', async () => {
+    // Two stashes sharing the exact same message — the scenario from issue #206
+    // (same branch stashed twice, or a stale leftover stash with the same derived name).
+    const sharedMessage = 'auto-stash-main';
+
+    repo.makeChange('file1.txt', 'first stash contents\n');
+    const firstHash = await repo.git.createStash(sharedMessage, 'all');
+
+    repo.makeChange('file1.txt', 'second stash contents\n');
+    const secondHash = await repo.git.createStash(sharedMessage, 'all');
+
+    assert.notStrictEqual(firstHash, secondHash, 'the two stashes must have distinct hashes');
+
+    const stashesBefore = await repo.git.listStashes();
+    assert.strictEqual(stashesBefore.length, 2);
+    // Both share the derived message.
+    assert.ok(stashesBefore.every((s) => s.message === sharedMessage));
+
+    // Without hash verification, popStash would always resolve to stash@{0} — the
+    // most-recently-created stash happens to occupy that slot here, so pop the *first*
+    // one created (now at a higher index) via its known hash to prove the hash wins.
+    await repo.git.popStash(sharedMessage, false, firstHash);
+
+    const stashesAfter = await repo.git.listStashes();
+    assert.strictEqual(stashesAfter.length, 1, 'exactly one stash should remain');
+    assert.strictEqual(stashesAfter[0].hash, secondHash, 'the remaining stash must be the second one, not the popped first one');
+
+    assert.strictEqual(repo.readFile('file1.txt'), 'first stash contents\n');
+  });
+
+  it('throws instead of popping a guess when the expected hash matches no stash', async () => {
+    const sharedMessage = 'auto-stash-main';
+
+    repo.makeChange('file1.txt', 'only stash contents\n');
+    await repo.git.createStash(sharedMessage, 'all');
+
+    await assert.rejects(
+      repo.git.popStash(sharedMessage, false, 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'),
+      /Could not verify the stash "auto-stash-main"/
+    );
+
+    // The stash must be left untouched.
+    const stashesAfter = await repo.git.listStashes();
+    assert.strictEqual(stashesAfter.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- `popStash` picked a stash by message equality alone, always taking the first index match — two stashes with the same derived message (repeat auto-stash on the same branch, a stale leftover from a crashed run, or a stash created in a terminal between the push and pop) could cause the wrong stash to be popped onto the target branch, silently restoring the wrong changes.
- `GitExecutor.createStash` now returns the new stash's commit hash (`git rev-parse stash@{0}` after `stash push`).
- `AutoStashService` (`pullAndStashChanges`, `rebaseAndStashChanges`, `doAutoStashAndPopInNewBranch`), `PrCloneInPlaceService`, and `checkoutToCommand`'s `createNewBranchFrom` now thread that hash alongside `stashMessage` and pass it to `popStash`.
- `popStash` accepts an optional `expectedHash` and, when provided, re-resolves the selector via the existing `resolveStashSelector(selector, expectedHash)` helper (already used by `StashService`/`stashTreeActionCommand`) instead of trusting the positional index. If the hash can't be matched to any stash, it throws a clear error naming the stash message rather than popping a guess.
- `PrCloneInPlaceService`'s persisted operation record (`IPersistedCloneOperation`, survives a window reload/crash) gained an optional `stashHash` field for backward compatibility with older persisted state.

Closes #206

- To test manually: enable an auto-stash mode, dirty the working tree, checkout to another branch to create an auto-stash, then (in a terminal) create a second stash with the exact same message before letting the extension pop/restore it — the extension should now either pop the correct stash or fail loudly instead of silently restoring the wrong one.

## Test plan
- [x] `yarn compile` (type check + lint) passes
- [x] `MOCHA_GREP="stash" yarn test:unit` passes (870 tests, including new `popStashHashVerification.test.ts`)
- [ ] `yarn test:e2e:ci` — requires `xvfb`, unavailable on this local macOS dev machine; will run in GitHub Actions CI