### PR TITLE
fix: normalize ref hashes and batch Memento writes in RefDetailsCache

### DIFF
--- a/src/commands/cleanupBranchesCommand/candidates.ts
+++ b/src/commands/cleanupBranchesCommand/candidates.ts
@@ -47,7 +47,7 @@ function describeCandidate(candidate: ICleanupCandidate): string {
   const relativeDate = ref.committerDate
     ? formatDistanceToNow(Number(ref.committerDate) * 1000, { addSuffix: true })
     : undefined;
-  const sha = ref.hash;
+  const sha = ref.hash ? ref.hash.slice(0, 7) : ref.hash;
   const parts = [relativeDate, sha].filter((part): part is string => !!part && part.length > 0);
 
   if (group === 'gone') {

--- a/src/commands/utils/refFormatting.ts
+++ b/src/commands/utils/refFormatting.ts
@@ -52,8 +52,14 @@ export const getRefDescription = (ref: IGitRef) => {
     .join(' • ');
 };
 
+const SHORT_HASH_LENGTH = 7;
+
+/** Truncates a full-length SHA to a short, compact form for display. */
+const shortenHash = (hash: string | undefined): string | undefined =>
+  hash ? hash.slice(0, SHORT_HASH_LENGTH) : hash;
+
 export const getRefDetails = (ref: IGitRef) => {
-  return [ref.authorName, ref.hash, ref.comment]
+  return [ref.authorName, shortenHash(ref.hash), ref.comment]
     .filter((part): part is string => !!part && part.trim().length > 0)
     .join(' • ');
 };

--- a/src/common/git/gitExecutor.ts
+++ b/src/common/git/gitExecutor.ts
@@ -540,7 +540,12 @@ export class GitExecutor {
     // Separator cannot occur in ref names, hashes, dates, or (practically)
     // commit subjects, and Git passes it through the format string verbatim.
     const SEPARATOR = '\x1f';
-    const format = `%(refname)${SEPARATOR}%(objectname:short)${SEPARATOR}%(*objectname:short)${SEPARATOR}%(committerdate:unix)${SEPARATOR}%(*committerdate:unix)${SEPARATOR}%(subject)${SEPARATOR}%(*subject)${SEPARATOR}%(upstream:track)${SEPARATOR}%(authorname)${SEPARATOR}%(*authorname)`;
+    // Use the full %(objectname) (not :short) so hashes produced here match the
+    // full 40-char SHAs VscodeGitProvider stores — RefDetailsCache validates
+    // cache hits by comparing hashes from both producers, and a length
+    // mismatch there defeats the cache. Short hashes are truncated at render
+    // time where a compact display is wanted (see refFormatting.ts).
+    const format = `%(refname)${SEPARATOR}%(objectname)${SEPARATOR}%(*objectname)${SEPARATOR}%(committerdate:unix)${SEPARATOR}%(*committerdate:unix)${SEPARATOR}%(subject)${SEPARATOR}%(*subject)${SEPARATOR}%(upstream:track)${SEPARATOR}%(authorname)${SEPARATOR}%(*authorname)`;
     const { stdout: branchesOutput } = await this.#execGitCommand([
       'for-each-ref',
       '--sort', '-committerdate',

--- a/src/services/refDetailsCache.ts
+++ b/src/services/refDetailsCache.ts
@@ -47,7 +47,7 @@ export class RefDetailsCache {
     }
 
     const refHash = this.getRefHash(ref);
-    if (entry.refHash !== refHash && entry.details.hash !== refHash) {
+    if (!this.hashesMatch(entry.refHash, refHash) && !this.hashesMatch(entry.details.hash, refHash)) {
       return undefined;
     }
 
@@ -84,10 +84,35 @@ export class RefDetailsCache {
     });
   }
 
+  /**
+   * Upserts many refs in a single Memento read-modify-write cycle instead of
+   * one per ref — `upsert` alone would read and rewrite the entire cache
+   * state for every ref, which is O(N) full-state writes for large repos.
+   */
   async upsertFromRefs(repoKey: string, refs: IGitRef[], now = Date.now()): Promise<void> {
-    for (const ref of refs) {
-      await this.upsert(repoKey, ref, ref, now);
+    if (!this.storage) {
+      return;
     }
+
+    const pending = refs
+      .map((ref) => ({ ref, sanitized: this.sanitize(ref) }))
+      .filter(({ sanitized }) => Object.keys(sanitized).length > 0);
+
+    if (pending.length === 0) {
+      return;
+    }
+
+    await this.enqueueUpdate(async () => {
+      const state = this.getState();
+      for (const { ref, sanitized } of pending) {
+        state.entries[this.createKey(repoKey, ref)] = {
+          refHash: this.getRefHash(ref),
+          details: sanitized,
+          updatedAt: now,
+        };
+      }
+      await this.updateState(state);
+    });
   }
 
   isMissing(repoKey: string, ref: IGitRef, now = Date.now()): boolean {
@@ -147,6 +172,20 @@ export class RefDetailsCache {
 
   private getRefHash(ref: IGitRef): string {
     return ref.hash ?? '';
+  }
+
+  /**
+   * Compares two commit hashes for cache-validity purposes. Different
+   * producers may emit different SHA lengths (e.g. legacy short-SHA entries
+   * persisted before hashes were normalized to full length), so hashes are
+   * considered equal when one is a non-empty prefix of the other rather than
+   * requiring an exact string match.
+   */
+  private hashesMatch(a: string | undefined, b: string | undefined): boolean {
+    if (!a || !b) {
+      return false;
+    }
+    return a.startsWith(b) || b.startsWith(a);
   }
 }
 

--- a/src/test/unit/cleanupBranches.test.ts
+++ b/src/test/unit/cleanupBranches.test.ts
@@ -121,7 +121,10 @@ describe('buildCleanupQuickPickItems', () => {
     const gone = items.find((item) => item.candidate?.ref.name === 'orphan');
 
     assert.ok(gone?.description?.includes('not merged — force delete'));
-    assert.ok(gone?.description?.includes('orphan-sha'));
+    // The QuickPick description shows a truncated (7-char) SHA for compact
+    // display; the full SHA is still used for the recovery document (see
+    // buildRecoveryDocument tests below).
+    assert.ok(gone?.description?.includes('orphan-'.slice(0, 7)));
   });
 
   it('omits a group separator entirely when that group has no candidates', () => {

--- a/src/test/unit/refDetailsCache.test.ts
+++ b/src/test/unit/refDetailsCache.test.ts
@@ -4,15 +4,21 @@ import * as vscode from 'vscode';
 import { IGitRef } from '../../common/git/types';
 import { RefDetailsCache, REF_DETAILS_CACHE_TTL_MS } from '../../services/refDetailsCache';
 
-function makeMemoryMemento(): Pick<vscode.Memento, 'get' | 'update'> & { values: Map<string, unknown> } {
+function makeMemoryMemento(): Pick<vscode.Memento, 'get' | 'update'> & {
+  values: Map<string, unknown>;
+  updateCallCount: number;
+} {
   const values = new Map<string, unknown>();
-  return {
+  const memento = {
     values,
+    updateCallCount: 0,
     get: <T>(key: string) => values.get(key) as T | undefined,
     update: async (key: string, value: unknown) => {
+      memento.updateCallCount += 1;
       values.set(key, value);
     },
   };
+  return memento;
 }
 
 function makeRef(overrides: Partial<IGitRef> = {}): IGitRef {
@@ -164,5 +170,51 @@ describe('RefDetailsCache', () => {
       cache.get('repo', makeRef({ name: 'three', fullName: 'three', hash: '3' }), 1000)?.comment,
       'three'
     );
+  });
+
+  it('hits the cache when a short-SHA producer entry is looked up with a full-SHA ref', async () => {
+    const cache = new RefDetailsCache(makeMemoryMemento());
+    const fullHash = 'abc1234def5678901234567890123456789012';
+    const shortHash = fullHash.slice(0, 7);
+
+    // Seed via the short-SHA producer path (e.g. getAllRefListExtended before
+    // the objectname:short -> objectname normalization).
+    await cache.upsert(
+      'repo',
+      makeRef({ hash: shortHash }),
+      { comment: 'Seeded via short SHA', authorName: 'A' },
+      1000
+    );
+
+    // Look up via the full-SHA producer path (e.g. VscodeGitProvider.mapRef).
+    const result = cache.get('repo', makeRef({ hash: fullHash }), 1000);
+
+    assert.deepStrictEqual(result, { comment: 'Seeded via short SHA', authorName: 'A' });
+  });
+
+  it('performs exactly one Memento update when upserting many refs via upsertFromRefs', async () => {
+    const memento = makeMemoryMemento();
+    const cache = new RefDetailsCache(memento);
+
+    const refs = Array.from({ length: 100 }, (_, i) =>
+      makeRef({
+        name: `branch-${i}`,
+        fullName: `branch-${i}`,
+        hash: `hash-${i}`,
+        comment: `Subject ${i}`,
+      })
+    );
+
+    await cache.upsertFromRefs('repo', refs, 1000);
+
+    assert.strictEqual(memento.updateCallCount, 1);
+
+    for (let i = 0; i < 100; i++) {
+      assert.strictEqual(
+        cache.get('repo', makeRef({ name: `branch-${i}`, fullName: `branch-${i}`, hash: `hash-${i}` }), 1000)
+          ?.comment,
+        `Subject ${i}`
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `RefDetailsCache` validated cache entries by comparing commit hashes, but the two producers emitted different lengths: `GitExecutor.getAllRefListExtended` used `%(objectname:short)` (7 chars) while `VscodeGitProvider.mapRef` stored the full 40-char SHA. Every fast-path lookup compared a 7-char hash against a 40-char hash for the same commit and missed, defeating the cache. Normalized the format string to `%(objectname)` so both producers store full SHAs, and added a defensive prefix-aware `hashesMatch` comparison (`a.startsWith(b) || b.startsWith(a)`) so any stale short-SHA entries already persisted on disk still validate correctly.
- Since refs now carry the full-length hash, truncated to 7 chars at the two render sites that wanted a compact display (`refFormatting.ts` `getRefDetails`, `cleanupBranchesCommand/candidates.ts` `describeCandidate`). The cleanup command's separate full-SHA "Undo hint" recovery document (`git branch <name> <sha>`) is untouched — it needs the real SHA, not a display truncation.
- Reworked `RefDetailsCache.upsertFromRefs` to read Memento state once, apply all upserts in memory, and call `update` exactly once instead of once per ref — avoiding O(N) full-state read-modify-write cycles when priming the cache for a large repo.

Closes #211

## Test plan

- [x] `MOCHA_GREP="refDetailsCache" yarn test:unit` — new tests: short-SHA-seeded entry hits on full-SHA lookup; `upsertFromRefs` with 100 refs triggers exactly one Memento `update` call
- [x] `yarn test:unit` (870 passing, 0 failing)
- [x] `yarn compile` (`check-types` + `lint` + build) — 0 errors