### PR TITLE
fix(stacks): stop status bar indicator failing with "command not found"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,6 +74,7 @@ import { AnalyticsEvent, capture, initAnalytics, setAnalyticsEnabled, shutdownAn
 import { randomUUID } from 'crypto';
 import { showErrorMessageWithIssueAction } from './utils/errorIssueNotification';
 import { UserCancelledError } from './utils/userCancelledError';
+import { revealView } from './utils/revealView';
 import { WorktreeTreeDataProvider } from './view/WorktreeTreeDataProvider';
 import { UpdateNotificationService } from './services/updateNotificationService';
 import { WorktreeTreeActionCommand } from './commands/worktreeTreeActionCommand';
@@ -286,6 +287,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   commandManager.registerCommand(`${EXTENSION_NAME}.stacks.refresh`, {
     execute: async () => refreshStacks(),
+  });
+
+  // Internal: backs the stack status bar indicator, deliberately not contributed
+  // to package.json so it doesn't appear in the command palette next to VS Code's
+  // own "Focus on Stacks View".
+  commandManager.registerCommand(`${EXTENSION_NAME}.stacks.show`, {
+    execute: async () => revealView(`${EXTENSION_NAME}.stacks`, EXTENSION_NAME),
   });
 
   const stackWebViewProvider = new StackWebViewProvider(context, logService, () => void refreshStacks());

--- a/src/statusBar/statusBarManager.ts
+++ b/src/statusBar/statusBarManager.ts
@@ -279,7 +279,10 @@ export class StatusBarManager implements Disposable {
     // Higher priority renders further left for items on the same alignment
     // side, so 101 lands immediately to the left of the mode item (100).
     this.stackStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 101);
-    this.stackStatusBarItem.command = `${EXTENSION_NAME}.stacks.focus`;
+    // Our own reveal command rather than the workbench-generated
+    // `git-smart-checkout.stacks.focus`, which is not always registered — see
+    // `revealView`.
+    this.stackStatusBarItem.command = `${EXTENSION_NAME}.stacks.show`;
 
     this.updateStatusBar();
     this.updateStackIndicator();

--- a/src/test/e2e/commandInterface.test.ts
+++ b/src/test/e2e/commandInterface.test.ts
@@ -404,6 +404,20 @@ describe('VS Code command interface', () => {
     assert.ok(commands.includes(commandId('removePRReviewInWorktree')));
   });
 
+  // The stack status bar indicator clicks through to this command; it must exist
+  // and survive a missing workbench-generated `git-smart-checkout.stacks.focus`.
+  it('registers the Stacks reveal command backing the status bar indicator', async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes(commandId('stacks.show')));
+
+    // Both reveal targets must be real commands, otherwise the fallback only
+    // trades one "command not found" for another.
+    assert.ok(commands.includes(`${EXTENSION_NAME}.stacks.focus`));
+    assert.ok(commands.includes(`workbench.view.extension.${EXTENSION_NAME}`));
+
+    await vscode.commands.executeCommand(commandId('stacks.show'));
+  });
+
   describe('checkoutTo', () => {
     const cases = [
       {

--- a/src/test/unit/revealView.test.ts
+++ b/src/test/unit/revealView.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+
+import { pickRevealCommand } from '../../utils/revealView';
+
+describe('pickRevealCommand', () => {
+  const viewId = 'git-smart-checkout.stacks';
+  const containerId = 'git-smart-checkout';
+
+  it('uses the workbench focus command when it is registered', () => {
+    assert.strictEqual(
+      pickRevealCommand(viewId, containerId, ['some.other.command', 'git-smart-checkout.stacks.focus']),
+      'git-smart-checkout.stacks.focus'
+    );
+  });
+
+  it('falls back to opening the view container when the focus command is missing', () => {
+    assert.strictEqual(
+      pickRevealCommand(viewId, containerId, ['some.other.command']),
+      'workbench.view.extension.git-smart-checkout'
+    );
+  });
+
+  it('falls back when no commands are available at all', () => {
+    assert.strictEqual(
+      pickRevealCommand(viewId, containerId, []),
+      'workbench.view.extension.git-smart-checkout'
+    );
+  });
+
+  it('does not confuse another view\'s focus command for this one', () => {
+    assert.strictEqual(
+      pickRevealCommand(viewId, containerId, ['git-smart-checkout.worktrees.focus']),
+      'workbench.view.extension.git-smart-checkout'
+    );
+  });
+});

--- a/src/utils/revealView.ts
+++ b/src/utils/revealView.ts
@@ -1,0 +1,32 @@
+import { commands } from 'vscode';
+
+/**
+ * Picks the command that reveals `viewId`.
+ *
+ * VS Code auto-generates a `<viewId>.focus` command for every contributed view,
+ * but that command is owned by the workbench, not by us: it is registered (and
+ * disposed) as the view descriptor enters and leaves a *located* view container,
+ * so it can be missing while the extension is updated in place, while the
+ * container is being relocated, or during a reload race. Executing it blind then
+ * fails with a raw `command '<viewId>.focus' not found` error in the user's face
+ * and nothing opens. Opening the container is always available and lands the user
+ * on the view anyway, so use it as the fallback.
+ */
+export function pickRevealCommand(
+  viewId: string,
+  viewContainerId: string,
+  availableCommands: readonly string[]
+): string {
+  const focusCommand = `${viewId}.focus`;
+
+  return availableCommands.includes(focusCommand)
+    ? focusCommand
+    : `workbench.view.extension.${viewContainerId}`;
+}
+
+/** Reveals `viewId`, falling back to its container when `<viewId>.focus` is unavailable. */
+export async function revealView(viewId: string, viewContainerId: string): Promise<void> {
+  const availableCommands = await commands.getCommands(true);
+
+  await commands.executeCommand(pickRevealCommand(viewId, viewContainerId, availableCommands));
+}


### PR DESCRIPTION
## Summary

- Clicking the stack status bar indicator (`$(layers) <pos>/<size>`) could fail with `command 'git-smart-checkout.stacks.focus' not found`, and nothing opened.
- `<viewId>.focus` is **generated by the workbench** (`ViewsService.registerFocusViewAction`), not contributed by us. It is registered and disposed as the view descriptor enters and leaves a *located* view container, so it can be absent while the extension updates in place, while the container is relocated, or during a reload race. `statusBarManager.ts` pointed the status bar item straight at it, leaving no fallback.
- The click now goes through our own `git-smart-checkout.stacks.show` (new `src/utils/revealView.ts`), which uses `.focus` when it is registered and otherwise falls back to `workbench.view.extension.git-smart-checkout` — which lands the user on the Stacks view either way.
- The new command is deliberately **not** contributed to `package.json`, matching the existing `checkoutBranch`/`fetchBranch` precedent, so it stays out of the command palette next to VS Code's own "Focus on Stacks View". No new settings, no user-facing surface added.

### Manual verification

1. Open a repo whose current branch is part of a GitHub PR stack, with `git-smart-checkout.stacks.enabled` on.
2. Confirm the `$(layers) 2/3`-style indicator appears in the status bar, immediately left of the mode item.
3. Click it → the **Stacks** view opens in the Git Smart Checkout activity bar container, with no error notification.
4. To exercise the fallback branch: hide/relocate the Git Smart Checkout container (or click during an extension update-in-place) and click the indicator again — it still opens the container instead of surfacing a raw "command not found".

## Test plan

- [x] Unit/integration tests pass (`yarn test`) — 912 passing, incl. 4 new `pickRevealCommand` cases
- [x] Type check passes (`yarn compile`)
- [x] E2E suite passes (`vscode-test --label e2e-ci`) — 215 tests, 0 failures; new case asserts `stacks.show` is registered, executes without throwing, and that **both** reveal targets are real commands (so the fallback can't trade one "not found" for another)
- [ ] Manual smoke test performed in VS Code extension host