### PR TITLE
fix(views): don't create a tree view the workbench hasn't registered

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,8 +87,9 @@ import { StashService } from './services/stashService';
 import { StashTreeDataProvider } from './view/StashTreeDataProvider';
 import { StashContentProvider, STASH_URI_SCHEME } from './view/stashContentProvider';
 import { StashTreeActionCommand } from './commands/stashTreeActionCommand';
+import { createTreeViewWhenContributed } from './view/createTreeViewWhenContributed';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   const anonymousId = context.globalState.get<string>('analytics.anonymousId') ?? (() => {
     const id = randomUUID();
     context.globalState.update('analytics.anonymousId', id);
@@ -681,16 +682,27 @@ export function activate(context: vscode.ExtensionContext) {
 
   const telemetryChangeListener = vscode.env.onDidChangeTelemetryEnabled(() => updateTelemetryState());
 
-  worktreeTreeView = vscode.window.createTreeView(`${EXTENSION_NAME}.worktrees`, {
-    treeDataProvider: worktreeTreeDataProvider,
-  });
-
-  stashTreeView = vscode.window.createTreeView(`${EXTENSION_NAME}.stashes`, {
-    treeDataProvider: stashTreeDataProvider,
-    // Enables selecting several stashes at once so "Drop" can act on the whole selection
-    // behind a single confirmation modal instead of one row at a time.
-    canSelectMany: true,
-  });
+  // Both trees go through `createTreeViewWhenContributed` rather than `createTreeView` directly:
+  // a window whose view registry doesn't hold our contribution would otherwise answer with an
+  // unactionable "No view is registered with id: ..." error notification. Created in parallel so
+  // the probe costs one round-trip, not two.
+  [worktreeTreeView, stashTreeView] = await Promise.all([
+    createTreeViewWhenContributed(
+      `${EXTENSION_NAME}.worktrees`,
+      { treeDataProvider: worktreeTreeDataProvider },
+      logService
+    ),
+    createTreeViewWhenContributed(
+      `${EXTENSION_NAME}.stashes`,
+      {
+        treeDataProvider: stashTreeDataProvider,
+        // Enables selecting several stashes at once so "Drop" can act on the whole selection
+        // behind a single confirmation modal instead of one row at a time.
+        canSelectMany: true,
+      },
+      logService
+    ),
+  ]);
 
   // Add to context subscriptions
   context.subscriptions.push(
@@ -715,11 +727,11 @@ export function activate(context: vscode.ExtensionContext) {
       `${EXTENSION_NAME}.prCommits`,
       prCommitsWebViewProvider
     ),
-    worktreeTreeView,
+    ...(worktreeTreeView ? [worktreeTreeView] : []),
     worktreeTreeDataProvider,
     stackWebViewProvider,
     vscode.window.registerWebviewViewProvider(`${EXTENSION_NAME}.stacks`, stackWebViewProvider),
-    stashTreeView,
+    ...(stashTreeView ? [stashTreeView] : []),
     stashTreeDataProvider,
     stashService,
     stashChangeListener,

--- a/src/test/unit/createTreeViewWhenContributed.test.ts
+++ b/src/test/unit/createTreeViewWhenContributed.test.ts
@@ -1,0 +1,130 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import {
+  CreateTreeViewDeps,
+  createTreeViewWhenContributed,
+} from '../../view/createTreeViewWhenContributed';
+import { LoggingService } from '../../logging/loggingService';
+
+const VIEW_ID = 'git-smart-checkout.stashes';
+
+/** Commands unrelated to the view, always present, so the probe has to match precisely. */
+const OTHER_COMMANDS = ['git-smart-checkout.checkoutTo', 'git-smart-checkout.stashes.refresh'];
+
+interface Harness {
+  deps: CreateTreeViewDeps;
+  logService: LoggingService;
+  /** One entry per `createTreeView` call, so "created at most once" is observable. */
+  createdViews: string[];
+  probeCount: () => number;
+  delays: number[];
+  warnings: string[];
+}
+
+/**
+ * @param registeredAfterProbes number of probes that report the view missing before it shows up;
+ * `Infinity` for a view that never gets registered.
+ */
+function makeHarness(registeredAfterProbes: number): Harness {
+  const createdViews: string[] = [];
+  const delays: number[] = [];
+  const warnings: string[] = [];
+  let probes = 0;
+
+  const deps: CreateTreeViewDeps = {
+    getCommands: async () => {
+      const isRegistered = probes >= registeredAfterProbes;
+      probes += 1;
+      return isRegistered ? [...OTHER_COMMANDS, `${VIEW_ID}.focus`] : [...OTHER_COMMANDS];
+    },
+    createTreeView: <T>(viewId: string) => {
+      createdViews.push(viewId);
+      return { title: viewId } as unknown as vscode.TreeView<T>;
+    },
+    // Resolves immediately: the test asserts on the requested backoff, not on real waiting.
+    delay: async (ms: number) => {
+      delays.push(ms);
+    },
+  };
+
+  const logService = {
+    warn: (message: string) => warnings.push(message),
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+  } as unknown as LoggingService;
+
+  return { deps, logService, createdViews, probeCount: () => probes, delays, warnings };
+}
+
+describe('createTreeViewWhenContributed', () => {
+  it('creates the view on the first probe when the contribution is already registered', async () => {
+    const harness = makeHarness(0);
+
+    const view = await createTreeViewWhenContributed(
+      VIEW_ID,
+      { treeDataProvider: {} as vscode.TreeDataProvider<unknown> },
+      harness.logService,
+      harness.deps
+    );
+
+    assert.ok(view, 'a view should be returned');
+    assert.deepStrictEqual(harness.createdViews, [VIEW_ID]);
+    assert.strictEqual(harness.probeCount(), 1, 'no retries are needed');
+    assert.deepStrictEqual(harness.delays, [], 'activation is not delayed in the happy path');
+    assert.deepStrictEqual(harness.warnings, []);
+  });
+
+  it('retries and creates the view once the contribution shows up late', async () => {
+    const harness = makeHarness(3);
+
+    const view = await createTreeViewWhenContributed(
+      VIEW_ID,
+      { treeDataProvider: {} as vscode.TreeDataProvider<unknown> },
+      harness.logService,
+      harness.deps
+    );
+
+    assert.ok(view, 'a view should be returned');
+    assert.deepStrictEqual(harness.createdViews, [VIEW_ID], 'created exactly once');
+    assert.strictEqual(harness.probeCount(), 4, 'three failed probes, then the successful one');
+    assert.deepStrictEqual(harness.delays, [100, 250, 500], 'backs off between retries');
+    assert.deepStrictEqual(harness.warnings, []);
+  });
+
+  it('never calls createTreeView, and warns, when the contribution never appears', async () => {
+    const harness = makeHarness(Infinity);
+
+    const view = await createTreeViewWhenContributed(
+      VIEW_ID,
+      { treeDataProvider: {} as vscode.TreeDataProvider<unknown> },
+      harness.logService,
+      harness.deps
+    );
+
+    assert.strictEqual(view, undefined);
+    // The whole point: calling through is what makes the workbench pop
+    // "No view is registered with id: ...".
+    assert.deepStrictEqual(harness.createdViews, []);
+    assert.strictEqual(harness.warnings.length, 1);
+    assert.ok(
+      harness.warnings[0].includes(VIEW_ID),
+      'the warning names the view that could not be created'
+    );
+  });
+
+  it('gives up after a bounded number of probes rather than retrying forever', async () => {
+    const harness = makeHarness(Infinity);
+
+    await createTreeViewWhenContributed(
+      VIEW_ID,
+      { treeDataProvider: {} as vscode.TreeDataProvider<unknown> },
+      harness.logService,
+      harness.deps
+    );
+
+    assert.strictEqual(harness.probeCount(), 6);
+    assert.deepStrictEqual(harness.delays, [100, 250, 500, 1000, 2000]);
+  });
+});

--- a/src/view/createTreeViewWhenContributed.ts
+++ b/src/view/createTreeViewWhenContributed.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+import { LoggingService } from '../logging/loggingService';
+
+/**
+ * Delays, in milliseconds, before each probe attempt. The first probe is immediate; the rest
+ * back off so a workbench that is still processing contributions gets a chance to catch up
+ * without holding activation for long when the view genuinely never appears.
+ */
+const PROBE_DELAYS_MS = [0, 100, 250, 500, 1000, 2000];
+
+export interface CreateTreeViewDeps {
+  getCommands: (filterInternal: boolean) => Thenable<string[]>;
+  createTreeView: <T>(viewId: string, options: vscode.TreeViewOptions<T>) => vscode.TreeView<T>;
+  delay: (ms: number) => Promise<void>;
+}
+
+const defaultDeps: CreateTreeViewDeps = {
+  getCommands: (filterInternal) => vscode.commands.getCommands(filterInternal),
+  createTreeView: (viewId, options) => vscode.window.createTreeView(viewId, options),
+  delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/**
+ * `vscode.window.createTreeView` for a view id the workbench does not know about does not throw —
+ * it makes the main thread pop an unactionable `No view is registered with id: <id>` error
+ * notification, which no try/catch on our side can intercept. That happens whenever this window's
+ * view registry doesn't (yet) hold our `contributes.views` entry: the extension host re-registering
+ * or restarting, or an activation racing the processing of contributions.
+ *
+ * So probe first, and only create the view once the workbench admits it exists. The probe is the
+ * auto-registered `<viewId>.focus` command: VS Code registers one per **registered** view
+ * descriptor (alongside `.open` / `.resetViewLocation`), independent of the view's `when` clause,
+ * so its presence in the command list is the only in-process signal that the descriptor is live.
+ *
+ * @returns the created view, or `undefined` if the contribution never showed up — in which case
+ * nothing is created, deliberately: calling through anyway is exactly what produces the raw error.
+ */
+export async function createTreeViewWhenContributed<T>(
+  viewId: string,
+  options: vscode.TreeViewOptions<T>,
+  logService: LoggingService,
+  deps: CreateTreeViewDeps = defaultDeps
+): Promise<vscode.TreeView<T> | undefined> {
+  for (const delayMs of PROBE_DELAYS_MS) {
+    if (delayMs > 0) {
+      await deps.delay(delayMs);
+    }
+
+    const commands = await deps.getCommands(true);
+    if (commands.includes(`${viewId}.focus`)) {
+      return deps.createTreeView<T>(viewId, options);
+    }
+  }
+
+  logService.warn(
+    `View "${viewId}" is not registered in this window, so it was not created. ` +
+      'Reload the window (Developer: Reload Window) to restore it.'
+  );
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Fixes the `No view is registered with id: git-smart-checkout.stashes` error notification seen when the extension loads.

**Diagnosis**

- The contribution itself is correct and is **not** changed here. `git-smart-checkout.stashes` is contributed as `type: "tree"` in the `git-smart-checkout` container, and a probe run against a real VS Code instance (clean profile *and* a copy of a real user profile) confirms the workbench registers it: `git-smart-checkout.stashes.focus` / `.open` / `.resetViewLocation` — the actions VS Code auto-registers per contributed view — are all present.
- The error string exists in exactly one place in VS Code: `MainThreadTreeViews.$registerTreeViewDataProvider`. After `whenInstalledExtensionsRegistered()` it looks the id up in `ViewsRegistry`, and when the descriptor (or its `treeView`) is missing it calls `notificationService.error('No view is registered with id: ' + id)`. That is a **main-thread notification**, so wrapping `createTreeView` in try/catch cannot intercept it.
- `activate()` called `vscode.window.createTreeView` for both the Worktrees and Stashes views unconditionally. In any window whose view registry doesn't (yet) hold our contribution — extension host re-registering/restarting, or an activation racing the processing of contributions — the user gets that cryptic, unactionable notification.

**Change**

- New `src/view/createTreeViewWhenContributed.ts`: probes whether the workbench actually knows the view before creating it, by checking for `<viewId>.focus` in `vscode.commands.getCommands(true)`. VS Code registers that command per **registered** view descriptor regardless of the view's `when` clause, which makes it the only in-process signal available.
- Probes back off (0/100/250/500/1000/2000 ms) to cover a workbench still processing contributions. If the view never appears, it logs a warning naming the view and returns `undefined` instead of calling through — calling through is precisely what produces the raw error.
- `src/extension.ts` wires both tree views through the helper, in parallel so activation isn't slowed (the happy path costs one `getCommands` round-trip and no delay). `activate` becomes `async`; every caller already awaits it. Views are pushed into `context.subscriptions` only when actually created.

**Manual verification**

1. Build and launch the extension host (F5).
2. Open the Git Smart Checkout activity-bar container — Worktrees and Stashes render as before, and no `No view is registered with id: …` notification appears.
3. Expand Stashes on a repo with stashes: auto-stash/other groups, per-stash files, and multi-select Drop all behave as before.
4. Negative path: in the Extension Host, `Developer: Restart Extension Host` a few times — previously this could surface the error notification; now the worst case is a warning in the `git-smart-checkout` output channel telling you to reload the window.

## Test plan
- [x] Unit/integration tests pass (`yarn test`) — 916 passing, incl. 4 new tests for the helper (immediate create, late registration + backoff, never-registered → no `createTreeView` + warning, bounded retries)
- [x] Type check passes (`yarn compile`)
- [ ] Manual smoke test performed in VS Code extension host