### PR TITLE
fix: resolve configured remote instead of hardcoding origin

### DIFF
--- a/src/commands/checkoutToCommand/index.ts
+++ b/src/commands/checkoutToCommand/index.ts
@@ -10,6 +10,7 @@ import { LoggingService } from '../../logging/loggingService';
 import { AutoStashService } from '../../services/autoStashService';
 import { RefDetailsCache } from '../../services/refDetailsCache';
 import { getRepoId } from '../../utils/getRepoId';
+import { resolveRemoteInteractive } from '../../utils/remoteSelection';
 import { UserCancelledError } from '../../utils/userCancelledError';
 import { BaseCommand } from '../command';
 import { validateBranchName } from '../createBranchFromTemplateCommand/validateBranchName';
@@ -386,12 +387,21 @@ export class CheckoutToCommand extends BaseCommand {
 
   protected async publishBranchAction(git: GitExecutor, ref: IGitRef): Promise<boolean> {
     try {
+      const remote = await resolveRemoteInteractive(git, {
+        branch: ref.name,
+        defaultRemote: this.configManager.get().defaultRemote,
+        purpose: 'push',
+      });
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: `Publishing ${ref.name}` },
-        () => git.pushSetUpstream(ref.name)
+        () => git.pushSetUpstream(ref.name, remote)
       );
       return true;
     } catch (e) {
+      if (e instanceof UserCancelledError) {
+        // User dismissed the remote picker — not an error.
+        return false;
+      }
       captureException(e);
       const msg = e instanceof Error ? e.message : String(e);
       await this.showErrorMessage(`Failed to publish branch ${ref.name}: ${msg}`, 'OK');
@@ -470,7 +480,12 @@ export class CheckoutToCommand extends BaseCommand {
     let force = false;
     let defaultBranch: string | undefined;
     try {
-      defaultBranch = await git.getDefaultBranch();
+      const remote = await resolveRemoteInteractive(git, {
+        branch: ref.name,
+        defaultRemote: this.configManager.get().defaultRemote,
+        purpose: 'fetch',
+      });
+      defaultBranch = await git.getDefaultBranch(remote);
       const merged = await git.getMergedBranches(defaultBranch);
       force = !merged.includes(ref.name);
     } catch (e) {

--- a/src/commands/cleanupBranchesCommand/index.ts
+++ b/src/commands/cleanupBranchesCommand/index.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 import { VscodeGitProvider } from '../../common/git/vscodeGitProvider';
+import { ConfigurationManager } from '../../configuration/configurationManager';
 import { LoggingService } from '../../logging/loggingService';
+import { resolveRemoteInteractive } from '../../utils/remoteSelection';
+import { UserCancelledError } from '../../utils/userCancelledError';
 import { BaseCommand } from '../command';
 import {
   buildCleanupQuickPickItems,
@@ -14,7 +17,11 @@ import {
 const UNDO_HINT_ACTION = 'Undo hint';
 
 export class CleanupBranchesCommand extends BaseCommand {
-  constructor(logService: LoggingService, private readonly provider?: VscodeGitProvider) {
+  constructor(
+    logService: LoggingService,
+    private readonly configManager: ConfigurationManager,
+    private readonly provider?: VscodeGitProvider
+  ) {
     super(logService);
   }
 
@@ -24,8 +31,17 @@ export class CleanupBranchesCommand extends BaseCommand {
 
     let base: string;
     try {
-      base = await git.getDefaultBranch();
+      const remote = await resolveRemoteInteractive(git, {
+        branch: current,
+        defaultRemote: this.configManager.get().defaultRemote,
+        purpose: 'fetch',
+      });
+      base = await git.getDefaultBranch(remote);
     } catch (error) {
+      if (error instanceof UserCancelledError) {
+        // User dismissed the remote picker — not an error.
+        return;
+      }
       await vscode.window.showErrorMessage(
         `Could not determine the default branch: ${error instanceof Error ? error.message : String(error)}`
       );

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -1068,8 +1068,8 @@ export class GitExecutor {
     await this.#execGitCommand(['tag', '-d', name]);
   }
 
-  async pushSetUpstream(branch: string): Promise<void> {
-    await this.#execGitCommand(['push', '-u', 'origin', branch]);
+  async pushSetUpstream(branch: string, remote = 'origin'): Promise<void> {
+    await this.#execGitCommand(['push', '-u', remote, branch]);
   }
 
   async getMergedBranches(base: string): Promise<string[]> {
@@ -1077,11 +1077,24 @@ export class GitExecutor {
     return stdout.split('\n').map((line) => line.replace(/^\s*[*+]\s*/, '').trim()).filter(Boolean);
   }
 
-  async getDefaultBranch(): Promise<string> {
+  async getDefaultBranch(remote = 'origin'): Promise<string> {
     try {
-      const { stdout } = await this.#execGitCommand(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
-      return stdout.trim().replace(/^origin\//, '');
+      const { stdout } = await this.#execGitCommand(['symbolic-ref', '--short', `refs/remotes/${remote}/HEAD`]);
+      return stdout.trim().replace(new RegExp(`^${remote}/`), '');
     } catch {
+      // The symbolic ref is only populated after an explicit `git remote set-head`
+      // (or a clone that set it up); many repos never have it. `git remote show`
+      // asks the remote directly for its HEAD branch instead.
+      try {
+        const { stdout } = await this.#execGitCommand(['remote', 'show', remote]);
+        const match = stdout.match(/HEAD branch:\s*(\S+)/);
+        if (match && match[1] && match[1] !== '(unknown)') {
+          return match[1];
+        }
+      } catch {
+        // Remote unreachable or doesn't exist — fall through to local guesses.
+      }
+
       const refs = await this.getAllRefListExtended();
       if (refs.some((ref) => !ref.remote && !ref.isTag && ref.name === 'main')) return 'main';
       if (refs.some((ref) => !ref.remote && !ref.isTag && ref.name === 'master')) return 'master';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -470,7 +470,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const manageAutoStashesCommand = new ManageAutoStashesCommand(logService, stashService, vscodeGitProvider);
   commandManager.registerCommand(`${EXTENSION_NAME}.manageAutoStashes`, manageAutoStashesCommand);
-  commandManager.registerCommand(`${EXTENSION_NAME}.cleanupBranches`, new CleanupBranchesCommand(logService, vscodeGitProvider));
+  commandManager.registerCommand(`${EXTENSION_NAME}.cleanupBranches`, new CleanupBranchesCommand(logService, configManager, vscodeGitProvider));
 
   const removePRReviewInWorktreeCommand = new RemovePRReviewInWorktreeCommand(
     logService,

--- a/src/test/e2e/checkoutInlineActions.test.ts
+++ b/src/test/e2e/checkoutInlineActions.test.ts
@@ -27,7 +27,8 @@ class TestableCheckoutToCommand extends CheckoutToCommand {
   errorMessages: string[] = [];
 
   constructor() {
-    super({} as ConfigurationManager, mockLogService, {} as AutoStashService);
+    const configManager = { get: () => ({ defaultRemote: undefined }) } as unknown as ConfigurationManager;
+    super(configManager, mockLogService, {} as AutoStashService);
   }
 
   protected async showInformationMessage(message: string): Promise<string | undefined> {

--- a/src/test/unit/checkoutToInlineActions.test.ts
+++ b/src/test/unit/checkoutToInlineActions.test.ts
@@ -33,7 +33,8 @@ class TestableCheckoutToCommand extends CheckoutToCommand {
   infoMessages: string[] = [];
 
   constructor() {
-    super({} as ConfigurationManager, mockLogService, {} as AutoStashService);
+    const configManager = { get: () => ({ defaultRemote: undefined }) } as unknown as ConfigurationManager;
+    super(configManager, mockLogService, {} as AutoStashService);
   }
 
   // Avoid popping a real (blocking) notification during tests — just record it.

--- a/src/test/unit/cleanupBranches.test.ts
+++ b/src/test/unit/cleanupBranches.test.ts
@@ -254,6 +254,85 @@ describe('GitExecutor.getDefaultBranch', () => {
     await assert.rejects(() => git.getDefaultBranch(), /Could not determine the default branch/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
+
+  it('resolves the HEAD branch of a non-"origin" remote (e.g. a fork\'s "upstream")', async () => {
+    const remoteDir = initRepo('gsc-default-upstream-remote-');
+    execSync('git checkout -q -b develop', { cwd: remoteDir });
+    commit(remoteDir, 'init');
+
+    const dir = initRepo('gsc-default-upstream-local-');
+    execSync('git checkout -q -b unrelated', { cwd: dir });
+    commit(dir, 'init');
+    execSync(`git remote add upstream "${remoteDir}"`, { cwd: dir });
+    execSync('git fetch -q upstream', { cwd: dir });
+    execSync('git remote set-head upstream develop', { cwd: dir });
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    assert.strictEqual(await git.getDefaultBranch('upstream'), 'develop');
+    fs.rmSync(remoteDir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('falls back to "git remote show <remote>" when the symbolic ref is absent, then to local main/master', async () => {
+    // A repo with only an "upstream" remote and no `refs/remotes/upstream/HEAD`
+    // symbolic ref set locally (e.g. never explicitly `git remote set-head`d)
+    // must still resolve via `git remote show upstream`, not throw or assume "origin".
+    const remoteDir = initRepo('gsc-default-show-remote-');
+    execSync('git checkout -q -b develop', { cwd: remoteDir });
+    commit(remoteDir, 'init');
+
+    const dir = initRepo('gsc-default-show-local-');
+    execSync('git checkout -q -b unrelated', { cwd: dir });
+    commit(dir, 'init');
+    execSync(`git remote add upstream "${remoteDir}"`, { cwd: dir });
+    execSync('git fetch -q upstream', { cwd: dir });
+    // Intentionally no `git remote set-head` — refs/remotes/upstream/HEAD is absent.
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    assert.strictEqual(await git.getDefaultBranch('upstream'), 'develop');
+    fs.rmSync(remoteDir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('GitExecutor.pushSetUpstream', () => {
+  function initRepo(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email "test@test.local"', { cwd: dir });
+    execSync('git config user.name "Test"', { cwd: dir });
+    return dir;
+  }
+
+  function commit(dir: string, message: string) {
+    fs.writeFileSync(path.join(dir, 'file.txt'), `${message}\n`);
+    execSync('git add file.txt', { cwd: dir });
+    execSync(`git commit -q -m "${message}"`, { cwd: dir });
+  }
+
+  it('pushes and sets upstream tracking against the given remote, not "origin"', async () => {
+    const remoteDir = initRepo('gsc-push-remote-');
+    execSync('git checkout -q -b main', { cwd: remoteDir });
+    commit(remoteDir, 'init');
+
+    const dir = initRepo('gsc-push-local-');
+    execSync(`git remote add upstream "${remoteDir}"`, { cwd: dir });
+    execSync('git fetch -q upstream', { cwd: dir });
+    execSync('git checkout -q -b feat upstream/main', { cwd: dir });
+    commit(dir, 'feat change');
+
+    const git = new GitExecutor(dir, mockLogService as unknown as LoggingService);
+    await git.pushSetUpstream('feat', 'upstream');
+
+    const remoteBranches = execSync('git branch', { cwd: remoteDir }).toString();
+    assert.ok(remoteBranches.includes('feat'), `expected "feat" to be pushed to remote, got: ${remoteBranches}`);
+
+    const upstreamRef = execSync('git rev-parse --abbrev-ref feat@{upstream}', { cwd: dir }).toString().trim();
+    assert.strictEqual(upstreamRef, 'upstream/feat');
+
+    fs.rmSync(remoteDir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 });
 
 describe('GitExecutor.getMergedBranches', () => {


### PR DESCRIPTION
## Summary
- `getDefaultBranch()` and `pushSetUpstream()` in `GitExecutor` hardcoded `origin`. In a fork workflow where the only remote is e.g. `upstream`, `getDefaultBranch` threw "Could not determine the default branch" and `pushSetUpstream` pushed to a nonexistent/wrong remote.
- Both methods now take a `remote: string` parameter (default `'origin'` for source compatibility). `getDefaultBranch(remote)` tries `git symbolic-ref refs/remotes/<remote>/HEAD` first, falls back to `git remote show <remote>` (parsing the `HEAD branch:` line) when the symbolic ref is unset, and only then falls back to a local `main`/`master` guess.
- All call sites (`CheckoutToCommand.publishBranchAction`/`deleteLocalBranchAction`, `CleanupBranchesCommand.execute`) now resolve the remote via the existing `resolveRemoteInteractive` helper (respecting the `defaultRemote` setting and per-repo remote memory) instead of assuming `origin`. `CleanupBranchesCommand` gained a `ConfigurationManager` constructor dependency to support this; its `extension.ts` wiring was updated accordingly.
- To test manually: in a repo whose only remote is named something other than `origin` (e.g. `git remote rename origin upstream`), run "Delete merged branches", "Publish" on an unpushed branch, and delete a local branch — all should resolve the default branch/remote correctly instead of erroring.

## Test plan
- [x] Unit/integration tests pass (`yarn test`)
- [x] Type check passes (`yarn compile`)
- [x] New unit tests: `GitExecutor.getDefaultBranch` resolves a non-origin remote's HEAD branch both via `symbolic-ref` and via `git remote show` fallback; `GitExecutor.pushSetUpstream` pushes and sets upstream tracking against a given remote (`upstream`), not `origin`
- [ ] Manual smoke test performed in VS Code extension host

Closes #210