### PR TITLE
fix: restore stashed changes when new-branch creation fails

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -564,11 +564,13 @@ export class CheckoutToCommand extends BaseCommand {
       return undefined;
     }
 
+    let stashedMessage: string | undefined;
     try {
       const dirty = await git.isWorkdirHasChanges();
       const stashName = `smart-checkout-new-branch-${Date.now()}`;
       if (dirty) {
         await git.createStash(stashName);
+        stashedMessage = stashName;
       }
       const newBranch = await git.createBranch(newBranchName, baseRef.fullName);
       capture(AnalyticsEvent.BranchCreated);
@@ -583,6 +585,17 @@ export class CheckoutToCommand extends BaseCommand {
     } catch (e) {
       captureException(e);
       const msg = e instanceof Error ? e.message : String(e);
+
+      if (stashedMessage) {
+        try {
+          await git.popStash(stashedMessage);
+        } catch {
+          throw new Error(
+            `Failed to create the new branch: ${msg}\n\nYour changes are preserved in stash '${stashedMessage}'.`
+          );
+        }
+      }
+
       throw new Error(`Failed to create the new branch: ${msg}`);
     }
   }

--- a/src/test/unit/checkoutToCreateBranchStashLeak.test.ts
+++ b/src/test/unit/checkoutToCreateBranchStashLeak.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert';
+
+import { CheckoutToCommand } from '../../commands/checkoutToCommand';
+import { GitExecutor } from '../../common/git/gitExecutor';
+import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { ConfigurationManager } from '../../configuration/configurationManager';
+import { AutoStashService } from '../../services/autoStashService';
+import { IGitRef } from '../../common/git/types';
+import { mockLogService } from '../e2e/helpers/mockLogService';
+
+const baseRef: IGitRef = { name: 'main', fullName: 'main', authorName: '', isTag: false };
+
+/** Command wrapper exposing constructor + git-executor stubbing for direct createNewBranchFrom calls. */
+class StashLeakCommand extends CheckoutToCommand {
+  popStashCalls: Array<{ stashName: string; apply?: boolean }> = [];
+
+  constructor(
+    private readonly popStashBehavior: 'succeed' | 'fail'
+  ) {
+    super({} as ConfigurationManager, mockLogService, {} as AutoStashService);
+  }
+
+  protected async getGitExecutor(_provider?: VscodeGitProvider): Promise<GitExecutor> {
+    return {
+      repositoryPath: '/repo',
+      getRepoInfo: async () => undefined,
+      isWorkdirHasChanges: async () => true,
+      createStash: async (_stashName: string) => undefined,
+      createBranch: async () => {
+        throw new Error('base ref is invalid or duplicate');
+      },
+      popStash: async (stashName: string, apply?: boolean) => {
+        this.popStashCalls.push({ stashName, apply });
+        if (this.popStashBehavior === 'fail') {
+          throw new Error('pop conflict');
+        }
+      },
+    } as unknown as GitExecutor;
+  }
+
+  protected async pickBaseRef(): Promise<IGitRef | undefined> {
+    return baseRef;
+  }
+
+  protected async showInputBox(): Promise<string | undefined> {
+    return 'feature/new-branch';
+  }
+}
+
+describe('CheckoutToCommand createNewBranchFrom stash handling on failure', () => {
+  it('pops the stash created before a failing createBranch call', async () => {
+    const command = new StashLeakCommand('succeed');
+    const git = await command['getGitExecutor']();
+
+    await assert.rejects(
+      () => command.createNewBranchFrom(git, [baseRef]),
+      (err: Error) => {
+        assert.match(err.message, /Failed to create the new branch: base ref is invalid or duplicate/);
+        assert.doesNotMatch(err.message, /preserved in stash/);
+        return true;
+      }
+    );
+
+    assert.strictEqual(command.popStashCalls.length, 1);
+    assert.match(command.popStashCalls[0].stashName, /^smart-checkout-new-branch-\d+$/);
+  });
+
+  it('mentions the stash name in the error when the recovery pop also fails', async () => {
+    const command = new StashLeakCommand('fail');
+    const git = await command['getGitExecutor']();
+
+    await assert.rejects(
+      () => command.createNewBranchFrom(git, [baseRef]),
+      (err: Error) => {
+        assert.match(err.message, /Failed to create the new branch: base ref is invalid or duplicate/);
+        assert.match(err.message, /Your changes are preserved in stash 'smart-checkout-new-branch-\d+'\./);
+        return true;
+      }
+    );
+
+    assert.strictEqual(command.popStashCalls.length, 1);
+    assert.match(command.popStashCalls[0].stashName, /^smart-checkout-new-branch-\d+$/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a silent stash leak in `CheckoutToCommand.createNewBranchFrom` (src/commands/checkoutToCommand/index.ts): when the workdir was dirty, a stash was created before `git.createBranch(...)`, but if `createBranch` threw (e.g. invalid or duplicate base ref), the catch block rethrew without popping the stash or telling the user — their working-tree changes appeared to vanish.
- Now the failure path tracks the created stash's message and attempts to pop it during error handling to restore the tree. If that recovery pop also fails, the rethrown error message names the stash (`Your changes are preserved in stash '<name>'.`) so the user can recover manually via `git stash pop` / the Stashes view.
- Manual verification: dirty workdir → "Create new branch from..." → pick a base ref that causes `createBranch` to fail (e.g. a name that already exists) → working-tree changes should reappear, or the error should name the stash if a pop conflict occurs.

Closes #209

## Test plan
- [x] Unit tests pass (`yarn test:unit`, `MOCHA_GREP="checkoutTo" yarn test:unit`) — added `src/test/unit/checkoutToCreateBranchStashLeak.test.ts` covering both the successful-recovery and failed-recovery paths
- [x] Type check + lint pass (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host