### PR TITLE
fix: dispose webview listeners on re-resolve and target the live webview instance

### DIFF
--- a/src/test/unit/prCommitsWebViewProvider.test.ts
+++ b/src/test/unit/prCommitsWebViewProvider.test.ts
@@ -1,0 +1,166 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { PrCloneService } from '../../services/prCloneService';
+import { GitHubCommit } from '../../types/dataTypes';
+import { WebviewCommand } from '../../types/webviewCommands';
+import { PrCommitsWebViewProvider } from '../../view/PrCommitsWebViewProvider';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+function makeMemento() {
+  const data = new Map<string, unknown>();
+  return {
+    get: <T>(key: string) => data.get(key) as T,
+    update: async (key: string, value: unknown) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function makeContext(): vscode.ExtensionContext {
+  return {
+    workspaceState: makeMemento(),
+    extensionUri: vscode.Uri.file(__dirname),
+  } as unknown as vscode.ExtensionContext;
+}
+
+function makePrCloneService(): PrCloneService {
+  return {
+    addCleanUpActions: () => {},
+  } as unknown as PrCloneService;
+}
+
+type Listener<T> = (arg: T) => void;
+
+/**
+ * A mock WebviewView whose `onDidReceiveMessage` / `onDidChangeVisibility`
+ * behave like the real VS Code Event API: every registration is tracked
+ * independently and returns a Disposable that removes just that listener.
+ * This lets tests prove that a re-resolve disposes the previous listeners
+ * instead of merely overwriting a single field.
+ */
+function makeMockWebviewView() {
+  const messageListeners: Listener<unknown>[] = [];
+  const visibilityListeners: Listener<void>[] = [];
+  const posted: unknown[] = [];
+
+  const webviewView = {
+    visible: true,
+    webview: {
+      options: undefined as unknown,
+      html: '',
+      postMessage: (message: unknown) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      },
+      onDidReceiveMessage: (listener: Listener<unknown>) => {
+        messageListeners.push(listener);
+        return {
+          dispose: () => {
+            const index = messageListeners.indexOf(listener);
+            if (index >= 0) {
+              messageListeners.splice(index, 1);
+            }
+          },
+        };
+      },
+    },
+    onDidChangeVisibility: (listener: Listener<void>) => {
+      visibilityListeners.push(listener);
+      return {
+        dispose: () => {
+          const index = visibilityListeners.indexOf(listener);
+          if (index >= 0) {
+            visibilityListeners.splice(index, 1);
+          }
+        },
+      };
+    },
+  };
+
+  return { webviewView, messageListeners, visibilityListeners, posted };
+}
+
+function makeCommit(sha: string): GitHubCommit {
+  return {
+    sha,
+    parents: [],
+    commit: { message: `Commit ${sha}` },
+  } as unknown as GitHubCommit;
+}
+
+describe('PrCommitsWebViewProvider', () => {
+  it('disposes listeners from the previous resolve so a re-resolve does not stack handlers', () => {
+    const provider = new PrCommitsWebViewProvider(makeContext(), mockLogService, makePrCloneService());
+    const { webviewView, messageListeners, visibilityListeners } = makeMockWebviewView();
+
+    // Simulate VS Code re-invoking resolveWebviewView when a collapsed view
+    // is re-expanded.
+    provider.resolveWebviewView(webviewView as unknown as vscode.WebviewView);
+    provider.resolveWebviewView(webviewView as unknown as vscode.WebviewView);
+
+    assert.strictEqual(
+      messageListeners.length,
+      1,
+      'expected exactly one onDidReceiveMessage listener to remain registered after re-resolve'
+    );
+    assert.strictEqual(
+      visibilityListeners.length,
+      1,
+      'expected exactly one onDidChangeVisibility listener to remain registered after re-resolve'
+    );
+  });
+
+  it('handles a TOGGLE_COMMIT message exactly once after resolving twice', async () => {
+    const provider = new PrCommitsWebViewProvider(makeContext(), mockLogService, makePrCloneService());
+    const { webviewView, messageListeners, posted } = makeMockWebviewView();
+
+    provider.resolveWebviewView(webviewView as unknown as vscode.WebviewView);
+    provider.resolveWebviewView(webviewView as unknown as vscode.WebviewView);
+
+    provider.updateCommits([makeCommit('abc123')]);
+    // updateCommits auto-selects non-merge commits.
+    assert.deepStrictEqual(provider.getSelectedCommits(), ['abc123']);
+
+    posted.length = 0;
+
+    // Simulate VS Code firing the message event exactly once. If a stale
+    // listener from the first resolve were still registered, this single
+    // emission would invoke the handler twice, toggling the commit back to
+    // its original state and posting UPDATE_COMMITS twice.
+    await Promise.all(
+      messageListeners.map((listener) =>
+        listener({ command: WebviewCommand.TOGGLE_COMMIT, sha: 'abc123' })
+      )
+    );
+
+    assert.deepStrictEqual(
+      provider.getSelectedCommits(),
+      [],
+      'expected the commit to be toggled off exactly once'
+    );
+
+    const updateCommitsMessages = posted.filter(
+      (message: any) => message.command === WebviewCommand.UPDATE_COMMITS
+    );
+    assert.strictEqual(
+      updateCommitsMessages.length,
+      1,
+      'expected exactly one UPDATE_COMMITS message to be posted for a single TOGGLE_COMMIT'
+    );
+  });
+
+  it('disposes tracked listeners when the provider itself is disposed', () => {
+    const provider = new PrCommitsWebViewProvider(makeContext(), mockLogService, makePrCloneService());
+    const { webviewView, messageListeners, visibilityListeners } = makeMockWebviewView();
+
+    provider.resolveWebviewView(webviewView as unknown as vscode.WebviewView);
+    assert.strictEqual(messageListeners.length, 1);
+    assert.strictEqual(visibilityListeners.length, 1);
+
+    provider.dispose();
+
+    assert.strictEqual(messageListeners.length, 0);
+    assert.strictEqual(visibilityListeners.length, 0);
+  });
+});

--- a/src/view/PrCloneWebViewProvider.ts
+++ b/src/view/PrCloneWebViewProvider.ts
@@ -126,6 +126,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
   private cloneServiceCleanUpAssigned = false;
   private readonly repositoryChangeSubscription: Disposable;
+  private viewDisposables: Disposable[] = [];
 
   constructor(
     private context: ExtensionContext,
@@ -141,6 +142,14 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
   resolveWebviewView(webviewView: WebviewView) {
     this.loggingService.info('...Resolve webview');
+
+    // Dispose listeners from any prior resolve before wiring up the new
+    // webview instance. VS Code re-invokes resolveWebviewView every time a
+    // collapsed view is re-expanded, so without this the old listeners
+    // keep firing alongside the new ones.
+    this.viewDisposables.forEach((disposable) => disposable.dispose());
+    this.viewDisposables = [];
+
     this.webviewView = webviewView;
 
     const extensionUri = this.context.extensionUri;
@@ -157,14 +166,14 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
       // register clean up actions
       this.prCloneService.addCleanUpActions({
         cleanUpActionEnd: async () => {
-          await webviewView.webview.postMessage({
+          await this.webviewView?.webview.postMessage({
             command: WebviewCommand.UPDATE_CLONING_STATE,
             isCloning: false,
           });
 
           await this.updateCloningState(false);
 
-          await webviewView.webview.postMessage({
+          await this.webviewView?.webview.postMessage({
             command: WebviewCommand.CANCEL_PR_CLONE,
           });
         },
@@ -175,7 +184,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
     webviewView.webview.html = this.getReactHtml(webviewView.webview, extensionUri);
 
-    webviewView.webview.onDidReceiveMessage(async (message) => {
+    const onDidReceiveMessage = webviewView.webview.onDidReceiveMessage(async (message) => {
       console.log(`[<<<< ]: received command: ${JSON.stringify(message)}`);
       switch (message.command) {
         case WebviewCommand.WEBVIEW_READY:
@@ -207,6 +216,8 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
           break;
       }
     });
+
+    this.viewDisposables.push(onDidReceiveMessage);
   }
 
   private async handleWebViewReady() {
@@ -663,5 +674,7 @@ export class PrCloneWebViewProvider implements WebviewViewProvider {
 
   dispose(): void {
     this.repositoryChangeSubscription.dispose();
+    this.viewDisposables.forEach((disposable) => disposable.dispose());
+    this.viewDisposables = [];
   }
 }

--- a/src/view/PrCommitsWebViewProvider.ts
+++ b/src/view/PrCommitsWebViewProvider.ts
@@ -1,6 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { commands, env, ExtensionContext, Uri, WebviewView, WebviewViewProvider } from 'vscode';
+import {
+  commands,
+  Disposable,
+  env,
+  ExtensionContext,
+  Uri,
+  WebviewView,
+  WebviewViewProvider,
+} from 'vscode';
 
 import { EXTENSION_NAME } from '../const';
 import { LoggingService } from '../logging/loggingService';
@@ -19,6 +27,7 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
   private isCloning: boolean = false;
 
   private cloneServiceCleanUpAssigned = false;
+  private viewDisposables: Disposable[] = [];
 
   constructor(
     private context: ExtensionContext,
@@ -62,13 +71,21 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
 
   resolveWebviewView(webviewView: WebviewView) {
     this.loggingService.info('...Resolve commits webview');
+
+    // Dispose listeners from any prior resolve before wiring up the new
+    // webview instance. VS Code re-invokes resolveWebviewView every time a
+    // collapsed view is re-expanded, so without this the old listeners
+    // keep firing alongside the new ones.
+    this.viewDisposables.forEach((disposable) => disposable.dispose());
+    this.viewDisposables = [];
+
     this.webviewView = webviewView;
 
     if (!this.cloneServiceCleanUpAssigned) {
       // register clean up actions
       this.prCloneService.addCleanUpActions({
         cleanUpActionEnd: async () => {
-          await webviewView.webview.postMessage({
+          await this.webviewView?.webview.postMessage({
             command: WebviewCommand.UPDATE_CLONING_STATE,
             isCloning: false,
           });
@@ -90,7 +107,7 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
 
     webviewView.webview.html = this.getReactHtml(webviewView.webview, extensionUri);
 
-    webviewView.webview.onDidReceiveMessage(async (message) => {
+    const onDidReceiveMessage = webviewView.webview.onDidReceiveMessage(async (message) => {
       this.loggingService.debug(`[CommitsWebView] received command: ${JSON.stringify(message)}`);
 
       switch (message.command) {
@@ -118,7 +135,7 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
     });
 
     // Handle webview visibility changes - restore state when becoming visible
-    webviewView.onDidChangeVisibility(() => {
+    const onDidChangeVisibility = webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible) {
         this.loggingService.debug('Commits webview became visible, restoring persisted state');
         // Load persisted state first in case it was updated
@@ -127,6 +144,8 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
         this.sendCommitsToWebview();
       }
     });
+
+    this.viewDisposables.push(onDidReceiveMessage, onDidChangeVisibility);
 
     // Send initial data if available
     if (this.commits.length > 0) {
@@ -357,6 +376,7 @@ export class PrCommitsWebViewProvider implements WebviewViewProvider {
   }
 
   dispose(): void {
-    // Clean up resources if needed
+    this.viewDisposables.forEach((disposable) => disposable.dispose());
+    this.viewDisposables = [];
   }
 }


### PR DESCRIPTION
## Summary
- `PrCommitsWebViewProvider` and `PrCloneWebViewProvider` now track every listener registration (`onDidReceiveMessage`, `onDidChangeVisibility`) made in `resolveWebviewView` in a private `viewDisposables` array, dispose it at the top of each `resolveWebviewView` call, and dispose it again in `dispose()`. VS Code re-invokes `resolveWebviewView` every time a collapsed panel is re-expanded, so previously listeners stacked up and a single message (e.g. `TOGGLE_COMMIT`) could fire the handler multiple times.
- `addCleanUpActions` callbacks in both providers now post through `this.webviewView?.webview.postMessage(...)` instead of a closed-over `webviewView` parameter captured on the first resolve, so clone-completion messages always reach the current live webview instead of a stale, disposed one.
- Added a unit test suite for `PrCommitsWebViewProvider` (previously untested): resolves a mocked webview twice, confirms only one listener remains registered after the second resolve, confirms a single `TOGGLE_COMMIT` message toggles the commit exactly once (not twice), and confirms `dispose()` clears tracked listeners.

Manual verification: collapse/reopen the PR Commits panel a few times, then toggle a commit — it should flip exactly once per click. Start a clone, collapse+reopen the PR Clone panel mid-clone — the form should unfreeze (buttons re-enable) once the clone finishes.

Closes #208

## Test plan
- [x] `yarn check-types` passes
- [x] `yarn lint` passes (no new warnings/errors)
- [x] `yarn test:unit` passes (871 tests, including 3 new ones for `PrCommitsWebViewProvider`)
- [ ] Manual smoke test in VS Code extension host (collapse/reopen panels, verify no duplicate toggles and clone completion unfreezes the live panel)